### PR TITLE
Epoch and plotting changes

### DIFF
--- a/src/poliastro/plotting.py
+++ b/src/poliastro/plotting.py
@@ -163,6 +163,7 @@ class OrbitPlotter(object):
                 epochs_legend[0].remove()
             temp_legend = self.ax.legend(self._epoch_handles, self._epoch_labels, loc='best')
             temp_legend.aname = 'epochs'
+            temp_legend.draggable()
             self.ax.add_artist(temp_legend)
 
         if label:
@@ -170,6 +171,7 @@ class OrbitPlotter(object):
             # orbit depending on the last plotted line, as they share variable
             l.set_label(label)
             self.ax.legend()
+            self.ax.get_legend().draggable()
 
         self.ax.set_xlabel("$x$ (km)")
         self.ax.set_ylabel("$y$ (km)")

--- a/src/poliastro/plotting.py
+++ b/src/poliastro/plotting.py
@@ -175,6 +175,12 @@ class OrbitPlotter(object):
             self.ax.legend()
             self.ax.get_legend().draggable()
 
+        # If orbit is plotted without label, but with epoch_label,
+        # self.ax.legend() has to be called
+        if not label and epoch_label and self.ax.get_legend():
+            self.ax.legend()
+            self.ax.get_legend().draggable()
+
         self.ax.set_xlabel("$x$ (km)")
         self.ax.set_ylabel("$y$ (km)")
         self.ax.set_aspect(1)

--- a/src/poliastro/plotting.py
+++ b/src/poliastro/plotting.py
@@ -2,6 +2,8 @@
 """ Plotting utilities.
 
 """
+from typing import List
+
 import numpy as np
 
 import matplotlib as mpl
@@ -57,8 +59,8 @@ class OrbitPlotter(object):
             _, self.ax = plt.subplots(figsize=(6, 6))
         self.num_points = num_points
         self._frame = None
-        self._epoch_handles = []
-        self._epoch_labels = []
+        self._epoch_handles = []  # type: List[mpl.lines.Line2D]
+        self._epoch_labels = []  # type: List[str]
         self._attractor_radius = None
 
     def set_frame(self, p_vec, q_vec, w_vec):

--- a/src/poliastro/plotting.py
+++ b/src/poliastro/plotting.py
@@ -156,7 +156,6 @@ class OrbitPlotter(object):
             l.set_label(label)
             self.ax.legend()
 
-        self.ax.set_title(orbit.epoch.iso)
         self.ax.set_xlabel("$x$ (km)")
         self.ax.set_ylabel("$y$ (km)")
         self.ax.set_aspect(1)

--- a/src/poliastro/plotting.py
+++ b/src/poliastro/plotting.py
@@ -57,6 +57,8 @@ class OrbitPlotter(object):
             _, self.ax = plt.subplots(figsize=(6, 6))
         self.num_points = num_points
         self._frame = None
+        self._epoch_handles = []
+        self._epoch_labels = []
         self._attractor_radius = None
 
     def set_frame(self, p_vec, q_vec, w_vec):
@@ -101,7 +103,7 @@ class OrbitPlotter(object):
 
         self.ax.add_patch(mpl.patches.Circle((0, 0), radius, lw=0, color=color))
 
-    def plot(self, orbit, osculating=True, label=None):
+    def plot(self, orbit, osculating=True, label=None, epoch_label=True):
         """Plots state and osculating orbit in their plane.
 
         """
@@ -149,6 +151,19 @@ class OrbitPlotter(object):
             l, = self.ax.plot(x.to(u.km).value, y.to(u.km).value,
                               '--', color=l.get_color())
             lines.append(l)
+
+        if epoch_label:
+            self._epoch_handles.append(l)
+
+            orbit.epoch.out_subfmt = 'date_hm'
+            self._epoch_labels.append(orbit.epoch.iso)
+
+            epochs_legend = self.ax.findobj(lambda x: True if x.aname == 'epochs' else False)
+            if epochs_legend:
+                epochs_legend[0].remove()
+            temp_legend = self.ax.legend(self._epoch_handles, self._epoch_labels, loc='best')
+            temp_legend.aname = 'epochs'
+            self.ax.add_artist(temp_legend)
 
         if label:
             # This will apply the label to either the point or the osculating

--- a/src/poliastro/tests/test_plotting.py
+++ b/src/poliastro/tests/test_plotting.py
@@ -4,6 +4,7 @@ import pytest
 import astropy.units as u
 
 import matplotlib.pyplot as plt
+from matplotlib.legend import Legend
 
 from poliastro.examples import iss
 
@@ -35,6 +36,23 @@ def test_axes_labels_and_title():
     assert ax.get_xlabel() == "$x$ (km)"
     assert ax.get_ylabel() == "$y$ (km)"
 
+
+def test_not_legends():
+    op = OrbitPlotter()
+    ss = iss
+    op.plot(ss, epoch_label=False)
+    legends = plt.gca().findobj(Legend)
+
+    assert not legends
+
+
+def test_legends():
+    op = OrbitPlotter()
+    ss = iss
+    op.plot(ss, label='iss', epoch_label=True)
+    legends = plt.gca().findobj(Legend)
+
+    assert len(legends) == 2
 
 def test_number_of_lines_for_osculating_orbit():
     _, (ax1, ax2) = plt.subplots(ncols=2)

--- a/src/poliastro/tests/test_plotting.py
+++ b/src/poliastro/tests/test_plotting.py
@@ -34,7 +34,6 @@ def test_axes_labels_and_title():
 
     assert ax.get_xlabel() == "$x$ (km)"
     assert ax.get_ylabel() == "$y$ (km)"
-    assert ax.get_title() == str(ss.epoch.iso)
 
 
 def test_number_of_lines_for_osculating_orbit():

--- a/src/poliastro/tests/test_plotting.py
+++ b/src/poliastro/tests/test_plotting.py
@@ -54,6 +54,7 @@ def test_legends():
 
     assert len(legends) == 2
 
+
 def test_number_of_lines_for_osculating_orbit():
     _, (ax1, ax2) = plt.subplots(ncols=2)
     op1 = OrbitPlotter(ax1)


### PR DESCRIPTION
Epoch removed from title, and added to a new `epoch legend` (optional). If these two legends are automatically located by Matplotlib in the 'best' place, they overlap. Possible solutions:
- [ ] Fixing one legend to a corner, and the other legend to another corner. Problem:
    * Legends could overlap with orbit plotting.
- [ ] Let `matplotlib` locate the first legend, and locate the second legend in a different place. Problem:
    * Same as above.
    * I haven't been able to get `loc` property of the first legend.
- [x] Making the two legends draggable.

Alternative solutions are welcome.