### PR TITLE
Pass path as enclosed argument to pytest.main

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -12,6 +12,7 @@ poliastro requires the following Python packages:
 * jplephem, for the planetary ephemerides using SPICE kernels
 * matplotlib, for orbit plotting
 * scipy, for root finding and numerical propagation
+* pytest, for running the tests from the package
 
 poliastro is usually tested on Linux, Windows and OS X on Python
 3.4 and 3.5, using NumPy 1.9 and 1.10 (single codebase).

--- a/src/poliastro/testing.py
+++ b/src/poliastro/testing.py
@@ -7,4 +7,4 @@ import pytest
 
 
 def test():
-    pytest.main(os.path.dirname(os.path.abspath(__file__)))
+    pytest.main([os.path.dirname(os.path.abspath(__file__))])


### PR DESCRIPTION
This prevents error when the path has whitespace, fixes
https://github.com/poliastro/poliastro/issues/126