### PR TITLE
added draft for mean_motion propagator

### DIFF
--- a/src/poliastro/tests/tests_twobody/test_propagation.py
+++ b/src/poliastro/tests/tests_twobody/test_propagation.py
@@ -1,4 +1,5 @@
 from pytest import approx
+import pytest
 
 import numpy as np
 from numpy.testing import assert_allclose
@@ -10,12 +11,13 @@ from astropy.tests.helper import assert_quantity_allclose
 from poliastro.constants import J2000
 from poliastro.bodies import Sun, Earth
 from poliastro.twobody import Orbit
-from poliastro.twobody.propagation import cowell
+from poliastro.twobody.propagation import cowell, kepler, mean_motion
 
 from poliastro.util import norm
 
 
-def test_propagation():
+@pytest.mark.parametrize('method', [kepler, mean_motion])
+def test_propagation(method):
     # Data from Vallado, example 2.4
     r0 = [1131.340, -2282.343, 6672.423] * u.km
     v0 = [-5.64305, 4.30333, 2.42879] * u.km / u.s
@@ -24,7 +26,7 @@ def test_propagation():
 
     ss0 = Orbit.from_vectors(Earth, r0, v0)
     tof = 40 * u.min
-    ss1 = ss0.propagate(tof)
+    ss1 = ss0.propagate(tof, method=method)
 
     r, v = ss1.rv()
 

--- a/src/poliastro/tests/tests_twobody/test_propagation.py
+++ b/src/poliastro/tests/tests_twobody/test_propagation.py
@@ -69,11 +69,11 @@ def test_propagation_hyperbolic():
 
 
 def test_propagation_mean_motion_parabolic():
-    # example from Howard Curtis, section 3.5, problem 3.15
-    p = 13200.0 * u.km
+    # example from Howard Curtis (3rd edition), section 3.5, problem 3.15
+    p = 2.0 * 6600 * u.km
     _a = 0.0 * u.deg
     orbit = Orbit.parabolic(Earth, p, _a, _a, _a, _a)
