### PR TITLE
Return times in Orbit.sample()

### DIFF
--- a/src/poliastro/plotting.py
+++ b/src/poliastro/plotting.py
@@ -151,7 +151,8 @@ class OrbitPlotter(object):
 
         lines = []
 
-        rr = orbit.sample(self.num_points).get_xyz().transpose()
+        _, positions = orbit.sample(self.num_points)
+        rr = positions.get_xyz().transpose()
 
         # Project on OrbitPlotter frame
         # x_vec, y_vec, z_vec = self._frame

--- a/src/poliastro/plotting.py
+++ b/src/poliastro/plotting.py
@@ -328,7 +328,7 @@ class OrbitPlotter3D:
         self._redraw_attractor(orbit.r_p * 0.15)  # Arbitrary threshold
 
         label = _generate_label(orbit, label)
-        trajectory = orbit.sample()
+        _, trajectory = orbit.sample()
 
         self._plot_trajectory(trajectory, label, color, True)
 

--- a/src/poliastro/tests/tests_twobody/test_orbit.py
+++ b/src/poliastro/tests/tests_twobody/test_orbit.py
@@ -169,7 +169,7 @@ def test_sample_numpoints():
     ss = Orbit.from_classical(_body, _d, _, _a, _a, _a, _a)
     times, positions = ss.sample(values=50)
 
-    assert len(positions) == 50 and len(times) == 50
+    assert len(positions) == len(times) == 50
 
 
 def test_sample_with_time_value():

--- a/src/poliastro/tests/tests_twobody/test_orbit.py
+++ b/src/poliastro/tests/tests_twobody/test_orbit.py
@@ -167,8 +167,9 @@ def test_sample_numpoints():
     _a = 1.0 * u.deg  # Unused angle
     _body = Sun  # Unused body
     ss = Orbit.from_classical(_body, _d, _, _a, _a, _a, _a)
+    times, positions = ss.sample(values=50)
 
-    assert len(ss.sample(values=50)) == 50
+    assert len(positions) == 50 and len(times) == 50
 
 
 def test_sample_with_time_value():
@@ -179,7 +180,8 @@ def test_sample_with_time_value():
     ss = Orbit.from_classical(_body, _d, _, _a, _a, _a, _a)
 
     expected_r = [ss.r]
-    r = ss.sample(values=[ss.period]).get_xyz().transpose()
+    _, positions = ss.sample(values=[ss.period])
+    r = positions.get_xyz().transpose()
 
     assert_quantity_allclose(r, expected_r, rtol=1.e-7)
 
@@ -192,6 +194,7 @@ def test_sample_with_nu_value():
     ss = Orbit.from_classical(_body, _d, _, _a, _a, _a, _a)
 
     expected_r = [ss.r]
-    r = ss.sample(values=[360] * u.deg).get_xyz().transpose()
+    _, positions = ss.sample(values=[360] * u.deg)
+    r = positions.get_xyz().transpose()
 
     assert_quantity_allclose(r, expected_r, rtol=1.e-7)

--- a/src/poliastro/tests/tests_twobody/test_sample.py
+++ b/src/poliastro/tests/tests_twobody/test_sample.py
@@ -16,7 +16,7 @@ def test_sample_angle_zero_returns_same():
 
     nu_values = [0] * u.deg
 
-    rr = ss0.sample(nu_values)
+    _, rr = ss0.sample(nu_values)
 
     assert (rr[0].get_xyz() == ss0.r).all()
 
@@ -34,7 +34,7 @@ def test_sample_one_point_equals_propagation_small_deltas(time_of_flight):
 
     expected_ss = ss0.propagate(time_of_flight)
 
-    rr = ss0.sample(sample_times)
+    _, rr = ss0.sample(sample_times)
 
     assert (rr[0].get_xyz() == expected_ss.r).all()
 
@@ -50,7 +50,7 @@ def test_sample_one_point_equals_propagation_big_deltas(time_of_flight):
 
     expected_ss = ss0.propagate(time_of_flight)
 
-    rr = ss0.sample(sample_times)
+    _, rr = ss0.sample(sample_times)
 
     assert (rr[0].get_xyz() == expected_ss.r).all()
 
@@ -65,7 +65,7 @@ def test_sample_nu_values():
 
     expected_ss = ss0.propagate(ss0.period / 2)
 
-    rr = ss0.sample(nu_values)
+    _, rr = ss0.sample(nu_values)
 
     assert len(rr) == len(nu_values)
     assert_quantity_allclose(rr[-1].get_xyz(), expected_ss.r)
@@ -80,7 +80,7 @@ def test_sample_num_points(num_points):
 
     expected_ss = ss0.propagate(ss0.period / 2)
 
-    rr = ss0.sample(num_points)
+    _, rr = ss0.sample(num_points)
 
     assert len(rr) == num_points
     assert_quantity_allclose(rr[num_points // 2].get_xyz(), expected_ss.r)

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -267,8 +267,9 @@ class Orbit(object):
 
         Returns
         -------
-        CartesianRepresentation
-            Position vector in each given value.
+        (Time, CartesianRepresentation)
+            A tuple containing Time and Position vector in each
+            given value.
 
         Notes
         -----
@@ -304,7 +305,7 @@ class Orbit(object):
         elif hasattr(values, "unit") and values.unit in ('rad', 'deg'):
             values = self._generate_time_values(values)
 
-        return self._sample(values)
+        return (values, self._sample(values))
 
     def _sample(self, time_values):
         values = np.zeros((len(time_values), 3)) * self.r.unit


### PR DESCRIPTION
Addresses #287. This PR returns a tuple `(Time, CartesianRepresentation)` in `Orbit.sample()`.

I've update existing and added a small test [here](https://github.com/ritiek/poliastro/blob/2e6ff3e6d87a35a808648107917679912f5e06fb/src/poliastro/tests/tests_twobody/test_orbit.py#L170-L172) that checks the value count. If there any other tests we need, please let me know!