### PR TITLE
Reject astropy 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
   - source activate test-environment
 
   # Install project requirements
-  - conda install numpy numba>=0.23 astropy>=1.0 matplotlib scipy jplephem pandoc
+  - conda install numpy numba>=0.23 "astropy>=1.0,!=2.0.0" matplotlib scipy jplephem pandoc
   - pip install coverage pytest pytest-cov codecov pytest-benchmark sphinx sphinx_rtd_theme nbsphinx IPython ipykernel 
 
 install:

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.6
-  - astropy
+  - astropy!=2.0.0
   - jplephem
   - matplotlib
   - numba

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     install_requires=[
         "numpy",
         "numba>=0.25",
-        "astropy>=1.2",
+        "astropy>=1.2,!=2.0.0",
         "matplotlib",
         "jplephem",
         "scipy",


### PR DESCRIPTION
The wrong Earth radius was used in astropy 2.0.0:

https://github.com/astropy/astropy/issues/6391

Fix #185.