### PR TITLE
Make numba optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
   - conda install numpy "numba>=0.18" "astropy>=1.0" matplotlib pytest pip coverage requests pyyaml
   - pip install coveralls pytest-cov
 script:
-  - py.test --cov poliastro -vv
+  - py.test -vv
+  - python -c "import poliastro; poliastro.test(coverage=True)"
 after_success:
   coveralls

--- a/poliastro/__init__.py
+++ b/poliastro/__init__.py
@@ -7,13 +7,6 @@ poliastro
 Utilities and Python wrappers for Orbital Mechanics
 
 """
-
-from __future__ import absolute_import
+from poliastro.testing import test
 
 __version__ = '0.3.0-dev'
-
-
-def test():
-    import os.path
-    import pytest
-    pytest.main(os.path.dirname(os.path.abspath(__file__)))

--- a/poliastro/iod.py
+++ b/poliastro/iod.py
@@ -3,9 +3,9 @@
 """
 
 import numpy as np
-import numba
 
 from poliastro.util import dot
+from poliastro.jit import jit
 from poliastro.stumpff import c2, c3
 
 
@@ -45,7 +45,7 @@ def lambert(k, r0, r, tof, short=True, numiter=35, rtol=1e-8):
     return v0, v
 
 
-@numba.njit
+@jit
 def _lambert(k, r0, r, tof, short, numiter, rtol):
     if short:
         t_m = +1

--- a/poliastro/jit.py
+++ b/poliastro/jit.py
@@ -1,0 +1,37 @@
+# coding: utf-8
+"""Just-in-time compiler.
+
+Wraps numba if it is available as a module, uses an identity
+decorator instead.
+
+"""
+import warnings
+import inspect
+
+
+def ijit(first=None, *args, **kwargs):
+    """Identity JIT, returns unchanged function.
+
+    """
+    def _jit(f):
+        return f
+
+    if inspect.isfunction(first):
+        return first
+    else:
+        return _jit
+
+
+def select_jit():
+    try:
+        import numba
+        jit = numba.njit
+    except ImportError:
+        warnings.warn("Could not import numba package. All poliastro functions "
+                      "will work properly but the CPU intensive algorithms will "
+                      "be slow. Consider installing numba to boost performance")
+        jit = ijit
+
+    return jit
+
+jit = select_jit()

--- a/poliastro/stumpff.py
+++ b/poliastro/stumpff.py
@@ -3,11 +3,12 @@
 
 """
 import numpy as np
-import numba
 from math import gamma
 
+from poliastro.jit import jit
 
-@numba.jit('f8(f8)', nopython=True)
+
+@jit('f8(f8)', nopython=True)
 def c2(psi):
     eps = 1.0
     if psi > eps:
@@ -26,7 +27,7 @@ def c2(psi):
     return res
 
 
-@numba.jit('f8(f8)', nopython=True)
+@jit('f8(f8)', nopython=True)
 def c3(psi):
     eps = 1.0
     if psi > eps:

--- a/poliastro/testing.py
+++ b/poliastro/testing.py
@@ -1,0 +1,19 @@
+# coding: utf-8
+"""Testing utilities.
+
+"""
+import os.path
+import pytest
+
+
+def test(coverage=False):
+    args = [os.path.dirname(os.path.abspath(__file__))]
+    if coverage:
+        # Monkey patch jit to prevent numba.jit from shadowing coverage
+        # figures (slow)
+        import poliastro.jit
+        poliastro.jit.jit = poliastro.jit.ijit
+
+        args += ["--cov", "poliastro"]
+
+    pytest.main(args)

--- a/poliastro/twobody/propagation.py
+++ b/poliastro/twobody/propagation.py
@@ -4,8 +4,8 @@
 """
 
 import numpy as np
-import numba
 
+from poliastro.jit import jit
 from poliastro.util import dot
 from poliastro.stumpff import c2, c3
 
@@ -53,7 +53,7 @@ def kepler(k, r0, v0, tof, numiter=35, rtol=1e-10):
     return r, v
 
 
-@numba.njit
+@jit
 def _kepler(k, r0, v0, tof, numiter, rtol):
     # Cache some results
     dot_r0v0 = dot(r0, v0)

--- a/poliastro/util.py
+++ b/poliastro/util.py
@@ -4,10 +4,11 @@
 """
 
 import numpy as np
-import numba
 
 from astropy.coordinates import angles
 from astropy import units as u
+
+from poliastro.jit import jit
 
 
 def rotate(vector, angle, axis='z', unit=None):
@@ -78,7 +79,7 @@ def norm(vec):
     return np.sqrt(vec.dot(vec))
 
 
-@numba.njit('f8(f8[:], f8[:])')
+@jit('f8(f8[:], f8[:])')
 def dot(u, v):
     """Returns the dot product of two vectors.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 numba
 astropy
 matplotlib
+pytest


### PR DESCRIPTION
This PR makes numba optional: poliastro falls back to using a dummy decorator and non jitted functions are called. This obviously has a performance cost but allows poliastro to be easily installed without numba, which has a somewhat complex compilation procedure.

Also, this is used to fix the coverage numbers: when the non-jitted functions are called, the coverage is properly computed (see #39).