### PR TITLE
Define absolute tolerance when comparing with 0.0

### DIFF
--- a/src/poliastro/tests/test_coordinates.py
+++ b/src/poliastro/tests/test_coordinates.py
@@ -45,5 +45,5 @@ def test_inertial_body_centered_to_pqw():
 
     molniya_peri = Orbit.from_vectors(bodies.Earth, molniya_r_peri, molniya_v_peri, molniya.epoch)
 
-    assert_quantity_allclose(molniya_peri.e_vec[-2:], [0, 0])
+    assert_quantity_allclose(molniya_peri.e_vec[-2:], [0, 0], atol=1e-12)
     assert_quantity_allclose(norm(molniya_peri.e_vec), norm(molniya.e_vec))


### PR DESCRIPTION
By default, assert_quantity_allclose() allows only a relative tolerance (1e-7), while the absolute tolerance is zero. For comparison with 0.0, this is however useless, and leads to failure on some CPU types ([arm64](https://tests.reproducible-builds.org/debian/rbuild/buster/arm64/poliastro_0.11.0-3.rbuild.log.gz), [i386](https://tests.reproducible-builds.org/debian/rbuild/buster/i386/poliastro_0.11.0-3.rbuild.log.gz)).

The value 1e-12 is chosen ad-hoc to let the test pass; it may need an adjustment.