### PR TITLE
Add conversion between different anomalies in hyperbolic orbits

### DIFF
--- a/src/poliastro/tests/tests_twobody/test_angles.py
+++ b/src/poliastro/tests/tests_twobody/test_angles.py
@@ -27,6 +27,18 @@ def test_true_to_eccentric():
         assert_quantity_allclose(E, expected_E, rtol=1e-6)
 
 
+def test_true_to_eccentric_hyperbolic():
+    # Data from Curtis, H. (2013). *Orbital mechanics for engineering students*.
+    # Example 3.5
+    nu = 100 * u.deg
+    ecc = 2.7696 * u.one
+    expected_F = 2.2927 * u.rad
+
+    F = angles.nu_to_F(nu, ecc)
+
+    assert_quantity_allclose(F, expected_F, rtol=1e-4)
+
+
 def test_mean_to_true():
     # Data from Schlesinger & Udick, 1912
     data = [
@@ -75,6 +87,18 @@ def test_true_to_mean():
         M = angles.nu_to_M(nu, ecc)
 
         assert_quantity_allclose(M, expected_M, rtol=1e-4)
+
+
+def test_true_to_mean_hyperbolic():
+    # Data from Curtis, H. (2013). *Orbital mechanics for engineering students*.
+    # Example 3.5
+    nu = 100 * u.deg
+    ecc = 2.7696 * u.one
+    expected_M = 11.279 * u.rad
+
+    M = angles.nu_to_M(nu, ecc)
+
+    assert_quantity_allclose(M, expected_M, rtol=1e-4)
 
 
 def test_flight_path_angle():

--- a/src/poliastro/tests/tests_twobody/test_angles.py
+++ b/src/poliastro/tests/tests_twobody/test_angles.py
@@ -101,6 +101,18 @@ def test_true_to_mean_hyperbolic():
     assert_quantity_allclose(M, expected_M, rtol=1e-4)
 
 
+def test_mean_to_true_hyperbolic():
+    # Data from Curtis, H. (2013). *Orbital mechanics for engineering students*.
+    # Example 3.5
+    M = 11.279 * u.rad
+    ecc = 2.7696 * u.one
+    expected_nu = 100 * u.deg
+
+    nu = angles.M_to_nu(M, ecc)
+
+    assert_quantity_allclose(nu, expected_nu, rtol=1e-4)
+
+
 def test_flight_path_angle():
     # Data from Curtis, example 2.5
     nu = 109.5 * u.deg

--- a/src/poliastro/twobody/angles.py
+++ b/src/poliastro/twobody/angles.py
@@ -109,8 +109,9 @@ def F_to_nu(F, ecc):
         True anomaly (rad).
 
     """
-    nu = 2 * np.arctan((np.exp(F.value) * np.sqrt(ecc + 1) - np.sqrt(ecc + 1)) /
-                       (np.exp(F.value) * np.sqrt(ecc - 1) + np.sqrt(ecc - 1)))
+    with u.set_enabled_equivalencies(u.dimensionless_angles()):
+        nu = 2 * np.arctan((np.exp(F) * np.sqrt(ecc + 1) - np.sqrt(ecc + 1)) /
+                           (np.exp(F) * np.sqrt(ecc - 1) + np.sqrt(ecc - 1)))
     return nu
 
 

--- a/src/poliastro/twobody/angles.py
+++ b/src/poliastro/twobody/angles.py
@@ -16,6 +16,14 @@ def _kepler_equation_prime(E, M, ecc):
     return 1 - ecc * np.cos(E)
 
 
+def _kepler_equation_hyper(F, M, ecc):
+    return -F + ecc * np.sinh(F) - M
+
+
+def _kepler_equation_prime_hyper(F, M, ecc):
+    return ecc * np.cosh(F) - 1
+
+
 def nu_to_E(nu, ecc):
     """Eccentric anomaly from true anomaly.
 
@@ -38,6 +46,31 @@ def nu_to_E(nu, ecc):
     return E
 
 
+def nu_to_F(nu, ecc):
+    """Hyperbolic eccentric anomaly from true anomaly.
+
+    Parameters
+    ----------
+    nu : float
+        True anomaly (rad).
+    ecc : float
+        Eccentricity (>1).
+
+    Returns
+    -------
+    F : float
+        Hyperbolic eccentric anomaly.
+
+    Note
+    -----
+    Taken from Curtis, H. (2013). *Orbital mechanics for engineering students*. 167
+
+    """
+    F = np.log((np.sqrt(ecc + 1) + np.sqrt(ecc - 1) * np.tan(nu / 2)) /
+               (np.sqrt(ecc + 1) - np.sqrt(ecc - 1) * np.tan(nu / 2))) * u.rad
+    return F
+
+
 def E_to_nu(E, ecc):
     """True anomaly from eccentric anomaly.
 
@@ -57,6 +90,27 @@ def E_to_nu(E, ecc):
 
     """
     nu = 2 * np.arctan(np.sqrt((1 + ecc) / (1 - ecc)) * np.tan(E / 2))
+    return nu
+
+
+def F_to_nu(F, ecc):
+    """True anomaly from hyperbolic eccentric anomaly.
+
+    Parameters
+    ----------
+    F : float
+        Hyperbolic eccentric anomaly (rad).
+    ecc : float
+        Eccentricity (>1).
+
+    Returns
+    -------
+    nu : float
+        True anomaly (rad).
+
+    """
+    nu = 2 * np.arctan((np.exp(F) * np.sqrt(ecc + 1) - np.sqrt(ecc + 1)) /
+                       (np.exp(F) * np.sqrt(ecc - 1) + np.sqrt(ecc - 1)))
     return nu
 
 
@@ -84,6 +138,28 @@ def M_to_E(M, ecc):
     return E
 
 
+def M_to_F(M, ecc):
+    """Hyperbolic eccentric anomaly from mean anomaly.
+
+    Parameters
+    ----------
+    M : float
+        Mean anomaly (rad).
+    ecc : float
+        Eccentricity (>1).
+
+    Returns
+    -------
+    F : float
+        Hyperbolic eccentric anomaly.
+
+    """
+    with u.set_enabled_equivalencies(u.dimensionless_angles()):
+        F = optimize.newton(_kepler_equation_hyper, M, _kepler_equation_prime_hyper,
+                            args=(M, ecc))
+    return F
+
+
 def E_to_M(E, ecc):
     """Mean anomaly from eccentric anomaly.
 
@@ -104,6 +180,27 @@ def E_to_M(E, ecc):
     """
     with u.set_enabled_equivalencies(u.dimensionless_angles()):
         M = _kepler_equation(E, 0.0 * u.rad, ecc)
+    return M
+
+
+def F_to_M(F, ecc):
+    """Mean anomaly from eccentric anomaly.
+
+    Parameters
+    ----------
+    F : float
+        Hyperbolic eccentric anomaly (rad).
+    ecc : float
+        Eccentricity (>1).
+
+    Returns
+    -------
+    M : float
+        Mean anomaly (rad).
+
+    """
+    with u.set_enabled_equivalencies(u.dimensionless_angles()):
+        M = _kepler_equation_hyper(F, 0.0 * u.rad, ecc)
     return M
 
 
@@ -131,8 +228,12 @@ def M_to_nu(M, ecc):
     33.673284930211658
 
     """
-    E = M_to_E(M, ecc)
-    nu = E_to_nu(E, ecc)
+    if ecc > 1:
+        F = M_to_F(M, ecc)
+        nu = F_to_nu(F, ecc)
+    else:
+        E = M_to_E(M, ecc)
+        nu = E_to_nu(E, ecc)
     return nu
 
 
@@ -154,8 +255,12 @@ def nu_to_M(nu, ecc):
         Mean anomaly (rad).
 
     """
-    E = nu_to_E(nu, ecc)
-    M = E_to_M(E, ecc)
+    if ecc > 1:
+        F = nu_to_F(nu, ecc)
+        M = F_to_M(F, ecc)
+    else:
+        E = nu_to_E(nu, ecc)
+        M = E_to_M(E, ecc)
     return M
 
 

--- a/src/poliastro/twobody/angles.py
+++ b/src/poliastro/twobody/angles.py
@@ -109,8 +109,8 @@ def F_to_nu(F, ecc):
         True anomaly (rad).
 
     """
-    nu = 2 * np.arctan((np.exp(F) * np.sqrt(ecc + 1) - np.sqrt(ecc + 1)) /
-                       (np.exp(F) * np.sqrt(ecc - 1) + np.sqrt(ecc - 1)))
+    nu = 2 * np.arctan((np.exp(F.value) * np.sqrt(ecc + 1) - np.sqrt(ecc + 1)) /
+                       (np.exp(F.value) * np.sqrt(ecc - 1) + np.sqrt(ecc - 1)))
     return nu
 
 


### PR DESCRIPTION
Current anomaly conversions (mean -> true, true -> eccentric, ...)
are only valid when eccentricity < 1, not for hyperbolic orbits.