### PR TITLE
Avoid accessing protected class members from outside

### DIFF
--- a/poliastro/twobody/classical.py
+++ b/poliastro/twobody/classical.py
@@ -92,10 +92,10 @@ def coe2mee(p, ecc, inc, raan, argp, nu):
     return p, f, g, h, k, L
 
 
-class _ClassicalState(State):
+class ClassicalState(State):
     def __init__(self, attractor, p, ecc, inc, raan, argp, nu,
                  epoch):
-        super(_ClassicalState, self).__init__(attractor, epoch)
+        super(ClassicalState, self).__init__(attractor, epoch)
         self._p = p
         self._ecc = ecc
         self._inc = inc
@@ -134,6 +134,11 @@ class _ClassicalState(State):
 
         """
         elem_names = [r"a", r"e", r"i", r"\Omega", r"\omega", r"\nu"]
+        # noinspection PyProtectedMember
+        # Each element is an astropy Quantity:
+        # https://github.com/astropy/astropy/blob/v1.0.7/astropy/units/quantity.py#L935
+        # '_repr_index' is an internal method for IPython use:
+        # http://ipython.readthedocs.org/en/3.x/config/integrating.html#rich-display
         elem_values = [elem._repr_latex_().strip("$")
                        for elem in self.elements]
         pairs = zip(elem_names, elem_values)
@@ -150,10 +155,10 @@ class _ClassicalState(State):
                       self.argp.to(u.rad).value,
                       self.nu.to(u.rad).value)
 
-        return super(_ClassicalState, self).from_vectors(self.attractor,
-                                                         r * u.km,
-                                                         v * u.km / u.s,
-                                                         self.epoch)
+        return super(ClassicalState, self).from_vectors(self.attractor,
+                                                        r * u.km,
+                                                        v * u.km / u.s,
+                                                        self.epoch)
 
     def to_classical(self):
         return self
@@ -166,7 +171,7 @@ class _ClassicalState(State):
                                    self.argp.to(u.rad).value,
                                    self.nu.to(u.rad).value)
 
-        return super(_ClassicalState, self).from_equinoctial(
+        return super(ClassicalState, self).from_equinoctial(
             self.attractor,
             p * u.km,
             f * u.rad,

--- a/poliastro/twobody/core.py
+++ b/poliastro/twobody/core.py
@@ -58,7 +58,7 @@ class State(object):
 
         assert np.any(r.value), "Position vector must be non zero"
 
-        return poliastro.twobody.rv._RVState(
+        return poliastro.twobody.rv.RVState(
             attractor, r, v, epoch)
 
     @staticmethod
@@ -90,7 +90,7 @@ class State(object):
                            (u.m, u.one, u.rad, u.rad, u.rad, u.rad)):
             raise u.UnitsError("Units must be consistent")
 
-        return poliastro.twobody.classical._ClassicalState(
+        return poliastro.twobody.classical.ClassicalState(
             attractor, p, ecc, inc, raan, argp, nu, epoch)
 
     @staticmethod
@@ -121,7 +121,7 @@ class State(object):
                            (u.m, u.one, u.rad, u.rad, u.rad, u.rad)):
             raise u.UnitsError("Units must be consistent")
 
-        return poliastro.twobody.equinoctial._ModifiedEquinoctialState(
+        return poliastro.twobody.equinoctial.ModifiedEquinoctialState(
             attractor, p, f, g, h, k, L, epoch)
 
     @classmethod

--- a/poliastro/twobody/equinoctial.py
+++ b/poliastro/twobody/equinoctial.py
@@ -30,10 +30,10 @@ def mee2coe(p, f, g, h, k, L):
     return p, ecc, inc, raan, argp, nu
 
 
-class _ModifiedEquinoctialState(State):
+class ModifiedEquinoctialState(State):
     def __init__(self, attractor, p, f, g, h, k, L,
                  epoch):
-        super(_ModifiedEquinoctialState, self).__init__(attractor, epoch)
+        super(ModifiedEquinoctialState, self).__init__(attractor, epoch)
         self._p = p
         self._f = f
         self._g = g
@@ -73,7 +73,7 @@ class _ModifiedEquinoctialState(State):
                                               self.k.to(u.rad).value,
                                               self.L.to(u.rad).value)
 
-        return super(_ModifiedEquinoctialState, self).from_classical(
+        return super(ModifiedEquinoctialState, self).from_classical(
             self.attractor,
             p * u.km,
             ecc * u.one,

--- a/poliastro/twobody/rv.py
+++ b/poliastro/twobody/rv.py
@@ -60,9 +60,9 @@ def rv2coe(k, r, v, tol=1e-8):
     return p, ecc, inc, raan, argp, nu
 
 
-class _RVState(State):
+class RVState(State):
     def __init__(self, attractor, r, v, epoch):
-        super(_RVState, self).__init__(attractor, epoch)
+        super(RVState, self).__init__(attractor, epoch)
         self._r = r
         self._v = v
 
@@ -83,11 +83,11 @@ class _RVState(State):
                     self.r.to(u.km).value,
                     self.v.to(u.km / u.s).value)
 
-        return super(_RVState, self).from_classical(self.attractor,
-                                                    p * u.km,
-                                                    ecc * u.one,
-                                                    inc * u.rad,
-                                                    raan * u.rad,
-                                                    argp * u.rad,
-                                                    nu * u.rad,
-                                                    self.epoch)
+        return super(RVState, self).from_classical(self.attractor,
+                                                   p * u.km,
+                                                   ecc * u.one,
+                                                   inc * u.rad,
+                                                   raan * u.rad,
+                                                   argp * u.rad,
+                                                   nu * u.rad,
+                                                   self.epoch)


### PR DESCRIPTION
Found a few cases of protected class members accessed from outside
their modules. Fixed these by either making the member public or by
using a property to access the member.