### PR TITLE
added tests, changed rtol and numiter in kepler

### DIFF
--- a/src/poliastro/tests/tests_twobody/test_propagation.py
+++ b/src/poliastro/tests/tests_twobody/test_propagation.py
@@ -265,7 +265,10 @@ def test_long_propagations_kepler_agrees_mean_motion():
     assert_quantity_allclose(r_mm, r_k, rtol=1e-6)
     assert_quantity_allclose(v_mm, v_k, rtol=1e-6)
 
-    halleys = dastcom5.orbit_from_name('1P')[0]
+    r_halleys = [-9018878.63569932, -94116054.79839276, 22619058.69943215]  # km
+    v_halleys = [-49.95092305, -12.94843055, -4.29251577]  # km/s
+    halleys = Orbit.from_vectors(Sun, r_halleys * u.km, v_halleys * u.km / u.s)
+
     r_mm, v_mm = halleys.propagate(tof, method=mean_motion).rv()
     r_k, v_k = halleys.propagate(tof, method=kepler).rv()
     assert_quantity_allclose(r_mm, r_k, rtol=1e-6)

--- a/src/poliastro/tests/tests_twobody/test_propagation.py
+++ b/src/poliastro/tests/tests_twobody/test_propagation.py
@@ -262,8 +262,8 @@ def test_long_propagations_kepler_agrees_mean_motion():
     tof = 100 * u.year
     r_mm, v_mm = iss.propagate(tof, method=mean_motion).rv()
     r_k, v_k = iss.propagate(tof, method=kepler).rv()
-    assert_quantity_allclose(r_mm, r_k, rtol=1e-6)
-    assert_quantity_allclose(v_mm, v_k, rtol=1e-6)
+    assert_quantity_allclose(r_mm, r_k)
+    assert_quantity_allclose(v_mm, v_k)
 
     r_halleys = [-9018878.63569932, -94116054.79839276, 22619058.69943215]  # km
     v_halleys = [-49.95092305, -12.94843055, -4.29251577]  # km/s
@@ -271,5 +271,5 @@ def test_long_propagations_kepler_agrees_mean_motion():
 
     r_mm, v_mm = halleys.propagate(tof, method=mean_motion).rv()
     r_k, v_k = halleys.propagate(tof, method=kepler).rv()
-    assert_quantity_allclose(r_mm, r_k, rtol=1e-6)
-    assert_quantity_allclose(v_mm, v_k, rtol=1e-6)
+    assert_quantity_allclose(r_mm, r_k)
+    assert_quantity_allclose(v_mm, v_k)

--- a/src/poliastro/tests/tests_twobody/test_propagation.py
+++ b/src/poliastro/tests/tests_twobody/test_propagation.py
@@ -273,3 +273,18 @@ def test_long_propagations_kepler_agrees_mean_motion():
     r_k, v_k = halleys.propagate(tof, method=kepler).rv()
     assert_quantity_allclose(r_mm, r_k)
     assert_quantity_allclose(v_mm, v_k)
+
+
+@pytest.mark.parametrize('method', [mean_motion, kepler])
+def test_long_propagation_preserves_orbit_elements(method):
+    tof = 100 * u.year
+    r_halleys = np.array([-9018878.63569932, -94116054.79839276, 22619058.69943215])  # km
+    v_halleys = np.array([-49.95092305, -12.94843055, -4.29251577])  # km/s
+    halleys = Orbit.from_vectors(Sun, r_halleys * u.km, v_halleys * u.km / u.s)
+
+    params_ini = rv2coe(Sun.k.to(u.km**3 / u.s**2).value, r_halleys, v_halleys)[:-1]
+    r_new, v_new = halleys.propagate(tof, method=method).rv()
+    params_final = rv2coe(Sun.k.to(u.km**3 / u.s**2).value,
+                          r_new.to(u.km).value, v_new.to(u.km / u.s).value)[:-1]
+    print(params_ini, params_final)
+    assert_quantity_allclose(params_ini, params_final)

--- a/src/poliastro/tests/tests_twobody/test_propagation.py
+++ b/src/poliastro/tests/tests_twobody/test_propagation.py
@@ -15,6 +15,8 @@ from poliastro.twobody import Orbit
 from poliastro.twobody.propagation import cowell, kepler, mean_motion
 from poliastro.examples import iss
 
+from poliastro.neos import dastcom5
+
 from poliastro.util import norm
 
 
@@ -254,3 +256,17 @@ def test_propagate_long_times_keeps_geometry(method):
     assert_quantity_allclose(iss.argp, res.argp)
 
     assert_quantity_allclose((res.epoch - iss.epoch).to(time_of_flight.unit), time_of_flight)
