### PR TITLE
Switched to new method to measure coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,6 @@ install:
   - pip install coveralls pytest-cov
 script:
   - py.test -vv
-  - NUMBA_DISABLE_JIT=1 py.test
+  - NUMBA_DISABLE_JIT=1 py.test --cov poliastro
 after_success:
   coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,6 @@ install:
   - pip install coveralls pytest-cov
 script:
   - py.test -vv
-  - python -c "import poliastro; poliastro.test(coverage=True)"
+  - NUMBA_DISABLE_JIT=1 py.test
 after_success:
   coveralls

--- a/poliastro/testing.py
+++ b/poliastro/testing.py
@@ -6,14 +6,5 @@ import os.path
 import pytest
 
 
-def test(coverage=False):
-    args = [os.path.dirname(os.path.abspath(__file__))]
-    if coverage:
-        # Monkey patch jit to prevent numba.jit from shadowing coverage
-        # figures (slow)
-        import poliastro.jit
-        poliastro.jit.jit = poliastro.jit.ijit
-
-        args += ["--cov", "poliastro"]
-
-    pytest.main(args)
+def test():
+    pytest.main(os.path.dirname(os.path.abspath(__file__)))


### PR DESCRIPTION
Uses the variable NUMBA_DISABLE_JIT introduced in numba 0.19. Fixes #39.