### PR TITLE
Changed Python version to 3.5 in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - defaults
   - conda-forge
 dependencies:
-  - python=3.6
+  - python=3.5
   - astropy
   - jplephem
   - matplotlib


### PR DESCRIPTION
I've been trying building the docs, but `conda` in ReadTheDocs seems to be using Sphinx 1.3.5 which needs Python 3.5, as documented in this issue: https://github.com/rtfd/readthedocs.org/issues/2566
@Juanlu001 I know you've participated in related discussions, and possibly this problem will be fixed very soon: https://github.com/rtfd/readthedocs.org/pull/2802, but meanwhile, it would be great to be able to compile and update the docs.