### PR TITLE
optimizing orbit.sample

### DIFF
--- a/src/poliastro/tests/tests_twobody/test_sample.py
+++ b/src/poliastro/tests/tests_twobody/test_sample.py
@@ -1,5 +1,6 @@
 import pytest
 
+import timeit
 from astropy.tests.helper import assert_quantity_allclose
 from astropy import units as u
 from astropy.time import Time
@@ -41,6 +42,18 @@ def test_sample_one_point_equals_propagation_small_deltas(time_of_flight, method
     _, rr = ss0.sample(sample_times, method)
 
     assert_quantity_allclose(rr[0].get_xyz(), expected_ss.r)
+
+
+def test_sampling_cowell_dense_output_agrees_mean_motion():
+    r0 = [1131.340, -2282.343, 6672.423] * u.km
+    v0 = [-5.64305, 4.30333, 2.42879] * u.km / u.s
+    ss0 = Orbit.from_vectors(Earth, r0, v0)
+    sample_times = Time([ss0.epoch + x * u.h for x in range(100)])
+
+    _, rr = ss0.sample(sample_times, cowell)
+    for i, sample_time in enumerate(sample_times):
+        expected_ss = ss0.propagate(sample_time - ss0.epoch)
+        assert_quantity_allclose(rr[i].get_xyz(), expected_ss.r)
 
 
 @pytest.mark.parametrize("time_of_flight", [6 * u.h, 2 * u.day])

--- a/src/poliastro/twobody/angles.py
+++ b/src/poliastro/twobody/angles.py
@@ -135,7 +135,7 @@ def M_to_E(M, ecc):
     """
     with u.set_enabled_equivalencies(u.dimensionless_angles()):
         E = optimize.newton(_kepler_equation, M, _kepler_equation_prime,
-                            args=(M, ecc))
+                            args=(M, ecc), tol=1e-10)
     return E
 
 
@@ -157,7 +157,7 @@ def M_to_F(M, ecc):
     """
     with u.set_enabled_equivalencies(u.dimensionless_angles()):
         F = optimize.newton(_kepler_equation_hyper, np.arcsinh(M / ecc), _kepler_equation_prime_hyper,
-                            args=(M, ecc), maxiter=100)
+                            args=(M, ecc), maxiter=100, tol=1e-10)
     return F
 
 

--- a/src/poliastro/twobody/angles.py
+++ b/src/poliastro/twobody/angles.py
@@ -135,7 +135,7 @@ def M_to_E(M, ecc):
     """
     with u.set_enabled_equivalencies(u.dimensionless_angles()):
         E = optimize.newton(_kepler_equation, M, _kepler_equation_prime,
-                            args=(M, ecc), tol=1e-10)
+                            args=(M, ecc))
     return E
 
 
@@ -157,7 +157,7 @@ def M_to_F(M, ecc):
     """
     with u.set_enabled_equivalencies(u.dimensionless_angles()):
         F = optimize.newton(_kepler_equation_hyper, np.arcsinh(M / ecc), _kepler_equation_prime_hyper,
-                            args=(M, ecc), maxiter=100, tol=1e-10)
+                            args=(M, ecc), maxiter=100)
     return F
 
 

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -337,8 +337,6 @@ class Orbit(object):
         # if use cowell, propagate to max_time and use other values as intermediate (dense output)
         if method == cowell:
             values, _ = cowell(self, (time_values - self.epoch).to(u.s).value)
-            if len(time_values) == 1:
-                values = [values]
             values = values * u.km
         else:
             values = np.zeros((len(time_values), 3)) * self.r.unit

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -50,7 +50,7 @@ def func_twobody(t0, u_, k, ad, ad_kwargs):
     return du
 
 
-def cowell(orbit, tof, rtol=1e-12, *, ad=None, **ad_kwargs):
+def cowell(orbit, tof, rtol=1e-11, *, ad=None, **ad_kwargs):
     """Propagates orbit using Cowell's formulation.
 
     Parameters

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -90,7 +90,8 @@ def cowell(orbit, tof, rtol=1e-11, *, ad=None, **ad_kwargs):
 
     f_with_ad = functools.partial(func_twobody, k=k, ad=ad, ad_kwargs=ad_kwargs)
 
-    if not hasattr(tof, "__len__"):
+    multiple_input = hasattr(tof, "__len__")
+    if not multiple_input:
         tof = [tof]
 
     result = solve_ivp(f_with_ad, (0, max(tof)), u0,
@@ -106,7 +107,7 @@ def cowell(orbit, tof, rtol=1e-11, *, ad=None, **ad_kwargs):
         rrs.append(y[:3])
         vvs.append(y[3:])
 
-    if len(tof) == 1:
+    if not multiple_input:
         return rrs[0], vvs[0]
     return rrs, vvs
 

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -50,7 +50,7 @@ def func_twobody(t0, u_, k, ad, ad_kwargs):
     return du
 
 
-def cowell(orbit, tof, rtol=1e-10, *, ad=None, **ad_kwargs):
+def cowell(orbit, tof, rtol=1e-12, *, ad=None, **ad_kwargs):
     """Propagates orbit using Cowell's formulation.
 
     Parameters


### PR DESCRIPTION
Hello, @Juanlu001 

Did I understand correctly how you proposed it to be? Perhaps the current version seems quite ugly, though uses dense_output. 

The problem is that `cowell` function can be called from `propagate` and from `sample` methods, that's why we need at some places first wrap into `[]` and then unwrap `[0]`. 