### PR TITLE
Added test for Lagrange points function

### DIFF
--- a/src/poliastro/tests/tests_threebody/test_restricted.py
+++ b/src/poliastro/tests/tests_threebody/test_restricted.py
@@ -1,0 +1,38 @@
+from math import cos, sin, pi
+
+from astropy.tests.helper import assert_quantity_allclose
+from astropy import units as u
+
+from poliastro.bodies import Earth, Moon
+from poliastro.threebody.restricted import lagrange_points_vec
+
+
+def test_lagrange_points_vec():
+
+    # Figure 2.36 from Curtis
+
+    deg60 = 60 * pi / 180
+    expected_L1 = 326400 * ([1, 0, 0] * u.km)
+    expected_L2 = 449100 * ([1, 0, 0] * u.km)
+    expected_L3 = -381600 * ([1, 0, 0] * u.km)
+    expected_L4 = 384400 * ([cos(deg60), sin(deg60), 0] * u.km)
+    expected_L5 = 384400 * ([cos(deg60), -sin(deg60), 0] * u.km)
+
+    earth_mass = Earth.mass
+    moon_mass = Moon.mass
+
+    # Values from Curtis
+    # earth_mass = 5.974e24 * u.kg
+    # moon_mass = 73.48e21 * u.kg
+
+    L1, L2, L3, L4, L5 = lagrange_points_vec(m1=earth_mass,
+                                             r1=([0, 0, 0] * u.km),
+                                             m2=moon_mass,
+                                             r2=384400 * ([1, 0, 0] * u.km),
+                                             n=[0, 0, 1] * u.one)
+
+    assert_quantity_allclose(L1, expected_L1, rtol=1.e-3)
+    assert_quantity_allclose(L2, expected_L2, rtol=1.e-3)
+    assert_quantity_allclose(L3, expected_L3, rtol=1.e-3)
+    assert_quantity_allclose(L4, expected_L4, rtol=1.e-3)
+    assert_quantity_allclose(L5, expected_L5, rtol=1.e-3)

--- a/src/poliastro/threebody/restricted.py
+++ b/src/poliastro/threebody/restricted.py
@@ -6,6 +6,8 @@
 
 import numpy as np
 
+from astropy import units as u
+
 from scipy.optimize import brentq
 
 from poliastro.util import norm

--- a/src/poliastro/threebody/restricted.py
+++ b/src/poliastro/threebody/restricted.py
@@ -1,7 +1,6 @@
-"""Restricted Circular 3-Body Problem (RC3BP)
+"""Circular Restricted 3-Body Problem (CR3BP)
 
