### PR TITLE
Fixes for CI tests, fix #79.

### DIFF
--- a/.binstar.yml
+++ b/.binstar.yml
@@ -7,7 +7,7 @@ script:
   - export NUMPY=$(python -c "from __future__ import print_function;import numpy as np;print(np.__version__[:np.__version__.rfind('.')])")
   - conda create -q -n test-environment python=$PYTHON
   - source activate test-environment
-  - conda install numpy=$NUMPY numba>=0.18 astropy>=1.0 matplotlib pytest pip coverage requests pyyaml scipy jplephem
+  - conda install numpy=$NUMPY numba>=0.18 astropy>=1.0 matplotlib pytest pip requests pyyaml scipy jplephem
   - pip install -e .
   - py.test poliastro -vv
 platform: 

--- a/.binstar.yml
+++ b/.binstar.yml
@@ -3,13 +3,13 @@ install:
   - conda config --set always_yes true
   - conda config --add channels poliastro
 script:
-  # Force conda build to use specific versions of Python and Numpy
-  - export CONDA_PY=$(python -c "from __future__ import print_function;from sys import version_info as ver;print(str(ver.major) + str(ver.minor))")
-  - export CONDA_NPY=$(python -c "from __future__ import print_function;import numpy;npver=numpy.__version__;print(npver[:npver.rfind('.')].replace('.',''))")
-  # Build once the env variables are set
-  - conda build buildscripts/condarecipe
-build_targets:
-  - conda
+  - export PYTHON=$(python -c "from __future__ import print_function;from sys import version_info as pyver;print(str(pyver[0]) + '.' + str(pyver[1]))")
+  - export NUMPY=$(python -c "from __future__ import print_function;import numpy as np;print(np.__version__[:np.__version__.rfind('.')])")
+  - conda create -q -n test-environment python=$PYTHON
+  - source activate test-environment
+  - conda install numpy=$NUMPY numba>=0.18 astropy>=1.0 matplotlib pytest pip coverage requests pyyaml scipy jplephem
+  - pip install -e .
+  - py.test poliastro -vv
 platform: 
   - linux-64
 engine:

--- a/.binstar.yml
+++ b/.binstar.yml
@@ -1,12 +1,10 @@
 package: poliastro
 install:
-  - conda config --set always_yes true
+  - conda config --set always_yes yes --set changeps1 no
   - conda config --add channels poliastro
 script:
   - export PYTHON=$(python -c "from __future__ import print_function;from sys import version_info as pyver;print(str(pyver[0]) + '.' + str(pyver[1]))")
   - export NUMPY=$(python -c "from __future__ import print_function;import numpy as np;print(np.__version__[:np.__version__.rfind('.')])")
-  - conda create -q -n test-environment python=$PYTHON
-  - source activate test-environment
   - conda install numpy=$NUMPY numba>=0.18 astropy>=1.0 matplotlib pytest pip requests pyyaml scipy jplephem
   - pip install -e .
   - py.test poliastro -vv

--- a/.binstar.yml
+++ b/.binstar.yml
@@ -1,18 +1,24 @@
 package: poliastro
+platform: linux-64
+engine:
+  - python=2.7
+  - python=3.3
+  - python=3.4
+  - python=2.7
+  - python=3.4
+env:
+  - NUMPY=1.9
+  - NUMPY=1.10
 install:
   - conda config --set always_yes yes --set changeps1 no
   - conda config --add channels poliastro
 script:
-  - export PYTHON=$(python -c "from __future__ import print_function;from sys import version_info as pyver;print(str(pyver[0]) + '.' + str(pyver[1]))")
-  - export NUMPY=$(python -c "from __future__ import print_function;import numpy as np;print(np.__version__[:np.__version__.rfind('.')])")
   - conda install numpy=$NUMPY numba>=0.18 astropy>=1.0 matplotlib pytest pip requests pyyaml scipy jplephem
   - pip install -e .
   - py.test poliastro -vv
