### PR TITLE
Measure coverage in parallel with tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,8 +127,7 @@ workflows:
             - quality
       - coverage:
           requires:
-            - test_py35
-            - test_py36
+            - quality
       - docs:
           requires:
             - test_py35


### PR DESCRIPTION
Related to #403: this is an easy change that should cut the CI running time by half. :crossed_fingers: 