### PR TITLE
Targets Python 3.5

### DIFF
--- a/.binstar.yml
+++ b/.binstar.yml
@@ -4,6 +4,7 @@ engine:
   - python=2.7
   - python=3.3
   - python=3.4
+  - python=3.5
 env:
   - NUMPY=1.9
   - NUMPY=1.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,10 @@ env:
     - PYTHON=2.7 NUMPY=1.9
     - PYTHON=3.3 NUMPY=1.9
     - PYTHON=3.4 NUMPY=1.9
+    - PYTHON=3.5 NUMPY=1.9
     - PYTHON=2.7 NUMPY=1.10
     - PYTHON=3.4 NUMPY=1.10
+    - PYTHON=3.5 NUMPY=1.10
 
 branches:
   only:

--- a/README
+++ b/README
@@ -47,8 +47,8 @@ poliastro requires the following Python packages:
 * matplotlib, for orbit plotting
 * SciPy, for root finding and numerical propagation
 
-poliastro is usually tested on Linux, Windows and OS X on Python 2.7, 3.3
-and 3.4, using NumPy 1.9 and 1.10 (single codebase).
+poliastro is usually tested on Linux, Windows and OS X on Python 2.7, 3.3,
+3.4 and 3.5, using NumPy 1.9 and 1.10 (single codebase).
 
 ==============  ============  ===================
 Platform        Site          Status

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,6 @@ branches:
   only:
   - master
   - 0.3.x
-  - "choco-appveyor#46"
 
 environment:
   global:
@@ -21,9 +20,13 @@ environment:
       NUMPY: 1.9
     - PYTHON: 3.4
       NUMPY: 1.9
+    - PYTHON: 3.5
+      NUMPY: 1.9
     - PYTHON: 2.7
       NUMPY: 1.10
     - PYTHON: 3.4
+      NUMPY: 1.10
+    - PYTHON: 3.5
       NUMPY: 1.10
 
 install:

--- a/buildscripts/condarecipe/meta.yaml
+++ b/buildscripts/condarecipe/meta.yaml
@@ -16,7 +16,7 @@ requirements:
 
   run:
     - python
-    - numpy >=1.9
+    - numpy {{NPY_VER}}*,>=1.9
     - scipy
     - numba >=0.18
     - astropy >=1.0

--- a/buildscripts/condarecipe/meta.yaml
+++ b/buildscripts/condarecipe/meta.yaml
@@ -16,7 +16,7 @@ requirements:
 
   run:
     - python
-    - numpy {{NPY_VER}}*,>=1.9
+    - numpy >=1.9
     - scipy
     - numba >=0.18
     - astropy >=1.0

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -13,8 +13,8 @@ poliastro requires the following Python packages:
 * matplotlib, for orbit plotting
 * scipy, for root finding and numerical propagation
 
-poliastro is usually tested on Linux and Windows on Python 2.7, 3.3 and 3.4
-(single codebase). It should work on OS X too with no changes (not tested).
+poliastro is usually tested on Linux, Windows and OS X on Python 2.7, 3.3,
+3.4 and 3.5, using NumPy 1.9 and 1.10 (single codebase).
 
 Installation
 ------------
@@ -22,8 +22,7 @@ Installation
 The easiest and fastest way to get the package up and running is to
 install poliastro using `conda <http://conda.io>`_::
 
-  $ conda create -n poliastro34 python=3.4 -q
-  $ conda install poliastro -c poliastro
+  $ conda install poliastro --channel poliastro
 
 You can also `install poliastro from PyPI`_ using pip, given that you already
 have all the requirements::


### PR DESCRIPTION
This step is required before fixing #74. Also, implemented idea to solve NumPy version madness when testing (cc @newlawrence).