### PR TITLE
Hyperbolic Plot Fix

### DIFF
--- a/src/poliastro/tests/tests_twobody/test_orbit.py
+++ b/src/poliastro/tests/tests_twobody/test_orbit.py
@@ -1,5 +1,6 @@
 import pytest
 
+import numpy as np
 from numpy.testing import assert_allclose
 
 from astropy import units as u
@@ -211,3 +212,21 @@ def test_hyperbolic_nu_value_check():
     assert isinstance(positions, CartesianRepresentation)
     assert isinstance(values, Time)
     assert len(positions) == len(values) == 100
+
+
+def test_hyperbolic_modulus_wrapped_nu():
+    a = Orbit.from_vectors(
+        Sun,
+        [-9.77441841e+07, 1.01000539e+08, 4.37584668e+07] * u.km,
+        [23.75936985, -43.09599568, -8.7084724] * u.km / u.s,
+    )
+    values = 100
+    wrapped_nu = a.nu if a.nu < 180 * u.deg else a.nu - 360 * u.deg
+    nu_limit = max(np.arccos(-(1 - 1 / 3.) / self.ecc), abs(wrapped_nu))
+    nu_values = np.linspace(-nu_limit, nu_limit, values)
+    values1, positions1 = a.sample(100)
+    values2, positions2 = a.sample(nu_values)
+    void = CartesianRepresentation(0, 0, 0) * u.km
+    assert (positions1[60] - positions2[60]).x == void.x
+    assert (positions1[60] - positions2[60]).y == void.y
+    assert (positions1[60] - positions2[60]).z == void.z

--- a/src/poliastro/tests/tests_twobody/test_orbit.py
+++ b/src/poliastro/tests/tests_twobody/test_orbit.py
@@ -222,11 +222,10 @@ def test_hyperbolic_modulus_wrapped_nu():
     )
     values = 100
     wrapped_nu = a.nu if a.nu < 180 * u.deg else a.nu - 360 * u.deg
-    nu_limit = max(np.arccos(-(1 - 1 / 3.) / self.ecc), abs(wrapped_nu))
+    nu_limit = max(np.arccos(-(1 - 1 / 3.) / a.ecc), abs(wrapped_nu))
     nu_values = np.linspace(-nu_limit, nu_limit, values)
     values1, positions1 = a.sample(100)
     values2, positions2 = a.sample(nu_values)
-    void = CartesianRepresentation(0, 0, 0) * u.km
-    assert (positions1[60] - positions2[60]).x == void.x
-    assert (positions1[60] - positions2[60]).y == void.y
-    assert (positions1[60] - positions2[60]).z == void.z
+    assert positions1[0].x == positions2[0].x
+    assert positions1[0].y == positions2[0].y
+    assert positions1[0].z == positions2[0].z

--- a/src/poliastro/tests/tests_twobody/test_orbit.py
+++ b/src/poliastro/tests/tests_twobody/test_orbit.py
@@ -1,6 +1,5 @@
 import pytest
 
-import numpy as np
 from numpy.testing import assert_allclose
 
 from astropy import units as u
@@ -215,17 +214,13 @@ def test_hyperbolic_nu_value_check():
 
 
 def test_hyperbolic_modulus_wrapped_nu():
-    a = Orbit.from_vectors(
+    ss = Orbit.from_vectors(
         Sun,
         [-9.77441841e+07, 1.01000539e+08, 4.37584668e+07] * u.km,
         [23.75936985, -43.09599568, -8.7084724] * u.km / u.s,
     )
-    values = 100
-    wrapped_nu = a.nu if a.nu < 180 * u.deg else a.nu - 360 * u.deg
-    nu_limit = max(np.arccos(-(1 - 1 / 3.) / a.ecc), abs(wrapped_nu))
-    nu_values = np.linspace(-nu_limit, nu_limit, values)
-    values1, positions1 = a.sample(100)
-    values2, positions2 = a.sample(nu_values)
-    assert positions1[0].x == positions2[0].x
-    assert positions1[0].y == positions2[0].y
-    assert positions1[0].z == positions2[0].z
+    num_values = 3
+
+    _, positions = ss.sample(num_values)
+
+    assert_quantity_allclose(positions[0].xyz, ss.r)

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -319,7 +319,7 @@ class Orbit(object):
                 # the arc cosine, which is in the range [0, 180)
                 # Start from -nu_limit
                 wrapped_nu = self.nu if self.nu < 180 * u.deg else self.nu - 360 * u.deg
-                nu_limit = max(np.arccos(-(1 - 1 / 3.) / self.ecc), wrapped_nu)
+                nu_limit = max(np.arccos(-(1 - 1 / 3.) / self.ecc), abs(wrapped_nu))
                 nu_values = np.linspace(-nu_limit, nu_limit, values)
 
             return self.sample(nu_values, method)


### PR DESCRIPTION
Now the hyperbolic plot looks much cleaner. 
```
Orbit.from_vectors(
    Sun,
    [ -9.77441841e+07,  1.01000539e+08,  4.37584668e+07] * u.km,
    [ 23.75936985,-43.09599568, -8.7084724 ] * u.km / u.s,
)
```
![screenshot from 2018-03-13 16-45-32](https://user-images.githubusercontent.com/24257914/37338691-350edbe2-26de-11e8-8c97-0e0fee89f232.png)

Earlier, we used to get a plot like this: 
![plot](https://user-images.githubusercontent.com/24257914/37338766-6f6f140a-26de-11e8-9c48-5c8454079db3.png)