-    Includes the computation of:
-    * Lagrange points
+    Includes the computation of Lagrange points
 """
 
 
@@ -12,10 +11,12 @@ from scipy.optimize import brentq
 from poliastro.util import norm
 
 
+@u.quantity_input(r12=u.km, m1=u.kg, m2=u.kg)
 def lagrange_points(r12, m1, m2):
-    """Computes the Lagrangian points of RC3BP given the distance between two
-    bodies and their masses.
+    """Computes the Lagrangian points of CR3BP.
 
+    Computes the Lagrangian points of CR3BP given the distance between two
+    bodies and their masses.
     It uses the formulation found in Eq. (2.204) of Curtis, Howard. 'Orbital
     mechanics for engineering students'. Elsevier, 3rd Edition.
 
@@ -69,10 +70,14 @@ def lagrange_points(r12, m1, m2):
     return lp * r12
 
 
+@u.quantity_input(m1=u.kg, r1=u.km,
+                  m2=u.kg, r2=u.km,
+                  n=u.one)
 def lagrange_points_vec(m1, r1, m2, r2, n):
-    """Computes the five Lagrange points in the RC3BP. Returns the positions
-    in the same frame of reference as `r1` and `r2` for the five Lagrangian
-    points.
+    """Computes the five Lagrange points in the CR3BP. 
+
+    Returns the positions in the same frame of reference as `r1` and `r2` 
+    for the five Lagrangian points.
 
     Parameters
     ----------
@@ -86,7 +91,6 @@ def lagrange_points_vec(m1, r1, m2, r2, n):
         Position of the secondary body.
     n : ~astropy.units.Quantity
         Normal vector to the orbital plane.
-
     Returns
     -------
     list:
@@ -132,149 +136,3 @@ def lagrange_points_vec(m1, r1, m2, r2, n):
     L5 = r1 + ux * x5 + uy * y5
 
     return [L1, L2, L3, L4, L5]
-
-
-def lagrange_points_from_body(body):
-    """Computes the five Lagrange points given a `Body`.
-
-    Parameters
-    ----------
-    body : Body
-        Orbiting body. 
-        Example: For Earth-Moon, pass Moon, because the attractor body is already known.
-
-    Returns
-    -------
-    list
-        Position of the Lagrange points: [L1, L2, L3, L4, L5]
-        The positions are of type ~astropy.units.Quantity
-    """
-    from poliastro.twobody import Orbit
-    from astropy import units as u
-
-    body_orbit = Orbit.from_body_ephem(body)
-    body_orbit_parent_r = np.zeros(3) * u.km  # origin in main body
-
-    return lagrange_points_vec(m1=body.parent.mass,
-                               r1=body_orbit_parent_r,
-                               m2=body.mass,
-                               r2=body_orbit.r,
-                               n=body_orbit.h_vec)
-
-
-def test_sun_earth():
-    from astropy import units as u
-    from astropy.constants import G, au
-    from poliastro.constants import GM_earth, GM_sun
-
-    # ORIGIN = "barycenter"
-    ORIGIN = "main body"
-
-    # Distance Sun - Earth
-    r12 = au.to(u.km).value
-
-    # Sun (1)
-    m1 = GM_sun / G
-
-    # Earth (2)
-    m2 = GM_earth / G
-
-    if ORIGIN == "barycenter":
-        x1 = - r12 * m2 / (m1 + m2)
-        x2 = r12 + x1
-    elif ORIGIN == "main body":
-        x1 = 0.
-        x2 = r12
-
-    # Positions
-    r1 = np.array([x1, 0, 0]) * u.km
-    r2 = np.array([x2, 0, 0]) * u.km
-
-    # normal vector
-    n = np.array([0., 0, 1]) * u.one
-
-    lp = lagrange_points_vec(m1, r1, m2, r2, n)
-
-    for p in lp:
-        print("{:+8.0f} {:+8.0f} {:+8.0f}".format(p[0], p[1], p[2]))
-
-    x = [p[0] for p in lp]
-    y = [p[1] for p in lp]
-
-    # Figure
-    import matplotlib.pyplot as plt
-    plt.figure()
-    plt.scatter(0, 0, marker="+", c="k", label="Origin")
-    plt.scatter(r1[0], r1[1], s=100, marker="$" + u"\u2609" + "$",
-                label="Sun", c="k")
-    plt.scatter(r2[0], r2[1], s=100, marker="$" + u"\u2641" + "$",
-                label="Earth", c="k")
-    for i in range(0, 5):
-        plt.scatter(x[i], y[i], marker="$L" + "{:d}$".format(i + 1),
-                    c="k", s=100)
-    plt.legend(loc="best")
-    plt.title("Sun-Earth Lagrangian points")
-    plt.xlabel("[km]")
-    plt.ylabel("[km]")
-    plt.tight_layout()
-    plt.show()
-    plt.close('all')
-
-
-def test_earth_moon():
-    from astropy import units as u
-    from astropy.constants import G
-    from poliastro.constants import GM_earth, GM_moon
-
-    # ORIGIN = "barycenter"
-    ORIGIN = "main body"
-
-    # Distance Earth - Moon
-    r12 = 384400
-
-    # Earth (1)
-    m1 = GM_earth / G
-
-    # Moon (2)
-    m2 = GM_moon / G
-
-    if ORIGIN == "barycenter":
-        x1 = - r12 * m2 / (m1 + m2)
-        x2 = r12 + x1
-    elif ORIGIN == "main body":
-        x1 = 0
-        x2 = r12
-
-    # Positions
-    r1 = np.array([x1, 0, 0]) * u.km
-    r2 = np.array([x2, 0, 0]) * u.km
-
-    # normal vector
-    n = np.array([0., 0, 1]) * u.one
-
-    lp = lagrange_points_vec(m1, r1, m2, r2, n)
-
-    for p in lp:
-        print("{:+8.0f} {:+8.0f} {:+8.0f}".format(p[0], p[1], p[2]))
-
-    x = [p[0] for p in lp]
-    y = [p[1] for p in lp]
-
-    # Figure
-    import matplotlib.pyplot as plt
-    plt.figure()
-    plt.scatter(0, 0, marker="+", c="k", label="Origin")
-    plt.scatter(r1[0], r1[1], s=100, marker="$" + u"\u2641" + "$",
-                label="Earth", c="k")
-    plt.scatter(r2[0], r2[1], s=100, marker="$" + u"\u263E" + "$",
-                label="Moon", c="k")
-    for i in range(0, 5):
-        plt.scatter(x[i], y[i], marker="$L" + "{:d}$".format(i + 1),
-                    c="k", s=100)
-    plt.legend(loc="best")
-    plt.title("Earth-Moon Lagrangian points")
-    plt.xlabel("[km]")
-    plt.ylabel("[km]")
-    plt.tight_layout()
-    plt.show()
-    plt.close('all')

--- a/src/poliastro/threebody/restricted.py
+++ b/src/poliastro/threebody/restricted.py
@@ -74,9 +74,9 @@ def lagrange_points(r12, m1, m2):
                   m2=u.kg, r2=u.km,
                   n=u.one)
 def lagrange_points_vec(m1, r1, m2, r2, n):
-    """Computes the five Lagrange points in the CR3BP. 
+    """Computes the five Lagrange points in the CR3BP.
 
-    Returns the positions in the same frame of reference as `r1` and `r2` 
+    Returns the positions in the same frame of reference as `r1` and `r2`
     for the five Lagrangian points.
 
     Parameters


### PR DESCRIPTION
As a continuation of previous work, I add a test for `lagrange_points_vec` in `tests/tests_threebody`.

I used the values that can be found in Figure 2.36 in Curtis, H. *Orbital Mechanics for Engineering Students*. 3rd Edition, which is the one that served as an example in the original pull request (#173 )

![Figure 2.36](https://user-images.githubusercontent.com/316517/44168601-276f9300-a0d2-11e8-88d9-4e64c813b1f6.png)

Also, I added the `u.quantity_input()` decorator to validate the units and corrected some small details in `restricted.py`.