### PR TITLE
Epoch fix

### DIFF
--- a/src/poliastro/plotting.py
+++ b/src/poliastro/plotting.py
@@ -57,6 +57,7 @@ class OrbitPlotter(object):
             _, self.ax = plt.subplots(figsize=(6, 6))
         self.num_points = num_points
         self._frame = None
+        self._states = []  # type: list
         self._attractor_radius = None
 
     def set_frame(self, p_vec, q_vec, w_vec):
@@ -116,6 +117,8 @@ class OrbitPlotter(object):
             self.set_attractor(orbit)
         elif new_radius < self._attractor_radius:
             self.set_attractor(orbit)
+
+        self._states.append(orbit)
 
         lines = []
 

--- a/src/poliastro/plotting.py
+++ b/src/poliastro/plotting.py
@@ -57,7 +57,7 @@ class OrbitPlotter(object):
             _, self.ax = plt.subplots(figsize=(6, 6))
         self.num_points = num_points
         self._frame = None
-        self._states = []  # type: list
+        self._orbits = []  # type: list
         self._attractor_radius = None
 
     def set_frame(self, p_vec, q_vec, w_vec):
@@ -112,8 +112,8 @@ class OrbitPlotter(object):
 
         # Propagates backwards of forwards to the last added orbit epoch.
         if propagate:
-            if self._states:
-                orbit = orbit.propagate(self._states[-1].epoch - orbit.epoch)
+            if self._orbits:
+                orbit = orbit.propagate(self._orbits[-1].epoch - orbit.epoch)
 
         # if new attractor radius is smaller, plot it
         new_radius = max(orbit.attractor.R.to(u.km).value,
@@ -123,7 +123,7 @@ class OrbitPlotter(object):
         elif new_radius < self._attractor_radius:
             self.set_attractor(orbit)
 
-        self._states.append(orbit)
+        self._orbits.append(orbit)
 
         lines = []
 

--- a/src/poliastro/plotting.py
+++ b/src/poliastro/plotting.py
@@ -102,13 +102,18 @@ class OrbitPlotter(object):
 
         self.ax.add_patch(mpl.patches.Circle((0, 0), radius, lw=0, color=color))
 
-    def plot(self, orbit, osculating=True, label=None):
+    def plot(self, orbit, osculating=True, label=None, propagate=False):
         """Plots state and osculating orbit in their plane.
 
         """
         # TODO: This function needs a refactoring
         if not self._frame:
             self.set_frame(*orbit.pqw())
+
+        # Propagates backwards of forwards to the last added orbit epoch.
+        if propagate:
+            if self._states:
+                orbit = orbit.propagate(self._states[-1].epoch - orbit.epoch)
 
         # if new attractor radius is smaller, plot it
         new_radius = max(orbit.attractor.R.to(u.km).value,

--- a/src/poliastro/tests/test_plotting.py
+++ b/src/poliastro/tests/test_plotting.py
@@ -49,6 +49,7 @@ def test_number_of_lines_for_osculating_orbit():
     assert len(l1) == 1
     assert len(l2) == 2
 
+
 def test_orbit_propagation():
     op1 = OrbitPlotter()
     op2 = OrbitPlotter()

--- a/src/poliastro/tests/test_plotting.py
+++ b/src/poliastro/tests/test_plotting.py
@@ -5,7 +5,7 @@ import astropy.units as u
 
 import matplotlib.pyplot as plt
 
-from poliastro.examples import iss
+from poliastro.examples import iss, molniya
 
 from poliastro.plotting import OrbitPlotter
 
@@ -48,3 +48,20 @@ def test_number_of_lines_for_osculating_orbit():
 
     assert len(l1) == 1
     assert len(l2) == 2
+
+def test_orbit_propagation():
+    op1 = OrbitPlotter()
+    op2 = OrbitPlotter()
+    ss1 = iss
+    ss2 = molniya
+
+    op1.plot(ss1)
+    op1.plot(ss2)
+
+    op2.plot(ss1)
+    op2.plot(ss2, propagate=True)
+
+    assert op1.ax.title.get_text() == ss2.epoch.iso
+    assert op2.ax.title.get_text() == ss1.epoch.iso
+    assert op1._orbits[1].epoch.tdb.iso == ss2.epoch.tdb.iso
+    assert op2._orbits[1].epoch.tdb.iso == ss1.epoch.tdb.iso


### PR DESCRIPTION
Quick and dirty fix to #205.

Without the fix, this code, with orbits with different epochs:
```Python
from poliastro import plotting
from poliastro import examples

frame = plotting.OrbitPlotter()

examples.iss.epoch
Out: <Time object: scale='utc' format='iso' value=2013-03-18 12:00:00.000>

examples.molniya.epoch
Out: <Time object: scale='utc' format='jyear_str' value=J2000.000>

frame.plot(examples.iss, label='iss')
frame.plot(examples.molniya, label='molniya')
```
yields:
![without_fix](https://user-images.githubusercontent.com/18404378/29641428-cedd222a-8863-11e7-965f-933f4ba267b9.png)
where epoch is wrong for the first orbit (`ISS`)

With the fix, and adding `propagate=True`:
```Python
from poliastro import plotting
from poliastro import examples

frame = plotting.OrbitPlotter()

examples.iss.epoch
Out: <Time object: scale='utc' format='iso' value=2013-03-18 12:00:00.000>

examples.molniya.epoch
Out: <Time object: scale='utc' format='jyear_str' value=J2000.000>

frame.plot(examples.iss, label='iss')
frame.plot(examples.molniya, label='molniya', propagate=True)
```
![with_fix](https://user-images.githubusercontent.com/18404378/29641490-1c8563de-8864-11e7-8bc7-6ece1d7a79e7.png)
`Molniya` orbit propagates forwards to the `ISS` epoch.