### PR TITLE
Restore semimajor axis as shape parameter

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,18 @@
 What's new
 ==========
 
+New in poliastro 0.5.0
+----------------------
+
+.. warning:: This version is not released yet.
+
+Backward incompatible changes:
+
+* **Creation of orbits from classical elements**: poliastro has
+  reverted the switch to the *semilatus rectum* \\(p\\) instead of the semimajor
+  axis \\(a\\) made in 0.4.0, so \\(a\\) must be used again. This change is
+  definitive.
+
 New in poliastro 0.4.2
 ----------------------
 

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -21,6 +21,8 @@ source code itself. Here is the complete list in no particular order:
   Aiaa, 1999.
 * Edelbaum, Theodore N. "Propulsion requirements for controllable satellites."
   *ARS Journal* 31, no. 8 (1961): 1079-1089.
+* Walker, M. J. H., B. Ireland, and Joyce Owens. "A set modified equinoctial
+  orbit elements." *Celestial Mechanics* 36.4 (1985): 409-419.
 
 Software
 --------

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -81,16 +81,12 @@ six parameters called orbital elements. Although there are several of
 these element sets, each one with its advantages and drawbacks, right now
 poliastro supports the *classical orbital elements*:
 
-* *Semilatus rectum* \\(p\\).
+* Semimajor axis \\(a\\).
 * Eccentricity \\(e\\).
 * Inclination \\(i\\).
 * Right ascension of the ascending node \\(\\Omega\\).
 * Argument of pericenter \\(\\omega\\).
 * True anomaly \\(\\nu\\).
-
-.. note:: poliastro uses the *semilatus rectum* instead of the semimajor
-    axis \\(a\\) to avoid singularities when working with parabolic or
-    near-parabolic orbits, where the latter takes infinite values.
 
 In this case, we'd use the method
 :py:meth:`~poliastro.twobody.State.from_classical`:
@@ -100,13 +96,12 @@ In this case, we'd use the method
     # Data for Mars at J2000 from JPL HORIZONS
     a = 1.523679 * u.AU
     ecc = 0.093315 * u.one
-    p = a * (1 - ecc**2)
     inc = 1.85 * u.deg
     raan = 49.562 * u.deg
     argp = 286.537 * u.deg
     nu = 23.33 * u.deg
     
-    ss = State.from_classical(Sun, p, ecc, inc, raan, argp, nu)
+    ss = State.from_classical(Sun, a, ecc, inc, raan, argp, nu)
 
 Notice that whether we create a ``State`` from \\(r\\) and \\(v\\) or from
 elements we can access many mathematical properties individually::

--- a/src/poliastro/twobody/classical.py
+++ b/src/poliastro/twobody/classical.py
@@ -105,26 +105,32 @@ class ClassicalState(State):
 
     @property
     def a(self):
+        """Semimajor axis. """
         return self._a
 
     @property
     def ecc(self):
+        """Eccentricity. """
         return self._ecc
 
     @property
     def inc(self):
+        """Inclination. """
         return self._inc
 
     @property
     def raan(self):
+        """Right ascension of the ascending node. """
         return self._raan
 
     @property
     def argp(self):
+        """Argument of the perigee. """
         return self._argp
 
     @property
     def nu(self):
+        """True anomaly. """
         return self._nu
 
     def _repr_latex_(self):
@@ -147,6 +153,9 @@ class ClassicalState(State):
         return r"$\begin{{align}}{0}\end{{align}}$".format(res)
 
     def to_vectors(self):
+        """Converts to position and velocity vector representation.
+
+        """
         r, v = coe2rv(self.attractor.k.to(u.km ** 3 / u.s ** 2).value,
                       self.p.to(u.km).value,
                       self.ecc.value,
@@ -161,9 +170,15 @@ class ClassicalState(State):
                                                         self.epoch)
 
     def to_classical(self):
+        """Converts to classical orbital elements representation.
+
+        """
         return self
 
     def to_equinoctial(self):
