### PR TITLE
Fixing intersphinx link to Python docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -110,7 +110,7 @@ pygments_style = 'sphinx'
 
 #Intersphinx configuration
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3.4', None),
+    'python': ('https://docs.python.org/3', None),
     'astropy': ('http://docs.astropy.org/en/stable/', None),
     'numpy': ('https://docs.scipy.org/doc/numpy/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),


### PR DESCRIPTION
Just a minor error. poliastro docs were referencing Python 3.4 docs, instead of referencing Python 3.6.