### PR TITLE
Added function to compute SOI's radius

### DIFF
--- a/src/poliastro/patched_conics.py
+++ b/src/poliastro/patched_conics.py
@@ -1,0 +1,28 @@
+# coding: utf-8
+"""Patched Conics Computations
+
+Contains methods to compute interplanetary trajectories approximating the three
+body problem with Patched Conics.
+"""
+
+from astropy import units as u
+from poliastro.twobody import Orbit
+from poliastro.constants import J2000
+
+
+@u.quantity_input(a=u.m)
+def compute_soi(body, a=None):
+    """Computes the approximated radius of the Laplace Sphere of Influence (SOI)
+ for a body (:py:class:`~Body` class).
+    """
+    # Compute semimajor axis at epoch J2000 for the body if it was not
+    # introduced by the user
+    if a == None:
+        ss = Orbit.from_body_ephem(body, J2000)
+        a = ss.a
+
+    try:
+        r_soi = a * (body.k / body.parent.k)**(2 / 5)
+        return r_soi.decompose()
+    except AttributeError:
+        print('Body has no parent body assigned.')


### PR DESCRIPTION
As a result of Issue #150, in this Pull  Request an implementation of the computation of the radius of the Sphere of Influence of a body is proposed. The _approximate radius of the Laplace sphere of influence_ is computed using the formula presented by Bate, Mueller and White "Fundamentals of Astrodynamics" in equation 7.4-1.

To obtain the semimajor axis of the body two different approaches are used:
- Semimajor axis is introduced by the user.
- Semimajor axis is computed using **poliastro** for the ephemerides J2000 (default).

Some comments on the current status of the code:

- At the moment is not possible to compute the semimajor axis for Pluto since the following error arises when using **poliastro**'s ephemerides:
`KeyError: "pluto's position and velocity cannot be calculated with the 'builtin' ephemeris."`
- The results where validated using data from table A.2. from Curtis "Orbital Mechanics for Engineering Students". The computed radius from the code is bigger than the tabulated data, however as far as I know the source does not indicate which method is used to compute such data. There exit other approximations which may provide more accurate results (see [Wkipedia: Sphere of influence (astrodynamics). Increased accuracy on the SOI](https://en.wikipedia.org/wiki/Sphere_of_influence_(astrodynamics)#Increased_accuracy_on_the_SOI)).
- I tried to implement an exception for the case where no parent body exists, but it may be possible to do it better.
- It would be desirable to write tests.