### PR TITLE
Legend plotting

### DIFF
--- a/src/poliastro/plotting.py
+++ b/src/poliastro/plotting.py
@@ -103,7 +103,7 @@ class OrbitPlotter(object):
 
         self.ax.add_patch(mpl.patches.Circle((0, 0), radius, lw=0, color=color))
 
-    def plot(self, orbit, osculating=True, label=None):
+    def plot(self, orbit, label=None):
         """Plots state and osculating orbit in their plane.
 
         """
@@ -147,10 +147,9 @@ class OrbitPlotter(object):
                           'o', mew=0)
         lines.append(l)
 
-        if osculating:
-            l, = self.ax.plot(x.to(u.km).value, y.to(u.km).value,
-                              '--', color=l.get_color())
-            lines.append(l)
+        l, = self.ax.plot(x.to(u.km).value, y.to(u.km).value,
+                          '--', color=l.get_color())
+        lines.append(l)
 
         if label:
             # This will apply the label to either the point or the osculating

--- a/src/poliastro/plotting.py
+++ b/src/poliastro/plotting.py
@@ -169,9 +169,8 @@ class OrbitPlotter(object):
 
             handles.append(l)
             labels.append(label)
-            # temp_legend = self.ax.legend(handles, labels, loc='best')
             self.ax.figure.legend(handles, labels, mode="expand", loc="lower center", fancybox=True,
-                                  title="Name and epoch of orbits")
+                                  title="Names and epochs")
 
         self.ax.set_xlabel("$x$ (km)")
         self.ax.set_ylabel("$y$ (km)")

--- a/src/poliastro/plotting.py
+++ b/src/poliastro/plotting.py
@@ -156,7 +156,6 @@ class OrbitPlotter(object):
             l.set_label(label)
             self.ax.legend()
 
-        self.ax.set_title(orbit.epoch.iso)
         self.ax.set_xlabel("$x$ (km)")
         self.ax.set_ylabel("$y$ (km)")
         self.ax.set_aspect(1)

--- a/src/poliastro/plotting.py
+++ b/src/poliastro/plotting.py
@@ -159,7 +159,7 @@ class OrbitPlotter(object):
             labels = []  # type: List[str]
 
             orbit.epoch.out_subfmt = 'date_hm'
-            label = '{}  -  {}'.format(label, orbit.epoch.iso)
+            label = '{} ({})'.format(orbit.epoch.iso, label)
 
             legends = self.ax.figure.legends
             if legends:

--- a/src/poliastro/plotting.py
+++ b/src/poliastro/plotting.py
@@ -2,6 +2,8 @@
 """ Plotting utilities.
 
 """
+from typing import List
+
 import numpy as np
 
 import matplotlib as mpl
@@ -153,8 +155,23 @@ class OrbitPlotter(object):
         if label:
             # This will apply the label to either the point or the osculating
             # orbit depending on the last plotted line, as they share variable
-            l.set_label(label)
-            self.ax.legend()
+            handles = []  # type: List[mpl.lines.Line2D]
+            labels = []  # type: List[str]
+
+            orbit.epoch.out_subfmt = 'date_hm'
+            label = '{}  -  {}'.format(label, orbit.epoch.iso)
+
+            legends = self.ax.figure.legends
+            if legends:
+                handles = legends[0].get_lines()
+                labels = [text.get_text() for text in legends[0].get_texts()]
+                legends[0].remove()
+
+            handles.append(l)
+            labels.append(label)
+            # temp_legend = self.ax.legend(handles, labels, loc='best')
+            self.ax.figure.legend(handles, labels, mode="expand", loc="lower center", fancybox=True,
+                                  title="Name and epoch of orbits")
 
         self.ax.set_xlabel("$x$ (km)")
         self.ax.set_ylabel("$y$ (km)")

--- a/src/poliastro/tests/test_plotting.py
+++ b/src/poliastro/tests/test_plotting.py
@@ -37,16 +37,12 @@ def test_axes_labels_and_title():
 
 
 def test_number_of_lines_for_osculating_orbit():
-    _, (ax1, ax2) = plt.subplots(ncols=2)
-    op1 = OrbitPlotter(ax1)
-    op2 = OrbitPlotter(ax2)
+    op1 = OrbitPlotter()
     ss = iss
 
-    l1 = op1.plot(ss, osculating=False)
-    l2 = op2.plot(ss, osculating=True)
+    l1 = op1.plot(ss)
 
-    assert len(l1) == 1
-    assert len(l2) == 2
+    assert len(l1) == 2
 
 
 def test_legend():

--- a/src/poliastro/tests/test_plotting.py
+++ b/src/poliastro/tests/test_plotting.py
@@ -56,6 +56,6 @@ def test_legend():
     legend = plt.gcf().legends[0]
 
     ss.epoch.out_subfmt = 'date_hm'
-    label = '{}  -  {}'.format('ISS', ss.epoch.iso)
+    label = '{} ({})'.format(ss.epoch.iso, 'ISS')
 
     assert legend.get_texts()[0].get_text() == label

--- a/src/poliastro/tests/test_plotting.py
+++ b/src/poliastro/tests/test_plotting.py
@@ -47,3 +47,15 @@ def test_number_of_lines_for_osculating_orbit():
 
     assert len(l1) == 1
     assert len(l2) == 2
+
+
+def test_legend():
+    op = OrbitPlotter()
+    ss = iss
+    op.plot(ss, label='ISS')
+    legend = plt.gcf().legends[0]
+
+    ss.epoch.out_subfmt = 'date_hm'
+    label = '{}  -  {}'.format('ISS', ss.epoch.iso)
+
+    assert legend.get_texts()[0].get_text() == label

--- a/src/poliastro/tests/test_plotting.py
+++ b/src/poliastro/tests/test_plotting.py
@@ -34,7 +34,6 @@ def test_axes_labels_and_title():
 
     assert ax.get_xlabel() == "$x$ (km)"
     assert ax.get_ylabel() == "$y$ (km)"
-    assert ax.get_title() == str(ss.epoch.iso)
 
 
 def test_number_of_lines_for_osculating_orbit():


### PR DESCRIPTION
Another plotting PR 😆 .

Now label and epoch are in a figure legend.

Issues to discuss:
* Should epoch without label be showed in this case: `frame.plot(orbit)`?
* What format should epoch have? (Currently, `YYYY-MM-DD HH:MM`)
* What title should legend have?

Problems:
* When plotting several orbits, legend can overlap axes:
![planets](https://user-images.githubusercontent.com/18404378/29982517-50165466-8f52-11e7-84e2-c862d17aadb7.png)