-platform: 
-  - linux-64
-engine:
-  - python=2.7 numpy=1.9
-  - python=3.3 numpy=1.9
-  - python=3.4 numpy=1.9
-  - python=2.7 numpy=1.10
-  - python=3.4 numpy=1.10
+---
+package: poliastro
+platform: linux-64
+engine: python=3.3
+env: NUMPY=1.10
+exclude: true

--- a/.binstar.yml
+++ b/.binstar.yml
@@ -4,8 +4,6 @@ engine:
   - python=2.7
   - python=3.3
   - python=3.4
-  - python=2.7
-  - python=3.4
 env:
   - NUMPY=1.9
   - NUMPY=1.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,11 @@ install:
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - conda config --set always_yes yes --set changeps1 no
+  - conda config --add channels poliastro
   - conda update -q conda
   - conda create -q -n test-environment python=$PYTHON
   - source activate test-environment
-  - conda install numpy=$NUMPY numba>=0.18 astropy>=1.0 matplotlib pytest pip coverage requests pyyaml scipy
-  - conda install numpy=$NUMPY jplephem -c poliastro
+  - conda install numpy=$NUMPY numba>=0.18 astropy>=1.0 matplotlib pytest pip coverage requests pyyaml scipy jplephem
   - pip install coveralls pytest-cov
   - pip install -e .    # Needed to use py.test properly
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,6 @@ env:
     - PYTHON=2.7 NUMPY=1.10
     - PYTHON=3.4 NUMPY=1.10
 
-branches:
-  only:
-    - master
-
 install:
   - wget http://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - conda create -q -n test-environment python=$PYTHON
   - source activate test-environment
   - conda install numpy=$NUMPY numba>=0.18 astropy>=1.0 matplotlib pytest pip coverage requests pyyaml scipy
-  - conda install jplephem -c poliastro
+  - conda install numpy=$NUMPY jplephem -c poliastro
   - pip install coveralls pytest-cov
   - pip install -e .    # Needed to use py.test properly
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ env:
     - PYTHON=2.7 NUMPY=1.10
     - PYTHON=3.4 NUMPY=1.10
 
+branches:
+  only:
+    - master
+    - 0.3.x
+
 install:
   - wget http://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,12 @@
 
 version: 0.4.0.dev0-{build}
 
+branches:
+  only:
+  - master
+  - 0.3.x
+  - "choco-appveyor#46"
+
 environment:
   global:
     MINICONDA: "C:\\tools\\Miniconda"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ install:
 
   # Install dependencies
   - "conda install -q numpy=%NUMPY% numba>=0.18 astropy>=1.0 matplotlib pytest scipy"
-  - "conda install jplephem -c poliastro"
+  - "conda install numpy=%NUMPY% jplephem -c poliastro"
   - "pip install -e ."    # Needed to use py.test properly
   
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,12 +4,6 @@
 
 version: 0.4.0.dev0-{build}
 
-branches:
-  only:
-  - master
-  - 0.3.x
-  - "choco-appveyor#46"
-
 environment:
   global:
     MINICONDA: "C:\\tools\\Miniconda"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,6 +33,7 @@ install:
 
   # Install the build and runtime dependencies of the project.
   - "conda config --set always_yes yes --set changeps1 no"
+  - "conda config --add channels poliastro"
   - "conda update -q conda"
   - "conda info -a"
   - "conda create -q -n test-environment python=%PYTHON%"
@@ -42,8 +43,7 @@ install:
   - "python --version"
 
   # Install dependencies
-  - "conda install -q numpy=%NUMPY% numba>=0.18 astropy>=1.0 matplotlib pytest scipy"
-  - "conda install numpy=%NUMPY% jplephem -c poliastro"
+  - "conda install -q numpy=%NUMPY% numba>=0.18 astropy>=1.0 matplotlib pytest scipy jplephem"
   - "pip install -e ."    # Needed to use py.test properly
   
 build: off


### PR DESCRIPTION
Fixes the issue [#79](https://github.com/poliastro/poliastro/issues/79).

Tests under **Anaconda** are now performed the same way as in **Travis**. No more need of building the **conda** package.