-    orbit = orbit.propagate(0.8897 * 3600.0 / 2.0 * u.s, method=mean_motion)
+    orbit = orbit.propagate(0.8897 / 2.0 * u.h, method=mean_motion)
 
     _, _, _, _, _, nu0 = rv2coe(Earth.k.to(u.km**3 / u.s**2).value,
                                 orbit.r.to(u.km).value,
@@ -81,8 +81,8 @@ def test_propagation_mean_motion_parabolic():
     assert_quantity_allclose(nu0, np.deg2rad(90.0), rtol=1e-4)
 
     orbit = Orbit.parabolic(Earth, p, _a, _a, _a, _a)
-    orbit = orbit.propagate(36.0 * 3600.0 * u.s, method=mean_motion)
-    assert_quantity_allclose(np.sqrt(np.sum(np.array(orbit.r.to(u.km).value) ** 2)), 304700.0, rtol=1e-4)
+    orbit = orbit.propagate(36.0 * u.h, method=mean_motion)
+    assert_quantity_allclose(norm(orbit.r.to(u.km).value), 304700.0, rtol=1e-4)
 
 
 def test_propagation_zero_time_returns_same_state():

--- a/src/poliastro/tests/tests_twobody/test_sample.py
+++ b/src/poliastro/tests/tests_twobody/test_sample.py
@@ -7,7 +7,7 @@ from astropy.time import Time
 from poliastro.bodies import Earth
 from poliastro.twobody import Orbit
 from poliastro.twobody.propagation import propagate
-
+import numpy as np
 
 def test_sample_angle_zero_returns_same():
     # Data from Vallado, example 2.4
@@ -16,10 +16,9 @@ def test_sample_angle_zero_returns_same():
     ss0 = Orbit.from_vectors(Earth, r0, v0)
 
     nu_values = [0] * u.deg
-
     _, rr = ss0.sample(nu_values)
 
-    assert (rr[0].get_xyz() == ss0.r).all()
+    assert_quantity_allclose(rr[0].get_xyz(), ss0.r)
 
 
 @pytest.mark.parametrize("time_of_flight,function", [
@@ -40,7 +39,7 @@ def test_sample_one_point_equals_propagation_small_deltas(time_of_flight, functi
 
     _, rr = ss0.sample(sample_times, function)
 
-    assert (rr[0].get_xyz() == expected_ss.r).all()
+    assert_quantity_allclose(rr[0].get_xyz(), expected_ss.r)
 
 
 @pytest.mark.parametrize("time_of_flight,function", [
@@ -59,7 +58,7 @@ def test_sample_one_point_equals_propagation_big_deltas(time_of_flight, function
 
     _, rr = ss0.sample(sample_times, function)
 
-    assert (rr[0].get_xyz() == expected_ss.r).all()
+    assert_quantity_allclose(rr[0].get_xyz(), expected_ss.r)
 
 
 def test_sample_nu_values():

--- a/src/poliastro/tests/tests_twobody/test_sample.py
+++ b/src/poliastro/tests/tests_twobody/test_sample.py
@@ -6,7 +6,7 @@ from astropy.time import Time
 
 from poliastro.bodies import Earth
 from poliastro.twobody import Orbit
-from poliastro.twobody.propagation import propagate, kepler, mean_motion
+from poliastro.twobody.propagation import kepler, mean_motion, cowell
 import numpy as np
 
 
@@ -22,12 +22,8 @@ def test_sample_angle_zero_returns_same():
     assert_quantity_allclose(rr[0].get_xyz(), ss0.r)
 
 
-@pytest.mark.parametrize("time_of_flight,method", [
-    (1 * u.min, kepler),
-    (40 * u.min, kepler),
-    (1 * u.min, mean_motion),
-    (40 * u.min, mean_motion),
-])
+@pytest.mark.parametrize("time_of_flight", [1 * u.min, 40 * u.min])
+@pytest.mark.parametrize("method", [kepler, mean_motion, cowell])
 def test_sample_one_point_equals_propagation_small_deltas(time_of_flight, method):
     # Time arithmetic loses precision, see
     # https://github.com/astropy/astropy/issues/6638
@@ -45,12 +41,8 @@ def test_sample_one_point_equals_propagation_small_deltas(time_of_flight, method
     assert_quantity_allclose(rr[0].get_xyz(), expected_ss.r)
 
 
-@pytest.mark.parametrize("time_of_flight,method", [
-    (6 * u.h, kepler),
-    (2 * u.day, kepler),
-    (6 * u.h, mean_motion),
-    (2 * u.day, mean_motion),
-])
+@pytest.mark.parametrize("time_of_flight", [6 * u.h, 2 * u.day])
+@pytest.mark.parametrize("method", [kepler, mean_motion, cowell])
 def test_sample_one_point_equals_propagation_big_deltas(time_of_flight, method):
     # Data from Vallado, example 2.4
     r0 = [1131.340, -2282.343, 6672.423] * u.km

--- a/src/poliastro/tests/tests_twobody/test_sample.py
+++ b/src/poliastro/tests/tests_twobody/test_sample.py
@@ -6,7 +6,7 @@ from astropy.time import Time
 
 from poliastro.bodies import Earth
 from poliastro.twobody import Orbit
-from poliastro.twobody.propagation import propagate
+from poliastro.twobody.propagation import propagate, kepler, mean_motion
 import numpy as np
 
 
@@ -22,11 +22,13 @@ def test_sample_angle_zero_returns_same():
     assert_quantity_allclose(rr[0].get_xyz(), ss0.r)
 
 
-@pytest.mark.parametrize("time_of_flight,function", [
-    (1 * u.min, propagate),
-    (40 * u.min, propagate),
+@pytest.mark.parametrize("time_of_flight,method", [
+    (1 * u.min, kepler),
+    (40 * u.min, kepler),
+    (1 * u.min, mean_motion),
+    (40 * u.min, mean_motion),
 ])
-def test_sample_one_point_equals_propagation_small_deltas(time_of_flight, function):
+def test_sample_one_point_equals_propagation_small_deltas(time_of_flight, method):
     # Time arithmetic loses precision, see
     # https://github.com/astropy/astropy/issues/6638
     # Data from Vallado, example 2.4
@@ -36,18 +38,20 @@ def test_sample_one_point_equals_propagation_small_deltas(time_of_flight, functi
 
     sample_times = Time([ss0.epoch + time_of_flight])
 
-    expected_ss = ss0.propagate(time_of_flight, function)
+    expected_ss = ss0.propagate(time_of_flight, method)
 
-    _, rr = ss0.sample(sample_times, function)
+    _, rr = ss0.sample(sample_times, method)
 
     assert_quantity_allclose(rr[0].get_xyz(), expected_ss.r)
 
 
-@pytest.mark.parametrize("time_of_flight,function", [
-    (6 * u.h, propagate),
-    (2 * u.day, propagate),
+@pytest.mark.parametrize("time_of_flight,method", [
+    (6 * u.h, kepler),
+    (2 * u.day, kepler),
+    (6 * u.h, mean_motion),
+    (2 * u.day, mean_motion),
 ])
-def test_sample_one_point_equals_propagation_big_deltas(time_of_flight, function):
+def test_sample_one_point_equals_propagation_big_deltas(time_of_flight, method):
     # Data from Vallado, example 2.4
     r0 = [1131.340, -2282.343, 6672.423] * u.km
     v0 = [-5.64305, 4.30333, 2.42879] * u.km / u.s
@@ -57,7 +61,7 @@ def test_sample_one_point_equals_propagation_big_deltas(time_of_flight, function
 
     expected_ss = ss0.propagate(time_of_flight)
 
-    _, rr = ss0.sample(sample_times, function)
+    _, rr = ss0.sample(sample_times, method)
 
     assert_quantity_allclose(rr[0].get_xyz(), expected_ss.r)
 

--- a/src/poliastro/tests/tests_twobody/test_sample.py
+++ b/src/poliastro/tests/tests_twobody/test_sample.py
@@ -9,6 +9,7 @@ from poliastro.twobody import Orbit
 from poliastro.twobody.propagation import propagate
 import numpy as np
 
+
 def test_sample_angle_zero_returns_same():
     # Data from Vallado, example 2.4
     r0 = [1131.340, -2282.343, 6672.423] * u.km

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -237,7 +237,7 @@ class Orbit(object):
     def __repr__(self):
         return self.__str__()
 
-    def propagate(self, epoch_or_duration, method=kepler, rtol=1e-10):
+    def propagate(self, epoch_or_duration, method=mean_motion, rtol=1e-10):
         """Propagate this `Orbit` some `time` and return the result.
 
         Parameters
@@ -255,7 +255,7 @@ class Orbit(object):
 
         return propagate(self, time_of_flight, method=method, rtol=rtol)
 
-    def sample(self, values=None, function=propagate):
+    def sample(self, values=None, method=mean_motion):
         """Samples an orbit to some specified time values.
 
         .. versionadded:: 0.8.0
@@ -291,7 +291,7 @@ class Orbit(object):
 
         """
         if values is None:
-            return self.sample(100, function)
+            return self.sample(100, method)
 
         elif isinstance(values, int):
             if self.ecc < 1:
@@ -306,16 +306,16 @@ class Orbit(object):
                 nu_limit = np.arccos(-(1 - 1 / 3.) / self.ecc)
                 nu_values = np.linspace(-nu_limit, nu_limit, values)
 
-            return self.sample(nu_values, function)
+            return self.sample(nu_values, method)
 
         elif hasattr(values, "unit") and values.unit in ('rad', 'deg'):
             values = self._generate_time_values(values)
-        return (values, self._sample(values, function))
+        return (values, self._sample(values, method))
 
-    def _sample(self, time_values, function=propagate):
+    def _sample(self, time_values, method=mean_motion):
         values = np.zeros((len(time_values), 3)) * self.r.unit
         for ii, epoch in enumerate(time_values):
-            rr = self.propagate(epoch, function).r
+            rr = self.propagate(epoch, method).r
             values[ii] = rr
 
         return CartesianRepresentation(values, xyz_axis=1)

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -9,7 +9,7 @@ from astropy.coordinates import CartesianRepresentation, get_body_barycentric_po
 
 from poliastro.constants import J2000
 from poliastro.twobody.angles import nu_to_M, E_to_nu, nu_to_E
-from poliastro.twobody.propagation import propagate, cowell
+from poliastro.twobody.propagation import propagate, cowell, kepler, mean_motion
 
 from poliastro.twobody import rv
 from poliastro.twobody import classical
@@ -237,7 +237,7 @@ class Orbit(object):
     def __repr__(self):
         return self.__str__()
 
-    def propagate(self, epoch_or_duration, function=propagate, rtol=1e-10):
+    def propagate(self, epoch_or_duration, method=kepler, function=propagate, rtol=1e-10):
         """Propagate this `Orbit` some `time` and return the result.
 
         Parameters
@@ -253,7 +253,7 @@ class Orbit(object):
         else:
             time_of_flight = time.TimeDelta(epoch_or_duration)
 
-        return function(self, time_of_flight, rtol=rtol)
+        return function(self, time_of_flight, merhod=method, rtol=rtol)
 
     def sample(self, values=None, function=propagate):
         """Samples an orbit to some specified time values.

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -237,7 +237,7 @@ class Orbit(object):
     def __repr__(self):
         return self.__str__()
 
-    def propagate(self, epoch_or_duration, method=kepler, function=propagate, rtol=1e-10):
+    def propagate(self, epoch_or_duration, method=kepler, rtol=1e-10):
         """Propagate this `Orbit` some `time` and return the result.
 
         Parameters
@@ -253,7 +253,7 @@ class Orbit(object):
         else:
             time_of_flight = time.TimeDelta(epoch_or_duration)
 
-        return function(self, time_of_flight, method=method, rtol=rtol)
+        return propagate(self, time_of_flight, method=method, rtol=rtol)
 
     def sample(self, values=None, function=propagate):
         """Samples an orbit to some specified time values.

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -253,7 +253,7 @@ class Orbit(object):
         else:
             time_of_flight = time.TimeDelta(epoch_or_duration)
 
-        return function(self, time_of_flight, merhod=method, rtol=rtol)
+        return function(self, time_of_flight, method=method, rtol=rtol)
 
     def sample(self, values=None, function=propagate):
         """Samples an orbit to some specified time values.

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -131,10 +131,11 @@ def mean_motion(k, r0, v0, tof, **kwargs):
 
     # get the initial true anomaly and orbit parameters that are constant over time
     p, ecc, inc, raan, argp, nu0 = rv2coe(k, r0, v0)
+
     # get the initial mean anomaly
     M0 = nu_to_M(nu0, ecc)
     # elliptic or hyperbolic orbits
-    if ecc != 1.0:
+    if not np.isclose(ecc, 1.0, rtol=1e-06):
         a = p / (1.0 - ecc ** 2)
         # given the initial mean anomaly, calculate mean anomaly
         # at the end, mean motion (n) equals sqrt(mu / |a^3|)

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -105,6 +105,7 @@ def cowell(k, r0, v0, tof, rtol=1e-10, *, ad=None, callback=None, nsteps=1000):
 
     return r, v
 
+
 def mean_motion(k, r0, v0, tof, **kwargs):
     """Propagates orbit using mean motion
 
@@ -123,30 +124,24 @@ def mean_motion(k, r0, v0, tof, **kwargs):
 
     Note
     -----
-    This method takes initial \vec{r}, \vec{v}, 
-    calculates classical orbit parameters
-    increases mean anomaly and performs inverse 
-    transformation to get final \vec{r}, \vec{v}
-    The logic is based on formulae (4), (6) and (7) 
-    from http://dx.doi.org/10.1007/s10569-013-9476-9
-
+    This method takes initial \vec{r}, \vec{v}, calculates classical orbit parameters,
+    increases mean anomaly and performs inverse transformation to get final \vec{r}, \vec{v}
+    The logic is based on formulae (4), (6) and (7) from http://dx.doi.org/10.1007/s10569-013-9476-9
     """
 
     # get the initial true anomaly and orbit parameters that are constant over time
     p, ecc, inc, raan, argp, nu0 = rv2coe(k, r0, v0)
-
     # get the initial mean anomaly
     M0 = nu_to_M(nu0, ecc)
-    
     # elliptic or hyperbolic orbits
     if ecc != 1.0:
         a = p / (1.0 - ecc ** 2)
-        # given the initial mean anomaly, calculate mean anomaly 
+        # given the initial mean anomaly, calculate mean anomaly
         # at the end, mean motion (n) equals sqrt(mu / |a^3|)
         with u.set_enabled_equivalencies(u.dimensionless_angles()):
             M = M0 + tof * np.sqrt(k / np.abs(a ** 3)) * u.rad
             nu = M_to_nu(M, ecc)
-        
+
     # parabolic orbit
     else:
         q = p / 2.0
@@ -154,7 +149,7 @@ def mean_motion(k, r0, v0, tof, **kwargs):
         with u.set_enabled_equivalencies(u.dimensionless_angles()):
             M = M0 + tof * np.sqrt(k / (2.0 * q ** 3))
 
-        # using Barker's equation, which is solved analytically 
+        # using Barker's equation, which is solved analytically
         # for parabolic orbit, get true anomaly
         B = 3.0 * M / 2.0
         A = (B + np.sqrt(1.0 + B ** 2)) ** (2.0 / 3.0)
@@ -163,6 +158,7 @@ def mean_motion(k, r0, v0, tof, **kwargs):
         nu = 2.0 * np.arctan(D)
     with u.set_enabled_equivalencies(u.dimensionless_angles()):
         return coe2rv(k, p, ecc, inc, raan, argp, nu)
+
 
 def kepler(k, r0, v0, tof, rtol=1e-10, *, numiter=35):
     """Propagates Keplerian orbit.
@@ -217,6 +213,7 @@ def propagate(orbit, time_of_flight, *, method=mean_motion, rtol=1e-10, **kwargs
                   rtol=rtol,
                   **kwargs)
     return orbit.from_vectors(orbit.attractor, r * u.km, v * u.km / u.s, orbit.epoch + time_of_flight)
+
 
 @jit
 def _kepler(k, r0, v0, tof, numiter, rtol):

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -123,9 +123,12 @@ def mean_motion(k, r0, v0, tof, **kwargs):
 
     Note
     -----
-    This method takes initial \vec{r}, \vec{v}, calculates classical orbit parameters
-    increases mean anomaly and performs inverse transformation to get final \vec{r}, \vec{v}
-    The logic is based on formulae (4), (6) and (7) from http://dx.doi.org/10.1007/s10569-013-9476-9
+    This method takes initial \vec{r}, \vec{v}, 
+    calculates classical orbit parameters
+    increases mean anomaly and performs inverse 
+    transformation to get final \vec{r}, \vec{v}
+    The logic is based on formulae (4), (6) and (7) 
+    from http://dx.doi.org/10.1007/s10569-013-9476-9
 
     """
 
@@ -138,24 +141,28 @@ def mean_motion(k, r0, v0, tof, **kwargs):
     # elliptic or hyperbolic orbits
     if ecc != 1.0:
         a = p / (1.0 - ecc ** 2)
-        # given the initial mean anomaly, calculate mean anomaly at the end, mean motion (n) equals sqrt(mu / |a^3|)
-        M = M0 + tof * np.sqrt(k / np.abs(a ** 3))
-        nu = (M_to_nu(M * u.rad, ecc) / u.rad).to('').value
+        # given the initial mean anomaly, calculate mean anomaly 
+        # at the end, mean motion (n) equals sqrt(mu / |a^3|)
+        with u.set_enabled_equivalencies(u.dimensionless_angles()):
+            M = M0 + tof * np.sqrt(k / np.abs(a ** 3)) * u.rad
+            nu = M_to_nu(M, ecc)
         
     # parabolic orbit
     else:
         q = p / 2.0
         # mean motion n = sqrt(mu / 2 q^3) for parabolic orbit
-        M = M0 + tof * np.sqrt(k / (2.0 * q ** 3))
+        with u.set_enabled_equivalencies(u.dimensionless_angles()):
+            M = M0 + tof * np.sqrt(k / (2.0 * q ** 3))
 
-        # using Barker's equation, which is solved analytically for parabolic orbit, get true anomaly
+        # using Barker's equation, which is solved analytically 
+        # for parabolic orbit, get true anomaly
         B = 3.0 * M / 2.0
         A = (B + np.sqrt(1.0 + B ** 2)) ** (2.0 / 3.0)
         D = 2.0 * A * B / (1.0 + A + A ** 2)
 
         nu = 2.0 * np.arctan(D)
-
-    return coe2rv(k, p, ecc, inc, raan, argp, nu)
+    with u.set_enabled_equivalencies(u.dimensionless_angles()):
+        return coe2rv(k, p, ecc, inc, raan, argp, nu)
 
 def kepler(k, r0, v0, tof, rtol=1e-10, *, numiter=35):
     """Propagates Keplerian orbit.

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -1,4 +1,4 @@
-"""Propagation algorithms.
+"""Propagation algorithms
 
 """
 import numpy as np
@@ -6,6 +6,9 @@ import numpy as np
 from scipy.integrate import ode
 
 from astropy import units as u
+from poliastro.twobody.rv import rv2coe
+from poliastro.twobody.classical import coe2rv
+from poliastro.twobody.angles import nu_to_M, M_to_nu
 
 from poliastro.jit import jit
 from poliastro.stumpff import c2, c3
@@ -102,6 +105,57 @@ def cowell(k, r0, v0, tof, rtol=1e-10, *, ad=None, callback=None, nsteps=1000):
 
     return r, v
 
+def mean_motion(k, r0, v0, tof, **kwargs):
+    """Propagates orbit using mean motion
+
+    Parameters
+    ----------
+    k : float
+        Gravitational constant of main attractor (km^3 / s^2).
+    r0 : array
+        Initial position (km).
+    v0 : array
+        Initial velocity (km).
+    ad : function(t0, u, k), optional
+         Non Keplerian acceleration (km/s2), default to None.
+    tof : float
+        Time of flight (s).
+
+    Note
+    -----
+    This method takes initial \vec{r}, \vec{v}, calculates classical orbit parameters
+    increases mean anomaly and performs inverse transformation to get final \vec{r}, \vec{v}
+    The logic is based on formulae (4), (6) and (7) from http://dx.doi.org/10.1007/s10569-013-9476-9
+
+    """
+
+    # get the initial true anomaly and orbit parameters that are constant over time
+    p, ecc, inc, raan, argp, nu0 = rv2coe(k, r0, v0)
+
+    # get the initial mean anomaly
+    M0 = nu_to_M(nu0, ecc)
+    
+    # elliptic or hyperbolic orbits
+    if ecc != 1.0:
+        a = p / (1.0 - ecc ** 2)
+        # given the initial mean anomaly, calculate mean anomaly at the end, mean motion (n) equals sqrt(mu / |a^3|)
+        M = M0 + tof * np.sqrt(k / np.abs(a ** 3))
+        nu = (M_to_nu(M * u.rad, ecc) / u.rad).to('').value
+        
+    # parabolic orbit
+    else:
+        q = p / 2.0
+        # mean motion n = sqrt(mu / 2 q^3) for parabolic orbit
+        M = M0 + tof * np.sqrt(k / (2.0 * q ** 3))
+
+        # using Barker's equation, which is solved analytically for parabolic orbit, get true anomaly
+        B = 3.0 * M / 2.0
+        A = (B + np.sqrt(1.0 + B ** 2)) ** (2.0 / 3.0)
+        D = 2.0 * A * B / (1.0 + A + A ** 2)
+
+        nu = 2.0 * np.arctan(D)
+
+    return coe2rv(k, p, ecc, inc, raan, argp, nu)
 
 def kepler(k, r0, v0, tof, rtol=1e-10, *, numiter=35):
     """Propagates Keplerian orbit.
@@ -146,7 +200,7 @@ def kepler(k, r0, v0, tof, rtol=1e-10, *, numiter=35):
     return r, v
 
 
-def propagate(orbit, time_of_flight, *, method=kepler, rtol=1e-10, **kwargs):
+def propagate(orbit, time_of_flight, *, method=mean_motion, rtol=1e-10, **kwargs):
     """Propagate an orbit some time and return the result.
 
     """
@@ -156,7 +210,6 @@ def propagate(orbit, time_of_flight, *, method=kepler, rtol=1e-10, **kwargs):
                   rtol=rtol,
                   **kwargs)
     return orbit.from_vectors(orbit.attractor, r * u.km, v * u.km / u.s, orbit.epoch + time_of_flight)
-
 
 @jit
 def _kepler(k, r0, v0, tof, numiter, rtol):


### PR DESCRIPTION
Hello @Juanlu001 

There is a lot to correct, I believe, but there's a `mean_motion` function. Now `iss` and `halleys[0]` propagate without falling and results of propagation agree with the `kepler` propagator where is doesn't fall.