### PR TITLE
Fix notebooks, run in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           name: build docs
           command: |
             . venv/bin/activate
-            sphinx-build -vW -b html docs/source _HTMLTest
+            sphinx-build -vW -b html docs/source docs-html
 
       - store_artifacts:
           path: docs-html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,27 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/python:3.6.1
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - run:
+          name: install dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install .[dev]
+
+      - run:
+          name: build docs
+          command: |
+            . venv/bin/activate
+            sphinx-build -vW -b html docs/source _HTMLTest
+
+      - store_artifacts:
+          path: docs-html
+          destination: docs-html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
       - run:
           name: install dependencies
           command: |
+            sudo apt update && sudo apt install pandoc
             python3 -m venv venv
             . venv/bin/activate
             pip install .[dev]

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ env:
   global:
     - MPLBACKEND="Agg"
     - RUN_MYPY="true"
-    - RUN_NTB="false"
 
 matrix:
   include:
@@ -32,12 +31,8 @@ matrix:
     - os: linux
       python: pypy3
       env: PIP_EXTRA_INDEX_URL=https://antocuni.github.io/pypy-wheels/ubuntu/ RUN_MYPY="false"
-    - os: linux
-      python: 3.6
-      env: RUN_NTB="true"
   allow_failures:
     - python: pypy3
-    - env: RUN_NTB="true"
 
 addons:
   apt:
@@ -65,7 +60,6 @@ before_script:
 
 script:
   - pytest -vv  # Test against installed code
-  - if [[ $RUN_NTB == 'true' ]]; then sphinx-build -vW -b html docs/source _HTMLTest; fi  # Test docs build
 
 after_success:
   # Uninstall to test coverage against sources

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -40,7 +40,7 @@ Alternative installation methods
 If you don't want to use conda you can `install poliastro from PyPI`_
 using pip::
 
-  $ pip install numpy  # Run this one first!
+  $ pip install numpy  # Run this one first for pip 9 and older!
   $ pip install poliastro
 
 Finally, you can also install the latest development version of poliastro

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools",
+    "wheel",
+    "numpy",
+]


### PR DESCRIPTION
After we removed the notebooks from the continuous integration mandatory builds due to timeouts (see https://github.com/poliastro/poliastro/pull/323) we apparently missed some updates (see #377). This is an attempt to run the notebooks in Circle CI, a separated service, so we have proper warnings again when they get outdated.