### PR TITLE
Fixed dependency name in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,5 +13,5 @@ dependencies:
   - nbsphinx
   - IPython
   - ipykernel
-  - bs4
+  - beautifulsoup4
   - requests


### PR DESCRIPTION
`bs4` is only available from conda as `beautifulsoup4`