### PR TITLE
Use default ephemeris in tests

### DIFF
--- a/src/poliastro/tests/test_frames.py
+++ b/src/poliastro/tests/test_frames.py
@@ -43,10 +43,9 @@ def test_planetary_frames_have_proper_string_representations(body, frame):
     (Saturn, SaturnICRS),
     (Uranus, UranusICRS),
     (Neptune, NeptuneICRS),
-    (Pluto, PlutoICRS),
 ])
 def test_planetary_icrs_frame_is_just_translation(body, frame):
-    with solar_system_ephemeris.set("de432s"):
+    with solar_system_ephemeris.set("builtin"):
         epoch = J2000
         vector = CartesianRepresentation(x=100 * u.km, y=100 * u.km, z=100 * u.km)
         vector_result = frame(vector, obstime=epoch).transform_to(ICRS).represent_as(CartesianRepresentation)
@@ -66,10 +65,9 @@ def test_planetary_icrs_frame_is_just_translation(body, frame):
     (Saturn, SaturnICRS),
     (Uranus, UranusICRS),
     (Neptune, NeptuneICRS),
-    (Pluto, PlutoICRS),
 ])
 def test_icrs_body_position_to_planetary_frame_yields_zeros(body, frame):
-    with solar_system_ephemeris.set("de432s"):
+    with solar_system_ephemeris.set("builtin"):
         epoch = J2000
         vector = get_body_barycentric(body.name, epoch)
 

--- a/src/poliastro/tests/tests_twobody/test_perturbations.py
+++ b/src/poliastro/tests/tests_twobody/test_perturbations.py
@@ -203,7 +203,7 @@ sun_geo = {'body': Sun, 'tof': 200 * u.day, 'raan': 8.7 * u.deg, 'argp': -5.5 * 
 def test_3rd_body_Curtis(test_params):
     # based on example 12.11 from Howard Curtis
     body = test_params['body']
-    with solar_system_ephemeris.set('de432s'):
+    with solar_system_ephemeris.set('builtin'):
         j_date = 2454283.0 * u.day
         tof = (test_params['tof']).to(u.s).value
         body_r = build_ephem_interpolant(body, test_params['period'], (j_date, j_date + test_params['tof']), rtol=1e-2)
@@ -251,7 +251,7 @@ def normalize_to_Curtis(t0, sun_r):
 @pytest.mark.slow
 def test_solar_pressure():
     # based on example 12.9 from Howard Curtis
-    with solar_system_ephemeris.set('de432s'):
+    with solar_system_ephemeris.set('builtin'):
         j_date = 2438400.5 * u.day
         tof = 600 * u.day
         sun_r = build_ephem_interpolant(Sun, 365 * u.day, (j_date, j_date + tof), rtol=1e-2)


### PR DESCRIPTION
This is just for demonstration in #453 ...

Pluto is not part of the astropy builtin ephemeris calculation and therefore would require jplephem for astropy. This is my patch to delete them.