### PR TITLE
Add from_relative to Body class

### DIFF
--- a/src/poliastro/bodies.py
+++ b/src/poliastro/bodies.py
@@ -58,10 +58,10 @@ class _Body(object):
 
 
 class Body(_Body):
-    """Class to represent a generic body of the Solar System.
+    """Class to represent a generic body.
 
     """
-    def __init__(self, parent, k, name, symbol=None, R=0 * u.km):
+    def __init__(self, parent, k, name, symbol=None, R=0 * u.km, **kwargs):
         """Constructor.
 
         Parameters
@@ -83,11 +83,19 @@ class Body(_Body):
         self.name = name
         self.symbol = symbol
         self.R = R
+        self.kwargs = kwargs
 
     @classmethod
     @u.quantity_input(k=u.km ** 3 / u.s ** 2, R=u.km)
-    def from_parameters(cls, parent, k, name, symbol, R):
-        return cls(parent, k, name, symbol, R)
+    def from_parameters(cls, parent, k, name, symbol, R, **kwargs):
+        return cls(parent, k, name, symbol, R, **kwargs)
+
+    @classmethod
+    def from_relative(cls, reference, parent=None, k=None, name=None,
+                      symbol=None, R=None, **kwargs):
+        k = k * reference.k
+        R = R * reference.R
+        return cls(parent, k, name, symbol, R, **kwargs)
 
 
 class _Sun(_Body):

--- a/src/poliastro/coordinates.py
+++ b/src/poliastro/coordinates.py
@@ -129,4 +129,3 @@ def inertial_body_centered_to_pqw(r, v, source_body):
     v_pqw = (np.array([-sin(nu), (ecc + cos(nu)), 0]) * sqrt(k / p)).T * u.km / u.s
 
     return r_pqw, v_pqw
-

--- a/src/poliastro/tests/test_bodies.py
+++ b/src/poliastro/tests/test_bodies.py
@@ -36,3 +36,39 @@ def test_earth_has_k_given_in_literature():
     expected_k = 3.986004418e14 * u.m ** 3 / u.s ** 2
     k = bodies.Earth.k
     assert_quantity_allclose(k.decompose([u.km, u.s]), expected_k)
+
+
+def test_body_kwargs():
+    name = "2 Pallas"
+    symbol = u"\u26b4"
+    k = 1.41e10 * u.m ** 3 / u.s ** 2
+    pallas2 = bodies.Body(None, k, name, symbol)
+    assert pallas2.kwargs == {}
+    pallas2 = bodies.Body(None, k, name, symbol, custom='data')
+    assert 'custom' in pallas2.kwargs
+
+
+def test_from_relative():
+    TRAPPIST1 = bodies.Body.from_relative(reference=bodies.Sun,
+                                          parent=None,
+                                          k=0.08,  # Relative to the Sun
+                                          name='TRAPPIST',
+                                          symbol=None,
+                                          R=0.114)  # Relative to the Sun
+
+    TRAPPIST1D = bodies.Body.from_relative(reference=bodies.Earth,
+                                           parent=TRAPPIST1,  # Orbits TRAPPIST1
+                                           k=0.5,
+                                           name='TRAPPIST1D',
+                                           symbol=None,
+                                           R=0.772)  # Relative to the Earth
+
+    # check values properly calculated
+    VALUECHECK = bodies.Body.from_relative(reference=bodies.Earth,
+                                           parent=TRAPPIST1,
+                                           k=1,
+                                           name='VALUECHECK',
+                                           symbol=None,
+                                           R=1)
+    assert bodies.Earth.k == VALUECHECK.k
+    assert bodies.Earth.R == VALUECHECK.R

--- a/src/poliastro/tests/test_coordinates.py
+++ b/src/poliastro/tests/test_coordinates.py
@@ -7,6 +7,7 @@ from poliastro import coordinates, bodies
 from poliastro.examples import molniya
 from poliastro.twobody.orbit import Orbit
 
+
 # Note that function are tested using astropy current builtin ephemeris.
 # Horizons uses JPL ephemeris DE431, so expected values are hardcoded,
 # instead of being obtained using Horizons.


### PR DESCRIPTION
Add the from_relative method of creating a Body to allow easy creation
of bodies for exoplanets and other bodies that are often described with
mass and radius relative to Sun, Jupiter or Earth.  The from_relative
method will take any object as a reference as long as it implements the
attributes (k and R) and does not require the reference object to be a
poliastro Body object.

Updated the docstring on Body to remove reference to the Solar System
as bodies may be exoplanets, stars or other extrasolar objects.

Allowed for pass through of additional data to newly created bodies
using kwargs.