### PR TITLE
Relicensed to MIT license

### DIFF
--- a/README
+++ b/README
@@ -19,13 +19,13 @@ Overview
 .. image:: https://ci.appveyor.com/api/projects/status/ajg5j8byv8isslso/branch/master?svg=true
    :target: https://ci.appveyor.com/project/poliastro/poliastro/branch/master
 
-.. image:: https://img.shields.io/badge/license-BSD-blue.svg
+.. image:: https://img.shields.io/badge/license-MIT-blue.svg
    :target: https://raw.githubusercontent.com/poliastro/poliastro/master/COPYING
 
-poliastro is a pure Python package dedicated to problems arising in Astrodynamics and
+poliastro is an open source pure Python package dedicated to problems arising in Astrodynamics and
 Orbital Mechanics, such as orbit propagation, solution of the Lambert's
 problem, conversion between position and velocity vectors and classical
-orbital elements and orbit plotting.
+orbital elements and orbit plotting. It is released under the MIT license.
 
 .. code-block:: python
 
@@ -116,9 +116,8 @@ If you use poliastro on your project, please
 License
 =======
 
-poliastro is released under a 2-clause BSD license, hence allowing commercial
-use of the library. Please refer to the COPYING file. This includes the
-modified Fortran subroutines.
+poliastro is released under the MIT license, hence allowing commercial
+use of the library. Please refer to the COPYING file.
 
 FAQ
 ===

--- a/buildscripts/condarecipe/meta.yaml
+++ b/buildscripts/condarecipe/meta.yaml
@@ -31,5 +31,5 @@ test:
 
 about:
   home: https://poliastro.github.io/
-  license: Simplified BSD License
+  license: MIT License
   summary: "Python package for Orbital Mechanics"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,8 +30,8 @@ contributions and feedback are more than welcome.
 .. _`issue tracker`: https://github.com/poliastro/poliastro/issues
 .. _`wiki`: https://github.com/poliastro/poliastro/wiki/
 
-poliastro works on both Python 2 and 3 and is released under a 2-clause
-BSD license, hence allowing commercial use of the library.
+poliastro works on both Python 2 and 3 and is released under
+the MIT license, hence allowing commercial use of the library.
 
 .. code-block:: python
 
@@ -40,11 +40,11 @@ BSD license, hence allowing commercial use of the library.
     
     plot(molniya)
 
-poliastro relies on some Fortran subroutines written by David A. Vallado for
+older versions of poliastro relied on some Fortran subroutines written by David A. Vallado for
 his book "Fundamentals of Astrodynamics and Applications" and available on
 the Internet as the `companion software of the book`__.
 The author explicitly gave permission to redistribute these subroutines
-in this project under the current license.
+in this project under a permissive license.
 
 .. __: http://celestrak.com/software/vallado-sw.asp
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ if __name__ == '__main__':
           author_email="juanlu001@gmail.com",
           url="http://poliastro.github.io/",
           download_url="https://github.com/poliastro/poliastro",
-          license="BSD",
+          license="MIT",
           keywords=[
               "aero", "aerospace", "engineering",
               "astrodynamics", "orbits", "kepler", "orbital mechanics"
@@ -22,7 +22,7 @@ if __name__ == '__main__':
               "Development Status :: 3 - Pre-Alpha",
               "Intended Audience :: Education",
               "Intended Audience :: Science/Research",
-              "License :: OSI Approved :: BSD License",
+              "License :: OSI Approved :: MIT License",
               "Operating System :: OS Independent",
               "Programming Language :: Python",
               "Programming Language :: Python :: 3",


### PR DESCRIPTION
The reasons for the relicensing are two:

1. profiting from the higher popularity of MIT license over Simplified BSD (~45 % vs ~2 % on GitHub[[1]], 19 % vs <1 % on Open Hub[[2]]) and
2. avoiding confusion with the several incompatible BSD licenses[[3]].

[1]: https://github.com/blog/1964-open-source-license-usage-on-github-com
[2]: https://www.blackducksoftware.com/resources/data/top-20-open-source-licenses
[3]: https://twitter.com/johnmyleswhite/status/400303475352809472

I want to do this relicensing properly so I am going to block this PR until all contributors give agreement.

https://github.com/poliastro/poliastro/graphs/contributors

The list of poliastro contributors boil down to @Jorge-C and me. I am no longer distributing the Fortran subroutines so they will remain BSD licensed in poliastro 0.1 and 0.2.

@Jorge-C, do you give consent to change the license to MIT?