### PR TITLE
Travis CI for OS X tests and Anaconda.org for Linux tests successfully set up

### DIFF
--- a/.binstar.yml
+++ b/.binstar.yml
@@ -1,4 +1,7 @@
 package: poliastro
+install:
+  - conda config --set always_yes true
+  - conda config --add channels poliastro
 script:
   - conda build buildscripts/condarecipe
 build_targets:

--- a/.binstar.yml
+++ b/.binstar.yml
@@ -1,0 +1,11 @@
+package: poliastro
+script:
+  - conda build buildscripts/condarecipe
+build_targets:
+  - conda
+platform: 
+  - linux-64
+engine:
+  - python=2.7 numpy=1.9
+  - python=3.3 numpy=1.9
+  - python=3.4 numpy=1.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,7 @@ script:
   - py.test -vv
   - NUMBA_DISABLE_JIT=1 py.test --cov poliastro
 
-# Uncomment after pull request
-#after_success:
-#  coveralls
+after_success:
+  coveralls
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,11 @@ install:
   - conda install numpy "numba>=0.18" "astropy>=1.0" matplotlib pytest pip coverage requests pyyaml scipy
   - conda install jplephem -c poliastro
   - pip install coveralls pytest-cov
+  - pip install -e .    # Needed to use py.test properly
 
 script:
-  - py.test -vv
-  - NUMBA_DISABLE_JIT=1 py.test --cov poliastro
+  - py.test poliastro -vv
+  - NUMBA_DISABLE_JIT=1 py.test --cov poliastro poliastro/tests poliastro/twobody/tests --cov-config .coveragerc
 
 after_success:
   coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,6 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
-  - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
-  - source activate test-environment
   - conda install numpy "numba>=0.18" "astropy>=1.0" matplotlib pytest pip coverage requests pyyaml scipy
   - conda install jplephem -c poliastro
   - pip install coveralls pytest-cov
@@ -31,7 +28,8 @@ script:
   - py.test -vv
   - NUMBA_DISABLE_JIT=1 py.test --cov poliastro
 
-after_success:
-  coveralls
+# Uncomment after pull request
+#after_success:
+#  coveralls
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ language: objective-c
 
 env:
   matrix:
-    - python=2.7 CONDA_PY=27 CONDA-NPY=19
-    - python=3.3 CONDA_PY=33 CONDA_NPY=19
-    - python=3.4 CONDA_PY=34 CONDA_NPY=19
+    - PYTHON=2.7
+    - PYTHON=3.3
+    - PYTHON=3.4
 
 branches:
   only:
@@ -20,6 +20,8 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
+  - conda create -q -n test-environment python=$PYTHON
+  - source activate test-environment
   - conda install numpy "numba>=0.18" "astropy>=1.0" matplotlib pytest pip coverage requests pyyaml scipy
   - conda install jplephem -c poliastro
   - pip install coveralls pytest-cov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,23 @@
-language: python
-python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
+# The only current way of using OS X virtual machines in Travis CI
+# is setting up the environment for Objective-C
+# This is not a problem because Python will be installed through conda
+
+language: objective-c
+
+env:
+  matrix:
+    - python=2.7 CONDA_PY=27 CONDA-NPY=19
+    - python=3.3 CONDA_PY=33 CONDA_NPY=19
+    - python=3.4 CONDA_PY=34 CONDA_NPY=19
+
 branches:
   only:
     - master
+
 install:
-  - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+  - wget http://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
@@ -19,9 +26,11 @@ install:
   - conda install numpy "numba>=0.18" "astropy>=1.0" matplotlib pytest pip coverage requests pyyaml scipy
   - conda install jplephem -c poliastro
   - pip install coveralls pytest-cov
+
 script:
   - py.test -vv
   - NUMBA_DISABLE_JIT=1 py.test --cov poliastro
+
 after_success:
   coveralls
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,6 +37,7 @@ install:
   # Install dependencies
   - "conda install -q numpy numba>=0.18 astropy>=1.0 matplotlib pytest scipy"
   - "conda install jplephem -c poliastro"
+  - "pip install -e ."    # Needed to use py.test properly
   
 build: off
 

--- a/buildscripts/condarecipe/bld.bat
+++ b/buildscripts/condarecipe/bld.bat
@@ -1,2 +1,3 @@
+conda config --add channels poliastro
 "%PYTHON%" setup.py install
 if errorlevel 1 exit 1

--- a/buildscripts/condarecipe/bld.bat
+++ b/buildscripts/condarecipe/bld.bat
@@ -1,3 +1,2 @@
-conda config --add channels poliastro
 "%PYTHON%" setup.py install
 if errorlevel 1 exit 1

--- a/buildscripts/condarecipe/build.sh
+++ b/buildscripts/condarecipe/build.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-conda config --add channels poliastro
 $PYTHON setup.py install

--- a/buildscripts/condarecipe/build.sh
+++ b/buildscripts/condarecipe/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-
+conda config --add channels poliastro
 $PYTHON setup.py install

--- a/buildscripts/condarecipe/meta.yaml
+++ b/buildscripts/condarecipe/meta.yaml
@@ -17,6 +17,7 @@ requirements:
   run:
     - python
     - numpy
+    - scipy
     - numba >=0.18
     - astropy >=1.0
     - jplephem

--- a/buildscripts/condarecipe/run_test.bat
+++ b/buildscripts/condarecipe/run_test.bat
@@ -1,0 +1,4 @@
+CD %SRC_DIR%
+py.test poliastro
+IF %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%
+

--- a/buildscripts/condarecipe/run_test.sh
+++ b/buildscripts/condarecipe/run_test.sh
@@ -1,3 +1,2 @@
-cd $SRC_DIR/poliastro/tests
-
-py.test
+cd $SRC_DIR
+py.test poliastro

--- a/poliastro/tests/__init__.py
+++ b/poliastro/tests/__init__.py
@@ -1,2 +1,0 @@
-# This file allows for running the tests against the downloaded
-# source


### PR DESCRIPTION
I've managed to transfer the [Linux tests](https://anaconda.org/newlawrence/poliastro/builds) to **Anaconda.org** and configure **Travis CI** for [OS X tests](https://travis-ci.org/newlawrence/poliastro/builds).

The only change in the code (beyond those made in `.binstar.yml` and `.travis.yml`) has been to add `scipy`to the requirements section of the `meta.yaml`file.

There's nothing left to be done with Travis. To configure **Anaconda.org** builds, go to the **Continuous Integration** section of the repository settings in **Anaconda** and use this configuration:

* *Check* the option **add webhook**
* Regex defining the branches to test = **refs/heads/master**
* Regex defining the branches to test = *empty*
* Channel = *whatever you use for the repository in binstar* (I've used **main** for the tests)
* Subdirectory = *empty*
* Build Queue = **build/binstar/public** (this is **very important!!!**)
* E-mail = *as you wish*

Hope you like the changes 😊.