### PR TITLE
Neows epoch

### DIFF
--- a/src/poliastro/neos/__init__.py
+++ b/src/poliastro/neos/__init__.py
@@ -4,3 +4,4 @@ Functions related with NEOs and different NASA APIs.
 All of them are coded as part of SOCIS 2017 proposal.
 
 """
+from poliastro.neos import neows, dastcom5

--- a/src/poliastro/neos/neows.py
+++ b/src/poliastro/neos/neows.py
@@ -52,7 +52,7 @@ def orbit_from_spk_id(spk_id):
     argp = float(orbital_data['perihelion_argument']) * u.deg
     m = float(orbital_data['mean_anomaly']) * u.deg
     nu = M_to_nu(m.to(u.rad), ecc)
-    epoch = Time(orbital_data['orbit_determination_date'])
+    epoch = Time(float(orbital_data['epoch_osculation']), format='jd', scale='tdb')
 
     return Orbit.from_classical(attractor, a, ecc, inc,
                                 raan, argp, nu, epoch)

--- a/src/poliastro/tests/tests_neos/test_neos_neows.py
+++ b/src/poliastro/tests/tests_neos/test_neos_neows.py
@@ -22,7 +22,7 @@ def test_orbit_from_spk_id_has_proper_values(mock_get, mock_response):
             'ascending_node_longitude': '304.3221633898424',
             'perihelion_argument': '178.8165910886752',
             'mean_anomaly': '71.28027812836476',
-            "orbit_determination_date": "2017-06-06 06:20:43",
+            'epoch_osculation': '2458000.5',
         }
     }
 


### PR DESCRIPTION
Neows gets epoch from `epoch_osculation` instead of `orbit_determination_date`.