+        """Converts to modified equinoctial elements representation.
+
+        """
         p, f, g, h, k, L = coe2mee(self.p.to(u.km).value,
                                    self.ecc.value,
                                    self.inc.to(u.rad).value,

--- a/src/poliastro/twobody/classical.py
+++ b/src/poliastro/twobody/classical.py
@@ -93,10 +93,10 @@ def coe2mee(p, ecc, inc, raan, argp, nu):
 
 
 class ClassicalState(State):
-    def __init__(self, attractor, p, ecc, inc, raan, argp, nu,
+    def __init__(self, attractor, a, ecc, inc, raan, argp, nu,
                  epoch):
         super(ClassicalState, self).__init__(attractor, epoch)
-        self._p = p
+        self._a = a
         self._ecc = ecc
         self._inc = inc
         self._raan = raan
@@ -104,8 +104,8 @@ class ClassicalState(State):
         self._nu = nu
 
     @property
-    def p(self):
-        return self._p
+    def a(self):
+        return self._a
 
     @property
     def ecc(self):

--- a/src/poliastro/twobody/core.py
+++ b/src/poliastro/twobody/core.py
@@ -369,7 +369,7 @@ class State(object):
             res = ss_new
         return res
 
-    def to_rv(self):
+    def to_vectors(self):
         """Converts to position and velocity vector representation.
 
         """

--- a/src/poliastro/twobody/core.py
+++ b/src/poliastro/twobody/core.py
@@ -62,7 +62,7 @@ class State(object):
             attractor, r, v, epoch)
 
     @staticmethod
-    def from_classical(attractor, p, ecc, inc, raan, argp, nu,
+    def from_classical(attractor, a, ecc, inc, raan, argp, nu,
                        epoch=J2000):
         """Return `State` object from classical orbital elements.
 
@@ -86,12 +86,16 @@ class State(object):
             Epoch, default to J2000.
 
         """
-        if not check_units((p, ecc, inc, raan, argp, nu),
+        if not check_units((a, ecc, inc, raan, argp, nu),
                            (u.m, u.one, u.rad, u.rad, u.rad, u.rad)):
             raise u.UnitsError("Units must be consistent")
 
+        if ecc == 1.0 * u.one:
+            raise ValueError("For parabolic orbits use "
+                             "State.parabolic instead")
+
         return poliastro.twobody.classical.ClassicalState(
-            attractor, p, ecc, inc, raan, argp, nu, epoch)
+            attractor, a, ecc, inc, raan, argp, nu, epoch)
 
     @staticmethod
     def from_equinoctial(attractor, p, f, g, h, k, L, epoch=J2000):
@@ -181,10 +185,16 @@ class State(object):
                            (u.m, u.rad, u.rad, u.rad, u.rad)):
             raise u.UnitsError("Units must be consistent")
 
+        k = attractor.k.to(u.km ** 3 / u.s ** 2)
         ecc = 1.0 * u.one
+        r, v = poliastro.twobody.classical.coe2rv(
+                k.to(u.km ** 3 / u.s ** 2).value,
+                p.to(u.km).value, ecc.value, inc.to(u.rad).value,
+                raan.to(u.rad).value, argp.to(u.rad).value,
+                nu.to(u.rad).value)
 
-        return cls.from_classical(attractor, p, ecc, inc, raan, argp, nu,
-                                  epoch)
+        ss = cls.from_vectors(attractor, r * u.km, v * u.km / u.s, epoch)
+        return ss
 
     @property
     def r(self):
@@ -199,12 +209,12 @@ class State(object):
     @property
     def a(self):
         """Semimajor axis. """
-        return self.p / (1 - self.ecc**2)
+        return self.to_classical().a
 
     @property
     def p(self):
         """Semilatus rectum. """
-        return self.to_classical().p
+        return self.a * (1 - self.ecc**2)
 
     @property
     def r_p(self):
@@ -303,7 +313,7 @@ class State(object):
 
     def coe(self):
         """Classical orbital elements. """
-        return self.p, self.ecc, self.inc, self.raan, self.argp, self.nu
+        return self.a, self.ecc, self.inc, self.raan, self.argp, self.nu
 
     def pqw(self):
         """Perifocal frame (PQW) vectors. """

--- a/src/poliastro/twobody/equinoctial.py
+++ b/src/poliastro/twobody/equinoctial.py
@@ -73,9 +73,11 @@ class ModifiedEquinoctialState(State):
                                               self.k.to(u.rad).value,
                                               self.L.to(u.rad).value)
 
+        a = p / (1 - ecc**2)
+
         return super(ModifiedEquinoctialState, self).from_classical(
             self.attractor,
-            p * u.km,
+            a * u.km,
             ecc * u.one,
             inc * u.rad,
             raan * u.rad,

--- a/src/poliastro/twobody/rv.py
+++ b/src/poliastro/twobody/rv.py
@@ -83,8 +83,10 @@ class RVState(State):
                     self.r.to(u.km).value,
                     self.v.to(u.km / u.s).value)
 
+        a = p / (1 - ecc**2)
+
         return super(RVState, self).from_classical(self.attractor,
-                                                   p * u.km,
+                                                   a * u.km,
                                                    ecc * u.one,
                                                    inc * u.rad,
                                                    raan * u.rad,

--- a/src/poliastro/twobody/rv.py
+++ b/src/poliastro/twobody/rv.py
@@ -68,16 +68,24 @@ class RVState(State):
 
     @property
     def r(self):
+        """Position vector. """
         return self._r
 
     @property
     def v(self):
+        """Velocity vector. """
         return self._v
 
     def to_vectors(self):
+        """Converts to position and velocity vector representation.
+
+        """
         return self
 
     def to_classical(self):
+        """Converts to classical orbital elements representation.
+
+        """
         (p, ecc, inc, raan, argp, nu
          ) = rv2coe(self.attractor.k.to(u.km ** 3 / u.s ** 2).value,
                     self.r.to(u.km).value,


### PR DESCRIPTION
Closes #62. For reference:

> I find myself never dealing with parabolic orbits, yet I introduced this change and I find it extremely annoying for the remaining 100 % of my use cases.

See https://github.com/poliastro/poliastro/wiki/Parabolic-orbits:-final-decision for rationale.