+
+
+def test_long_propagations_kepler_agrees_mean_motion():
+    tof = 100 * u.year
+    r_mm, v_mm = iss.propagate(tof, method=mean_motion).rv()
+    r_k, v_k = iss.propagate(tof, method=kepler).rv()
+    assert_quantity_allclose(r_mm, r_k, rtol=1e-6)
+    assert_quantity_allclose(v_mm, v_k, rtol=1e-6)
+
+    halleys = dastcom5.orbit_from_name('1P')[0]
+    r_mm, v_mm = halleys.propagate(tof, method=mean_motion).rv()
+    r_k, v_k = halleys.propagate(tof, method=kepler).rv()
+    assert_quantity_allclose(r_mm, r_k, rtol=1e-6)
+    assert_quantity_allclose(v_mm, v_k, rtol=1e-6)

--- a/src/poliastro/tests/tests_twobody/test_sample.py
+++ b/src/poliastro/tests/tests_twobody/test_sample.py
@@ -57,7 +57,7 @@ def test_sample_one_point_equals_propagation_big_deltas(time_of_flight, method):
 
     _, rr = ss0.sample(sample_times, method)
 
-    assert_quantity_allclose(rr[0].get_xyz(), expected_ss.r)
+    assert_quantity_allclose(rr[0].get_xyz(), expected_ss.r, rtol=1e-6)
 
 
 def test_sample_nu_values():

--- a/src/poliastro/tests/tests_twobody/test_sample.py
+++ b/src/poliastro/tests/tests_twobody/test_sample.py
@@ -57,7 +57,7 @@ def test_sample_one_point_equals_propagation_big_deltas(time_of_flight, method):
 
     _, rr = ss0.sample(sample_times, method)
 
-    assert_quantity_allclose(rr[0].get_xyz(), expected_ss.r, rtol=1e-6)
+    assert_quantity_allclose(rr[0].get_xyz(), expected_ss.r)
 
 
 def test_sample_nu_values():

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -246,7 +246,7 @@ def _kepler(k, r0, v0, tof, numiter):
         xi_new = xi + (sqrt_mu * tof - xi * xi * xi * c3_psi -
                        dot_r0v0 / sqrt_mu * xi * xi * c2_psi -
                        norm_r0 * xi * (1 - psi * c3_psi)) / norm_r
-        if abs(xi_new - xi) < 1e-6:
+        if abs(xi_new - xi) < 1e-7:
             break
         else:
             count += 1

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -161,7 +161,7 @@ def mean_motion(orbit, tof, **kwargs):
         return coe2rv(k, p, ecc, inc, raan, argp, nu)
 
 
-def kepler(orbit, tof, rtol=1e-10, *, numiter=35, **kwargs):
+def kepler(orbit, tof, *, numiter=350, **kwargs):
     """Propagates Keplerian orbit.
 
     Parameters
@@ -170,8 +170,6 @@ def kepler(orbit, tof, rtol=1e-10, *, numiter=35, **kwargs):
         the Orbit object to propagate.
     tof : float
         Time of flight (s).
-    rtol : float, optional
-        Maximum relative error permitted, default to 1e-10.
     numiter : int, optional
         Maximum number of iterations, default to 35.
 
@@ -193,7 +191,7 @@ def kepler(orbit, tof, rtol=1e-10, *, numiter=35, **kwargs):
     r0 = orbit.r.to(u.km).value
     v0 = orbit.v.to(u.km / u.s).value
 
-    f, g, fdot, gdot = _kepler(k, r0, v0, tof, numiter, rtol)
+    f, g, fdot, gdot = _kepler(k, r0, v0, tof, numiter)
 
     assert np.abs(f * gdot - fdot * g - 1) < 1e-5  # Fixed tolerance
 
@@ -213,7 +211,7 @@ def propagate(orbit, time_of_flight, *, method=mean_motion, rtol=1e-10, **kwargs
 
 
 @jit
-def _kepler(k, r0, v0, tof, numiter, rtol):
+def _kepler(k, r0, v0, tof, numiter):
     # Cache some results
     dot_r0v0 = np.dot(r0, v0)
     norm_r0 = np.dot(r0, r0) ** .5
@@ -248,7 +246,7 @@ def _kepler(k, r0, v0, tof, numiter, rtol):
         xi_new = xi + (sqrt_mu * tof - xi * xi * xi * c3_psi -
                        dot_r0v0 / sqrt_mu * xi * xi * c2_psi -
                        norm_r0 * xi * (1 - psi * c3_psi)) / norm_r
-        if abs(np.divide(xi_new - xi, xi_new)) < rtol or abs(xi_new - xi) < rtol:
+        if abs(xi_new - xi) < 1e-6:
             break
         else:
             count += 1


### PR DESCRIPTION
The `kepler` method suffered from not convergence on large propagation times, when `xi` (universal formulation parameter) is high. 

It turns out, that the method converges in a physical sense, but numerically the requirement `rtol < 1e-10` is not satisfied but to the floating point operations limitation.

After relaxing the requirement `xi - xi_new` to `1e-7`, the method converges and provides physically accurate results. The other thing one had to do is to increase the maximum number of iterations done by the Newton method. The convergence check is done after each iteration, so this would not increase the propagation time for easy orbits, but will make the convergence of hard ones possible.

I added tests, checking that the orbits stated in the old issue converge (iss for 100 years and halleys for 100 years) and that their orbital elements conserve, meaning that the propagation is done right.