### PR TITLE
WIP: Split plotting backends, default to Plotly

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -128,6 +128,11 @@ else:
 
 # -- Options for HTML output ----------------------------------------------
 
+
+def setup(app):
+    app.add_javascript("https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js")
+    app.add_javascript("https://unpkg.com/@jupyter-widgets/html-manager@*/dist/embed-amd.js")
+
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 import sphinx_rtd_theme

--- a/docs/source/embed/molniya.html
+++ b/docs/source/embed/molniya.html
@@ -1,0 +1,1143 @@
+<script type="application/vnd.jupyter.widget-state+json">
+{
+    "version_major": 2,
+    "version_minor": 0,
+    "state": {
+        "7d31acae007941ec815b45abab6ccca9": {
+            "model_name": "FigureModel",
+            "model_module": "plotlywidget",
+            "model_module_version": "^0.4.0",
+            "state": {
+                "_data": [
+                    {
+                        "line": {
+                            "color": "rgb(31, 119, 180)",
+                            "dash": "dash",
+                            "width": 2
+                        },
+                        "mode": "lines",
+                        "name": "2013-03-18 12:00",
+                        "x": {
+                            "dtype": "float64",
+                            "shape": [
+                                100
+                            ]
+                        },
+                        "y": {
+                            "dtype": "float64",
+                            "shape": [
+                                100
+                            ]
+                        },
+                        "type": "scatter",
+                        "uid": "1b889298-e44e-11e8-aa89-a0afbda902ef"
+                    },
+                    {
+                        "marker": {
+                            "color": "rgb(31, 119, 180)",
+                            "size": 10
+                        },
+                        "mode": "markers",
+                        "name": "2013-03-18 12:00",
+                        "x": {
+                            "dtype": "float64",
+                            "shape": [
+                                1
+                            ]
+                        },
+                        "y": {
+                            "dtype": "float64",
+                            "shape": [
+                                1
+                            ]
+                        },
+                        "type": "scatter",
+                        "uid": "1b889299-e44e-11e8-aa89-a0afbda902ef"
+                    },
+                    {
+                        "type": "scatter",
+                        "uid": "1b88929a-e44e-11e8-aa89-a0afbda902ef"
+                    }
+                ],
+                "_js2py_layoutDelta": {},
+                "_js2py_pointsCallback": {},
+                "_js2py_relayout": {},
+                "_js2py_restyle": {},
+                "_js2py_traceDeltas": {},
+                "_js2py_update": {},
+                "_layout": {
+                    "autosize": true,
+                    "shapes": [
+                        {
+                            "fillcolor": "#204a87",
+                            "line": {
+                                "color": "#204a87"
+                            },
+                            "opacity": 1,
+                            "type": "circle",
+                            "x0": -6378.1366,
+                            "x1": 6378.1366,
+                            "xref": "x",
+                            "y0": -6378.1366,
+                            "y1": 6378.1366,
+                            "yref": "y"
+                        }
+                    ],
+                    "xaxis": {
+                        "constrain": "domain",
+                        "title": "x (km)"
+                    },
+                    "yaxis": {
+                        "scaleanchor": "x",
+                        "title": "y (km)"
+                    }
+                },
+                "_py2js_addTraces": {},
+                "_py2js_animate": {},
+                "_py2js_deleteTraces": {},
+                "_py2js_moveTraces": {},
+                "_py2js_relayout": {},
+                "_py2js_removeLayoutProps": {},
+                "_py2js_removeTraceProps": {},
+                "_py2js_restyle": {},
+                "_py2js_update": {},
+                "_view_count": 0
+            },
+            "buffers": [
+                {
+                    "data": "1JorrQF0ukBgQpq/Wma6QD73iwl0PbpATERwtHf5uUCKZQrVq5q5QCyOMyNyIblA1gcglUeOuECiAI/ew+G3QK3QadSYHLdAoOlztZE/tkDEZshYkku1QCQ1/UKWQbRAqO3doq8is0AqpMk2BvCxQLID1xvWqrBAbvLxD92orkCkpufgYNyrQIYQDjwa86hAeF6FYAnwpUBeJiIjSdaiQDsmMnYXUp9A118f7S7XmED6fe+0hkKSQE6Kv8TONYdAyBaxW7Scc0CQlSEX+RtdwBgDyT7hEYHAOm21yfNujsCrQdgfeNaVwDoiDxQYX5zAwDL7yU5locB+BA45NYmkwGUIxakCmKfATUsbLpCOqsA53U7Xz2mtwHKl9O1nE7DAXlti0F5hscBwTfZQdJ2ywDwuLZxixrPApgrZnPfatMC2kKU3Ftq1wMz6/HC3wrbAgasefOuTt8CCCFCy2ky4wBPFKHHG7LjAFnYV3wlzucAs3kWVGt+5wFTHVy6JMLrA6lgruQFnusAIjGoPTIK6wAiMag9MgrrA6FgruQFnusBVx1cuiTC6wC7eRZUa37nAFnYV3wlzucATxShxxuy4wIIIULLaTLjAgqsefOuTt8DM+vxwt8K2wLiQpTcW2rXAqgrZnPfatMA+Li2cYsazwHJN9lB0nbLAYlti0F5hscB0pfTtZxOwwD3dTtfPaa3ARksbLpCOqsBmCMWpApinwIYEDjk1iaTAzjL7yU5locA8Ig8UGF+cwK9B2B941pXAXm21yfNujsA0A8k+4RGBwBCWIRf5G13AjBaxW7Scc0Aair/EzjWHQN5977SGQpJA2l8f7S7XmEAuJjJ2F1KfQFgmIiNJ1qJAgF6FYAnwpUB+EA48GvOoQKCm5+Bg3KtAZvLxD92orkC0A9cb1qqwQCikyTYG8LFAp+3doq8is0AjNf1ClkG0QMZmyFiSS7VAoOlztZE/tkCs0GnUmBy3QKMAj97D4bdA1wcglUeOuEAsjjMjciG5QIllCtWrmrlATERwtHf5uUA+94sJdD26QF5Cmr9aZrpA1JorrQF0ukA=",
+                    "path": [
+                        "_data",
+                        0,
+                        "x",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                },
+                {
+                    "data": "AAAAAAAAgr2ESrKnF+F6QHTWyBA904pAESvmsyMNlEDa33qF/ZuaQOgKTrK0h6BABq6Rf2Cwo0DgJwqSwMSmQPwmGD2owalATCC0BQOkrEA/uDbP12ivQHhs9fWlBrFAdFogB1NHskAspsyLKHWzQMvA4mDvjrRAhR49EIWTtUA/MxL83IG2QLC12XMBWbdAvLqPsRQYuEDOl1C+Ub64QEXkYT0NS7lAHE/XHLa9uUAuMh0r1hW6QG68zpASU7pAtRtaLix1ukAeHxLd/3u6QN8+apOGZ7pAm683bNU3ukACB/CQHe25QKre+wash7lAWrJRYOkHuUBu0apPWW64QNGAwSCau7dAsz4kFWTwtkAmXEamiA22QJ+2ka3xE7VAmSdYc6AEtECvJp2lrOCyQIoByTdDqbFAlthuLKVfsEDgVcqUTAquQD4XDH1XNqtAFRcAV1VGqECcwGZSTT2lQHOLT2pgHqJAmdLbVozZnUBo+FTGkleXQAVct3WJvZBArOGUCn0khEAITvD4juRqQDBO8PiO5GrAsOGUCn0khMAOXLd1ib2QwFT4VMaSV5fAk9LbVozZncBwi09qYB6iwJrAZlJNPaXAEhcAV1VGqMA8Fwx9VzarwNxVypRMCq7AkthuLKVfsMCIAck3Q6mxwK0mnaWs4LLAlidYc6AEtMCetpGt8RO1wCRcRqaIDbbAtj4kFWTwtsDUgMEgmru3wGzRqk9ZbrjAV7JRYOkHucCp3vsGrIe5wAIH8JAd7bnAmq83bNU3usDePmqThme6wBwfEt3/e7rAtBtaLix1usBuvM6QElO6wC8yHSvWFbrAHE/XHLa9ucBE5GE9DUu5wM+XUL5RvrjAurqPsRQYuMCwtdlzAVm3wEAzEvzcgbbAhx49EIWTtcDJwOJg7460wCymzIsodbPAd1ogB1NHssB8bPX1pQaxwDu4Ns/XaK/ATyC0BQOkrMAAJxg9qMGpwOYnCpLAxKbABK6Rf2Cwo8DqCk6ytIegwOzfeoX9m5rADCvmsyMNlMB21sgQPdOKwKxKsqcX4XrAAAAAAAAAgr0=",
+                    "path": [
+                        "_data",
+                        0,
+                        "y",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                },
+                {
+                    "data": "ui6EYTgvskA=",
+                    "path": [
+                        "_data",
+                        1,
+                        "x",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                },
+                {
+                    "data": "C5zKDwk6s0A=",
+                    "path": [
+                        "_data",
+                        1,
+                        "y",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                }
+            ]
+        },
+        "f1372ac94cbf4c888b62c25dd94cb192": {
+            "model_name": "FigureModel",
+            "model_module": "plotlywidget",
+            "model_module_version": "^0.4.0",
+            "state": {
+                "_data": [
+                    {
+                        "line": {
+                            "color": "rgb(31, 119, 180)",
+                            "dash": "dash",
+                            "width": 2
+                        },
+                        "mode": "lines",
+                        "name": "2013-03-18 12:00",
+                        "x": {
+                            "dtype": "float64",
+                            "shape": [
+                                100
+                            ]
+                        },
+                        "y": {
+                            "dtype": "float64",
+                            "shape": [
+                                100
+                            ]
+                        },
+                        "type": "scatter",
+                        "uid": "205cf9d0-e44e-11e8-aa89-a0afbda902ef"
+                    },
+                    {
+                        "marker": {
+                            "color": "rgb(31, 119, 180)",
+                            "size": 10
+                        },
+                        "mode": "markers",
+                        "name": "2013-03-18 12:00",
+                        "x": {
+                            "dtype": "float64",
+                            "shape": [
+                                1
+                            ]
+                        },
+                        "y": {
+                            "dtype": "float64",
+                            "shape": [
+                                1
+                            ]
+                        },
+                        "type": "scatter",
+                        "uid": "205cf9d1-e44e-11e8-aa89-a0afbda902ef"
+                    },
+                    {
+                        "type": "scatter",
+                        "uid": "205cf9d2-e44e-11e8-aa89-a0afbda902ef"
+                    }
+                ],
+                "_js2py_layoutDelta": {},
+                "_js2py_pointsCallback": {},
+                "_js2py_relayout": {},
+                "_js2py_restyle": {},
+                "_js2py_traceDeltas": {},
+                "_js2py_update": {},
+                "_layout": {
+                    "autosize": true,
+                    "shapes": [
+                        {
+                            "fillcolor": "#204a87",
+                            "line": {
+                                "color": "#204a87"
+                            },
+                            "opacity": 1,
+                            "type": "circle",
+                            "x0": -6378.1366,
+                            "x1": 6378.1366,
+                            "xref": "x",
+                            "y0": -6378.1366,
+                            "y1": 6378.1366,
+                            "yref": "y"
+                        }
+                    ],
+                    "xaxis": {
+                        "constrain": "domain",
+                        "title": "x (km)"
+                    },
+                    "yaxis": {
+                        "scaleanchor": "x",
+                        "title": "y (km)"
+                    }
+                },
+                "_py2js_addTraces": {},
+                "_py2js_animate": {},
+                "_py2js_deleteTraces": {},
+                "_py2js_moveTraces": {},
+                "_py2js_relayout": {},
+                "_py2js_removeLayoutProps": {},
+                "_py2js_removeTraceProps": {},
+                "_py2js_restyle": {},
+                "_py2js_update": {},
+                "_view_count": 0
+            },
+            "buffers": [
+                {
+                    "data": "1JorrQF0ukBgQpq/Wma6QD73iwl0PbpATERwtHf5uUCKZQrVq5q5QCyOMyNyIblA1gcglUeOuECiAI/ew+G3QK3QadSYHLdAoOlztZE/tkDEZshYkku1QCQ1/UKWQbRAqO3doq8is0AqpMk2BvCxQLID1xvWqrBAbvLxD92orkCkpufgYNyrQIYQDjwa86hAeF6FYAnwpUBeJiIjSdaiQDsmMnYXUp9A118f7S7XmED6fe+0hkKSQE6Kv8TONYdAyBaxW7Scc0CQlSEX+RtdwBgDyT7hEYHAOm21yfNujsCrQdgfeNaVwDoiDxQYX5zAwDL7yU5locB+BA45NYmkwGUIxakCmKfATUsbLpCOqsA53U7Xz2mtwHKl9O1nE7DAXlti0F5hscBwTfZQdJ2ywDwuLZxixrPApgrZnPfatMC2kKU3Ftq1wMz6/HC3wrbAgasefOuTt8CCCFCy2ky4wBPFKHHG7LjAFnYV3wlzucAs3kWVGt+5wFTHVy6JMLrA6lgruQFnusAIjGoPTIK6wAiMag9MgrrA6FgruQFnusBVx1cuiTC6wC7eRZUa37nAFnYV3wlzucATxShxxuy4wIIIULLaTLjAgqsefOuTt8DM+vxwt8K2wLiQpTcW2rXAqgrZnPfatMA+Li2cYsazwHJN9lB0nbLAYlti0F5hscB0pfTtZxOwwD3dTtfPaa3ARksbLpCOqsBmCMWpApinwIYEDjk1iaTAzjL7yU5locA8Ig8UGF+cwK9B2B941pXAXm21yfNujsA0A8k+4RGBwBCWIRf5G13AjBaxW7Scc0Aair/EzjWHQN5977SGQpJA2l8f7S7XmEAuJjJ2F1KfQFgmIiNJ1qJAgF6FYAnwpUB+EA48GvOoQKCm5+Bg3KtAZvLxD92orkC0A9cb1qqwQCikyTYG8LFAp+3doq8is0AjNf1ClkG0QMZmyFiSS7VAoOlztZE/tkCs0GnUmBy3QKMAj97D4bdA1wcglUeOuEAsjjMjciG5QIllCtWrmrlATERwtHf5uUA+94sJdD26QF5Cmr9aZrpA1JorrQF0ukA=",
+                    "path": [
+                        "_data",
+                        0,
+                        "x",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                },
+                {
+                    "data": "AAAAAAAAgr2ESrKnF+F6QHTWyBA904pAESvmsyMNlEDa33qF/ZuaQOgKTrK0h6BABq6Rf2Cwo0DgJwqSwMSmQPwmGD2owalATCC0BQOkrEA/uDbP12ivQHhs9fWlBrFAdFogB1NHskAspsyLKHWzQMvA4mDvjrRAhR49EIWTtUA/MxL83IG2QLC12XMBWbdAvLqPsRQYuEDOl1C+Ub64QEXkYT0NS7lAHE/XHLa9uUAuMh0r1hW6QG68zpASU7pAtRtaLix1ukAeHxLd/3u6QN8+apOGZ7pAm683bNU3ukACB/CQHe25QKre+wash7lAWrJRYOkHuUBu0apPWW64QNGAwSCau7dAsz4kFWTwtkAmXEamiA22QJ+2ka3xE7VAmSdYc6AEtECvJp2lrOCyQIoByTdDqbFAlthuLKVfsEDgVcqUTAquQD4XDH1XNqtAFRcAV1VGqECcwGZSTT2lQHOLT2pgHqJAmdLbVozZnUBo+FTGkleXQAVct3WJvZBArOGUCn0khEAITvD4juRqQDBO8PiO5GrAsOGUCn0khMAOXLd1ib2QwFT4VMaSV5fAk9LbVozZncBwi09qYB6iwJrAZlJNPaXAEhcAV1VGqMA8Fwx9VzarwNxVypRMCq7AkthuLKVfsMCIAck3Q6mxwK0mnaWs4LLAlidYc6AEtMCetpGt8RO1wCRcRqaIDbbAtj4kFWTwtsDUgMEgmru3wGzRqk9ZbrjAV7JRYOkHucCp3vsGrIe5wAIH8JAd7bnAmq83bNU3usDePmqThme6wBwfEt3/e7rAtBtaLix1usBuvM6QElO6wC8yHSvWFbrAHE/XHLa9ucBE5GE9DUu5wM+XUL5RvrjAurqPsRQYuMCwtdlzAVm3wEAzEvzcgbbAhx49EIWTtcDJwOJg7460wCymzIsodbPAd1ogB1NHssB8bPX1pQaxwDu4Ns/XaK/ATyC0BQOkrMAAJxg9qMGpwOYnCpLAxKbABK6Rf2Cwo8DqCk6ytIegwOzfeoX9m5rADCvmsyMNlMB21sgQPdOKwKxKsqcX4XrAAAAAAAAAgr0=",
+                    "path": [
+                        "_data",
+                        0,
+                        "y",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                },
+                {
+                    "data": "ui6EYTgvskA=",
+                    "path": [
+                        "_data",
+                        1,
+                        "x",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                },
+                {
+                    "data": "C5zKDwk6s0A=",
+                    "path": [
+                        "_data",
+                        1,
+                        "y",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                }
+            ]
+        },
+        "a2faf70f714f4fa49d672634091eee07": {
+            "model_name": "FigureModel",
+            "model_module": "plotlywidget",
+            "model_module_version": "^0.4.0",
+            "state": {
+                "_data": [
+                    {
+                        "line": {
+                            "color": "rgb(31, 119, 180)",
+                            "dash": "dash",
+                            "width": 2
+                        },
+                        "mode": "lines",
+                        "name": "2013-03-18 12:00",
+                        "x": {
+                            "dtype": "float64",
+                            "shape": [
+                                100
+                            ]
+                        },
+                        "y": {
+                            "dtype": "float64",
+                            "shape": [
+                                100
+                            ]
+                        },
+                        "type": "scatter",
+                        "uid": "3029a3cc-e44e-11e8-aa89-a0afbda902ef"
+                    },
+                    {
+                        "marker": {
+                            "color": "rgb(31, 119, 180)",
+                            "size": 10
+                        },
+                        "mode": "markers",
+                        "name": "2013-03-18 12:00",
+                        "x": {
+                            "dtype": "float64",
+                            "shape": [
+                                1
+                            ]
+                        },
+                        "y": {
+                            "dtype": "float64",
+                            "shape": [
+                                1
+                            ]
+                        },
+                        "type": "scatter",
+                        "uid": "3029a3cd-e44e-11e8-aa89-a0afbda902ef"
+                    },
+                    {
+                        "type": "scatter",
+                        "uid": "3029a3ce-e44e-11e8-aa89-a0afbda902ef"
+                    }
+                ],
+                "_js2py_relayout": {},
+                "_js2py_restyle": {},
+                "_js2py_update": {},
+                "_layout": {
+                    "autosize": true,
+                    "shapes": [
+                        {
+                            "fillcolor": "#204a87",
+                            "line": {
+                                "color": "#204a87"
+                            },
+                            "opacity": 1,
+                            "type": "circle",
+                            "x0": -6378.1366,
+                            "x1": 6378.1366,
+                            "xref": "x",
+                            "y0": -6378.1366,
+                            "y1": 6378.1366,
+                            "yref": "y"
+                        }
+                    ],
+                    "xaxis": {
+                        "constrain": "domain",
+                        "title": "x (km)"
+                    },
+                    "yaxis": {
+                        "scaleanchor": "x",
+                        "title": "y (km)"
+                    }
+                },
+                "_py2js_addTraces": {},
+                "_py2js_animate": {},
+                "_py2js_deleteTraces": {},
+                "_py2js_moveTraces": {},
+                "_py2js_relayout": {},
+                "_py2js_removeLayoutProps": {},
+                "_py2js_removeTraceProps": {},
+                "_py2js_restyle": {},
+                "_py2js_update": {},
+                "_view_count": 0
+            },
+            "buffers": [
+                {
+                    "data": "1JorrQF0ukBgQpq/Wma6QD73iwl0PbpATERwtHf5uUCKZQrVq5q5QCyOMyNyIblA1gcglUeOuECiAI/ew+G3QK3QadSYHLdAoOlztZE/tkDEZshYkku1QCQ1/UKWQbRAqO3doq8is0AqpMk2BvCxQLID1xvWqrBAbvLxD92orkCkpufgYNyrQIYQDjwa86hAeF6FYAnwpUBeJiIjSdaiQDsmMnYXUp9A118f7S7XmED6fe+0hkKSQE6Kv8TONYdAyBaxW7Scc0CQlSEX+RtdwBgDyT7hEYHAOm21yfNujsCrQdgfeNaVwDoiDxQYX5zAwDL7yU5locB+BA45NYmkwGUIxakCmKfATUsbLpCOqsA53U7Xz2mtwHKl9O1nE7DAXlti0F5hscBwTfZQdJ2ywDwuLZxixrPApgrZnPfatMC2kKU3Ftq1wMz6/HC3wrbAgasefOuTt8CCCFCy2ky4wBPFKHHG7LjAFnYV3wlzucAs3kWVGt+5wFTHVy6JMLrA6lgruQFnusAIjGoPTIK6wAiMag9MgrrA6FgruQFnusBVx1cuiTC6wC7eRZUa37nAFnYV3wlzucATxShxxuy4wIIIULLaTLjAgqsefOuTt8DM+vxwt8K2wLiQpTcW2rXAqgrZnPfatMA+Li2cYsazwHJN9lB0nbLAYlti0F5hscB0pfTtZxOwwD3dTtfPaa3ARksbLpCOqsBmCMWpApinwIYEDjk1iaTAzjL7yU5locA8Ig8UGF+cwK9B2B941pXAXm21yfNujsA0A8k+4RGBwBCWIRf5G13AjBaxW7Scc0Aair/EzjWHQN5977SGQpJA2l8f7S7XmEAuJjJ2F1KfQFgmIiNJ1qJAgF6FYAnwpUB+EA48GvOoQKCm5+Bg3KtAZvLxD92orkC0A9cb1qqwQCikyTYG8LFAp+3doq8is0AjNf1ClkG0QMZmyFiSS7VAoOlztZE/tkCs0GnUmBy3QKMAj97D4bdA1wcglUeOuEAsjjMjciG5QIllCtWrmrlATERwtHf5uUA+94sJdD26QF5Cmr9aZrpA1JorrQF0ukA=",
+                    "path": [
+                        "_data",
+                        0,
+                        "x",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                },
+                {
+                    "data": "AAAAAAAAgr2ESrKnF+F6QHTWyBA904pAESvmsyMNlEDa33qF/ZuaQOgKTrK0h6BABq6Rf2Cwo0DgJwqSwMSmQPwmGD2owalATCC0BQOkrEA/uDbP12ivQHhs9fWlBrFAdFogB1NHskAspsyLKHWzQMvA4mDvjrRAhR49EIWTtUA/MxL83IG2QLC12XMBWbdAvLqPsRQYuEDOl1C+Ub64QEXkYT0NS7lAHE/XHLa9uUAuMh0r1hW6QG68zpASU7pAtRtaLix1ukAeHxLd/3u6QN8+apOGZ7pAm683bNU3ukACB/CQHe25QKre+wash7lAWrJRYOkHuUBu0apPWW64QNGAwSCau7dAsz4kFWTwtkAmXEamiA22QJ+2ka3xE7VAmSdYc6AEtECvJp2lrOCyQIoByTdDqbFAlthuLKVfsEDgVcqUTAquQD4XDH1XNqtAFRcAV1VGqECcwGZSTT2lQHOLT2pgHqJAmdLbVozZnUBo+FTGkleXQAVct3WJvZBArOGUCn0khEAITvD4juRqQDBO8PiO5GrAsOGUCn0khMAOXLd1ib2QwFT4VMaSV5fAk9LbVozZncBwi09qYB6iwJrAZlJNPaXAEhcAV1VGqMA8Fwx9VzarwNxVypRMCq7AkthuLKVfsMCIAck3Q6mxwK0mnaWs4LLAlidYc6AEtMCetpGt8RO1wCRcRqaIDbbAtj4kFWTwtsDUgMEgmru3wGzRqk9ZbrjAV7JRYOkHucCp3vsGrIe5wAIH8JAd7bnAmq83bNU3usDePmqThme6wBwfEt3/e7rAtBtaLix1usBuvM6QElO6wC8yHSvWFbrAHE/XHLa9ucBE5GE9DUu5wM+XUL5RvrjAurqPsRQYuMCwtdlzAVm3wEAzEvzcgbbAhx49EIWTtcDJwOJg7460wCymzIsodbPAd1ogB1NHssB8bPX1pQaxwDu4Ns/XaK/ATyC0BQOkrMAAJxg9qMGpwOYnCpLAxKbABK6Rf2Cwo8DqCk6ytIegwOzfeoX9m5rADCvmsyMNlMB21sgQPdOKwKxKsqcX4XrAAAAAAAAAgr0=",
+                    "path": [
+                        "_data",
+                        0,
+                        "y",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                },
+                {
+                    "data": "ui6EYTgvskA=",
+                    "path": [
+                        "_data",
+                        1,
+                        "x",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                },
+                {
+                    "data": "C5zKDwk6s0A=",
+                    "path": [
+                        "_data",
+                        1,
+                        "y",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                }
+            ]
+        },
+        "3b1cb1707271445c84b4320dab6f4f9a": {
+            "model_name": "FigureModel",
+            "model_module": "plotlywidget",
+            "model_module_version": "^0.4.0",
+            "state": {
+                "_data": [
+                    {
+                        "line": {
+                            "color": "rgb(31, 119, 180)",
+                            "dash": "dash",
+                            "width": 2
+                        },
+                        "mode": "lines",
+                        "name": "2013-03-18 12:00",
+                        "x": {
+                            "dtype": "float64",
+                            "shape": [
+                                100
+                            ]
+                        },
+                        "y": {
+                            "dtype": "float64",
+                            "shape": [
+                                100
+                            ]
+                        },
+                        "type": "scatter",
+                        "uid": "3d5efa1a-e44e-11e8-aa89-a0afbda902ef"
+                    },
+                    {
+                        "marker": {
+                            "color": "rgb(31, 119, 180)",
+                            "size": 10
+                        },
+                        "mode": "markers",
+                        "name": "2013-03-18 12:00",
+                        "x": {
+                            "dtype": "float64",
+                            "shape": [
+                                1
+                            ]
+                        },
+                        "y": {
+                            "dtype": "float64",
+                            "shape": [
+                                1
+                            ]
+                        },
+                        "type": "scatter",
+                        "uid": "3d5efa1b-e44e-11e8-aa89-a0afbda902ef"
+                    },
+                    {
+                        "type": "scatter",
+                        "uid": "3d5efa1c-e44e-11e8-aa89-a0afbda902ef"
+                    }
+                ],
+                "_js2py_layoutDelta": {},
+                "_js2py_pointsCallback": {},
+                "_js2py_relayout": {},
+                "_js2py_restyle": {},
+                "_js2py_traceDeltas": {},
+                "_js2py_update": {},
+                "_layout": {
+                    "autosize": true,
+                    "shapes": [
+                        {
+                            "fillcolor": "#204a87",
+                            "line": {
+                                "color": "#204a87"
+                            },
+                            "opacity": 1,
+                            "type": "circle",
+                            "x0": -6378.1366,
+                            "x1": 6378.1366,
+                            "xref": "x",
+                            "y0": -6378.1366,
+                            "y1": 6378.1366,
+                            "yref": "y"
+                        }
+                    ],
+                    "xaxis": {
+                        "constrain": "domain",
+                        "title": "x (km)"
+                    },
+                    "yaxis": {
+                        "scaleanchor": "x",
+                        "title": "y (km)"
+                    }
+                },
+                "_py2js_addTraces": {},
+                "_py2js_animate": {},
+                "_py2js_deleteTraces": {},
+                "_py2js_moveTraces": {},
+                "_py2js_relayout": {},
+                "_py2js_removeLayoutProps": {},
+                "_py2js_removeTraceProps": {},
+                "_py2js_restyle": {},
+                "_py2js_update": {},
+                "_view_count": 0
+            },
+            "buffers": [
+                {
+                    "data": "1JorrQF0ukBgQpq/Wma6QD73iwl0PbpATERwtHf5uUCKZQrVq5q5QCyOMyNyIblA1gcglUeOuECiAI/ew+G3QK3QadSYHLdAoOlztZE/tkDEZshYkku1QCQ1/UKWQbRAqO3doq8is0AqpMk2BvCxQLID1xvWqrBAbvLxD92orkCkpufgYNyrQIYQDjwa86hAeF6FYAnwpUBeJiIjSdaiQDsmMnYXUp9A118f7S7XmED6fe+0hkKSQE6Kv8TONYdAyBaxW7Scc0CQlSEX+RtdwBgDyT7hEYHAOm21yfNujsCrQdgfeNaVwDoiDxQYX5zAwDL7yU5locB+BA45NYmkwGUIxakCmKfATUsbLpCOqsA53U7Xz2mtwHKl9O1nE7DAXlti0F5hscBwTfZQdJ2ywDwuLZxixrPApgrZnPfatMC2kKU3Ftq1wMz6/HC3wrbAgasefOuTt8CCCFCy2ky4wBPFKHHG7LjAFnYV3wlzucAs3kWVGt+5wFTHVy6JMLrA6lgruQFnusAIjGoPTIK6wAiMag9MgrrA6FgruQFnusBVx1cuiTC6wC7eRZUa37nAFnYV3wlzucATxShxxuy4wIIIULLaTLjAgqsefOuTt8DM+vxwt8K2wLiQpTcW2rXAqgrZnPfatMA+Li2cYsazwHJN9lB0nbLAYlti0F5hscB0pfTtZxOwwD3dTtfPaa3ARksbLpCOqsBmCMWpApinwIYEDjk1iaTAzjL7yU5locA8Ig8UGF+cwK9B2B941pXAXm21yfNujsA0A8k+4RGBwBCWIRf5G13AjBaxW7Scc0Aair/EzjWHQN5977SGQpJA2l8f7S7XmEAuJjJ2F1KfQFgmIiNJ1qJAgF6FYAnwpUB+EA48GvOoQKCm5+Bg3KtAZvLxD92orkC0A9cb1qqwQCikyTYG8LFAp+3doq8is0AjNf1ClkG0QMZmyFiSS7VAoOlztZE/tkCs0GnUmBy3QKMAj97D4bdA1wcglUeOuEAsjjMjciG5QIllCtWrmrlATERwtHf5uUA+94sJdD26QF5Cmr9aZrpA1JorrQF0ukA=",
+                    "path": [
+                        "_data",
+                        0,
+                        "x",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                },
+                {
+                    "data": "AAAAAAAAgr2ESrKnF+F6QHTWyBA904pAESvmsyMNlEDa33qF/ZuaQOgKTrK0h6BABq6Rf2Cwo0DgJwqSwMSmQPwmGD2owalATCC0BQOkrEA/uDbP12ivQHhs9fWlBrFAdFogB1NHskAspsyLKHWzQMvA4mDvjrRAhR49EIWTtUA/MxL83IG2QLC12XMBWbdAvLqPsRQYuEDOl1C+Ub64QEXkYT0NS7lAHE/XHLa9uUAuMh0r1hW6QG68zpASU7pAtRtaLix1ukAeHxLd/3u6QN8+apOGZ7pAm683bNU3ukACB/CQHe25QKre+wash7lAWrJRYOkHuUBu0apPWW64QNGAwSCau7dAsz4kFWTwtkAmXEamiA22QJ+2ka3xE7VAmSdYc6AEtECvJp2lrOCyQIoByTdDqbFAlthuLKVfsEDgVcqUTAquQD4XDH1XNqtAFRcAV1VGqECcwGZSTT2lQHOLT2pgHqJAmdLbVozZnUBo+FTGkleXQAVct3WJvZBArOGUCn0khEAITvD4juRqQDBO8PiO5GrAsOGUCn0khMAOXLd1ib2QwFT4VMaSV5fAk9LbVozZncBwi09qYB6iwJrAZlJNPaXAEhcAV1VGqMA8Fwx9VzarwNxVypRMCq7AkthuLKVfsMCIAck3Q6mxwK0mnaWs4LLAlidYc6AEtMCetpGt8RO1wCRcRqaIDbbAtj4kFWTwtsDUgMEgmru3wGzRqk9ZbrjAV7JRYOkHucCp3vsGrIe5wAIH8JAd7bnAmq83bNU3usDePmqThme6wBwfEt3/e7rAtBtaLix1usBuvM6QElO6wC8yHSvWFbrAHE/XHLa9ucBE5GE9DUu5wM+XUL5RvrjAurqPsRQYuMCwtdlzAVm3wEAzEvzcgbbAhx49EIWTtcDJwOJg7460wCymzIsodbPAd1ogB1NHssB8bPX1pQaxwDu4Ns/XaK/ATyC0BQOkrMAAJxg9qMGpwOYnCpLAxKbABK6Rf2Cwo8DqCk6ytIegwOzfeoX9m5rADCvmsyMNlMB21sgQPdOKwKxKsqcX4XrAAAAAAAAAgr0=",
+                    "path": [
+                        "_data",
+                        0,
+                        "y",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                },
+                {
+                    "data": "ui6EYTgvskA=",
+                    "path": [
+                        "_data",
+                        1,
+                        "x",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                },
+                {
+                    "data": "C5zKDwk6s0A=",
+                    "path": [
+                        "_data",
+                        1,
+                        "y",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                }
+            ]
+        },
+        "71248a902a8c48dabc424a59e5372ab6": {
+            "model_name": "FigureModel",
+            "model_module": "plotlywidget",
+            "model_module_version": "^0.4.0",
+            "state": {
+                "_data": [
+                    {
+                        "line": {
+                            "color": "rgb(31, 119, 180)",
+                            "dash": "dash",
+                            "width": 2
+                        },
+                        "mode": "lines",
+                        "name": "2013-03-18 12:00",
+                        "x": {
+                            "dtype": "float64",
+                            "shape": [
+                                100
+                            ]
+                        },
+                        "y": {
+                            "dtype": "float64",
+                            "shape": [
+                                100
+                            ]
+                        },
+                        "type": "scatter",
+                        "uid": "3d5efa1d-e44e-11e8-aa89-a0afbda902ef"
+                    },
+                    {
+                        "marker": {
+                            "color": "rgb(31, 119, 180)",
+                            "size": 10
+                        },
+                        "mode": "markers",
+                        "name": "2013-03-18 12:00",
+                        "x": {
+                            "dtype": "float64",
+                            "shape": [
+                                1
+                            ]
+                        },
+                        "y": {
+                            "dtype": "float64",
+                            "shape": [
+                                1
+                            ]
+                        },
+                        "type": "scatter",
+                        "uid": "3d5efa1e-e44e-11e8-aa89-a0afbda902ef"
+                    },
+                    {
+                        "type": "scatter",
+                        "uid": "3d5efa1f-e44e-11e8-aa89-a0afbda902ef"
+                    }
+                ],
+                "_js2py_pointsCallback": {},
+                "_js2py_relayout": {},
+                "_js2py_restyle": {},
+                "_js2py_update": {},
+                "_layout": {
+                    "autosize": true,
+                    "shapes": [
+                        {
+                            "fillcolor": "#204a87",
+                            "line": {
+                                "color": "#204a87"
+                            },
+                            "opacity": 1,
+                            "type": "circle",
+                            "x0": -6378.1366,
+                            "x1": 6378.1366,
+                            "xref": "x",
+                            "y0": -6378.1366,
+                            "y1": 6378.1366,
+                            "yref": "y"
+                        }
+                    ],
+                    "xaxis": {
+                        "constrain": "domain",
+                        "title": "x (km)"
+                    },
+                    "yaxis": {
+                        "scaleanchor": "x",
+                        "title": "y (km)"
+                    }
+                },
+                "_py2js_addTraces": {},
+                "_py2js_animate": {},
+                "_py2js_deleteTraces": {},
+                "_py2js_moveTraces": {},
+                "_py2js_relayout": {},
+                "_py2js_removeLayoutProps": {},
+                "_py2js_removeTraceProps": {},
+                "_py2js_restyle": {},
+                "_py2js_update": {},
+                "_view_count": 0
+            },
+            "buffers": [
+                {
+                    "data": "1JorrQF0ukBgQpq/Wma6QD73iwl0PbpATERwtHf5uUCKZQrVq5q5QCyOMyNyIblA1gcglUeOuECiAI/ew+G3QK3QadSYHLdAoOlztZE/tkDEZshYkku1QCQ1/UKWQbRAqO3doq8is0AqpMk2BvCxQLID1xvWqrBAbvLxD92orkCkpufgYNyrQIYQDjwa86hAeF6FYAnwpUBeJiIjSdaiQDsmMnYXUp9A118f7S7XmED6fe+0hkKSQE6Kv8TONYdAyBaxW7Scc0CQlSEX+RtdwBgDyT7hEYHAOm21yfNujsCrQdgfeNaVwDoiDxQYX5zAwDL7yU5locB+BA45NYmkwGUIxakCmKfATUsbLpCOqsA53U7Xz2mtwHKl9O1nE7DAXlti0F5hscBwTfZQdJ2ywDwuLZxixrPApgrZnPfatMC2kKU3Ftq1wMz6/HC3wrbAgasefOuTt8CCCFCy2ky4wBPFKHHG7LjAFnYV3wlzucAs3kWVGt+5wFTHVy6JMLrA6lgruQFnusAIjGoPTIK6wAiMag9MgrrA6FgruQFnusBVx1cuiTC6wC7eRZUa37nAFnYV3wlzucATxShxxuy4wIIIULLaTLjAgqsefOuTt8DM+vxwt8K2wLiQpTcW2rXAqgrZnPfatMA+Li2cYsazwHJN9lB0nbLAYlti0F5hscB0pfTtZxOwwD3dTtfPaa3ARksbLpCOqsBmCMWpApinwIYEDjk1iaTAzjL7yU5locA8Ig8UGF+cwK9B2B941pXAXm21yfNujsA0A8k+4RGBwBCWIRf5G13AjBaxW7Scc0Aair/EzjWHQN5977SGQpJA2l8f7S7XmEAuJjJ2F1KfQFgmIiNJ1qJAgF6FYAnwpUB+EA48GvOoQKCm5+Bg3KtAZvLxD92orkC0A9cb1qqwQCikyTYG8LFAp+3doq8is0AjNf1ClkG0QMZmyFiSS7VAoOlztZE/tkCs0GnUmBy3QKMAj97D4bdA1wcglUeOuEAsjjMjciG5QIllCtWrmrlATERwtHf5uUA+94sJdD26QF5Cmr9aZrpA1JorrQF0ukA=",
+                    "path": [
+                        "_data",
+                        0,
+                        "x",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                },
+                {
+                    "data": "AAAAAAAAgr2ESrKnF+F6QHTWyBA904pAESvmsyMNlEDa33qF/ZuaQOgKTrK0h6BABq6Rf2Cwo0DgJwqSwMSmQPwmGD2owalATCC0BQOkrEA/uDbP12ivQHhs9fWlBrFAdFogB1NHskAspsyLKHWzQMvA4mDvjrRAhR49EIWTtUA/MxL83IG2QLC12XMBWbdAvLqPsRQYuEDOl1C+Ub64QEXkYT0NS7lAHE/XHLa9uUAuMh0r1hW6QG68zpASU7pAtRtaLix1ukAeHxLd/3u6QN8+apOGZ7pAm683bNU3ukACB/CQHe25QKre+wash7lAWrJRYOkHuUBu0apPWW64QNGAwSCau7dAsz4kFWTwtkAmXEamiA22QJ+2ka3xE7VAmSdYc6AEtECvJp2lrOCyQIoByTdDqbFAlthuLKVfsEDgVcqUTAquQD4XDH1XNqtAFRcAV1VGqECcwGZSTT2lQHOLT2pgHqJAmdLbVozZnUBo+FTGkleXQAVct3WJvZBArOGUCn0khEAITvD4juRqQDBO8PiO5GrAsOGUCn0khMAOXLd1ib2QwFT4VMaSV5fAk9LbVozZncBwi09qYB6iwJrAZlJNPaXAEhcAV1VGqMA8Fwx9VzarwNxVypRMCq7AkthuLKVfsMCIAck3Q6mxwK0mnaWs4LLAlidYc6AEtMCetpGt8RO1wCRcRqaIDbbAtj4kFWTwtsDUgMEgmru3wGzRqk9ZbrjAV7JRYOkHucCp3vsGrIe5wAIH8JAd7bnAmq83bNU3usDePmqThme6wBwfEt3/e7rAtBtaLix1usBuvM6QElO6wC8yHSvWFbrAHE/XHLa9ucBE5GE9DUu5wM+XUL5RvrjAurqPsRQYuMCwtdlzAVm3wEAzEvzcgbbAhx49EIWTtcDJwOJg7460wCymzIsodbPAd1ogB1NHssB8bPX1pQaxwDu4Ns/XaK/ATyC0BQOkrMAAJxg9qMGpwOYnCpLAxKbABK6Rf2Cwo8DqCk6ytIegwOzfeoX9m5rADCvmsyMNlMB21sgQPdOKwKxKsqcX4XrAAAAAAAAAgr0=",
+                    "path": [
+                        "_data",
+                        0,
+                        "y",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                },
+                {
+                    "data": "ui6EYTgvskA=",
+                    "path": [
+                        "_data",
+                        1,
+                        "x",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                },
+                {
+                    "data": "C5zKDwk6s0A=",
+                    "path": [
+                        "_data",
+                        1,
+                        "y",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                }
+            ]
+        },
+        "79047c76b45144e59238f274e7d99bc2": {
+            "model_name": "FigureModel",
+            "model_module": "plotlywidget",
+            "model_module_version": "^0.4.0",
+            "state": {
+                "_data": [
+                    {
+                        "line": {
+                            "color": "rgb(31, 119, 180)",
+                            "dash": "dash",
+                            "width": 2
+                        },
+                        "mode": "lines",
+                        "name": "2013-03-18 12:00",
+                        "x": {
+                            "dtype": "float64",
+                            "shape": [
+                                100
+                            ]
+                        },
+                        "y": {
+                            "dtype": "float64",
+                            "shape": [
+                                100
+                            ]
+                        },
+                        "type": "scatter",
+                        "uid": "41a6440c-e44e-11e8-aa89-a0afbda902ef"
+                    },
+                    {
+                        "marker": {
+                            "color": "rgb(31, 119, 180)",
+                            "size": 10
+                        },
+                        "mode": "markers",
+                        "name": "2013-03-18 12:00",
+                        "x": {
+                            "dtype": "float64",
+                            "shape": [
+                                1
+                            ]
+                        },
+                        "y": {
+                            "dtype": "float64",
+                            "shape": [
+                                1
+                            ]
+                        },
+                        "type": "scatter",
+                        "uid": "41a6440d-e44e-11e8-aa89-a0afbda902ef"
+                    },
+                    {
+                        "type": "scatter",
+                        "uid": "41a6440e-e44e-11e8-aa89-a0afbda902ef"
+                    }
+                ],
+                "_js2py_pointsCallback": {},
+                "_js2py_relayout": {},
+                "_js2py_restyle": {},
+                "_js2py_update": {},
+                "_layout": {
+                    "autosize": true,
+                    "shapes": [
+                        {
+                            "fillcolor": "#204a87",
+                            "line": {
+                                "color": "#204a87"
+                            },
+                            "opacity": 1,
+                            "type": "circle",
+                            "x0": -6378.1366,
+                            "x1": 6378.1366,
+                            "xref": "x",
+                            "y0": -6378.1366,
+                            "y1": 6378.1366,
+                            "yref": "y"
+                        }
+                    ],
+                    "xaxis": {
+                        "constrain": "domain",
+                        "title": "x (km)"
+                    },
+                    "yaxis": {
+                        "scaleanchor": "x",
+                        "title": "y (km)"
+                    }
+                },
+                "_py2js_addTraces": {},
+                "_py2js_animate": {},
+                "_py2js_deleteTraces": {},
+                "_py2js_moveTraces": {},
+                "_py2js_relayout": {},
+                "_py2js_removeLayoutProps": {},
+                "_py2js_removeTraceProps": {},
+                "_py2js_restyle": {},
+                "_py2js_update": {},
+                "_view_count": 0
+            },
+            "buffers": [
+                {
+                    "data": "1JorrQF0ukBgQpq/Wma6QD73iwl0PbpATERwtHf5uUCKZQrVq5q5QCyOMyNyIblA1gcglUeOuECiAI/ew+G3QK3QadSYHLdAoOlztZE/tkDEZshYkku1QCQ1/UKWQbRAqO3doq8is0AqpMk2BvCxQLID1xvWqrBAbvLxD92orkCkpufgYNyrQIYQDjwa86hAeF6FYAnwpUBeJiIjSdaiQDsmMnYXUp9A118f7S7XmED6fe+0hkKSQE6Kv8TONYdAyBaxW7Scc0CQlSEX+RtdwBgDyT7hEYHAOm21yfNujsCrQdgfeNaVwDoiDxQYX5zAwDL7yU5locB+BA45NYmkwGUIxakCmKfATUsbLpCOqsA53U7Xz2mtwHKl9O1nE7DAXlti0F5hscBwTfZQdJ2ywDwuLZxixrPApgrZnPfatMC2kKU3Ftq1wMz6/HC3wrbAgasefOuTt8CCCFCy2ky4wBPFKHHG7LjAFnYV3wlzucAs3kWVGt+5wFTHVy6JMLrA6lgruQFnusAIjGoPTIK6wAiMag9MgrrA6FgruQFnusBVx1cuiTC6wC7eRZUa37nAFnYV3wlzucATxShxxuy4wIIIULLaTLjAgqsefOuTt8DM+vxwt8K2wLiQpTcW2rXAqgrZnPfatMA+Li2cYsazwHJN9lB0nbLAYlti0F5hscB0pfTtZxOwwD3dTtfPaa3ARksbLpCOqsBmCMWpApinwIYEDjk1iaTAzjL7yU5locA8Ig8UGF+cwK9B2B941pXAXm21yfNujsA0A8k+4RGBwBCWIRf5G13AjBaxW7Scc0Aair/EzjWHQN5977SGQpJA2l8f7S7XmEAuJjJ2F1KfQFgmIiNJ1qJAgF6FYAnwpUB+EA48GvOoQKCm5+Bg3KtAZvLxD92orkC0A9cb1qqwQCikyTYG8LFAp+3doq8is0AjNf1ClkG0QMZmyFiSS7VAoOlztZE/tkCs0GnUmBy3QKMAj97D4bdA1wcglUeOuEAsjjMjciG5QIllCtWrmrlATERwtHf5uUA+94sJdD26QF5Cmr9aZrpA1JorrQF0ukA=",
+                    "path": [
+                        "_data",
+                        0,
+                        "x",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                },
+                {
+                    "data": "AAAAAAAAgr2ESrKnF+F6QHTWyBA904pAESvmsyMNlEDa33qF/ZuaQOgKTrK0h6BABq6Rf2Cwo0DgJwqSwMSmQPwmGD2owalATCC0BQOkrEA/uDbP12ivQHhs9fWlBrFAdFogB1NHskAspsyLKHWzQMvA4mDvjrRAhR49EIWTtUA/MxL83IG2QLC12XMBWbdAvLqPsRQYuEDOl1C+Ub64QEXkYT0NS7lAHE/XHLa9uUAuMh0r1hW6QG68zpASU7pAtRtaLix1ukAeHxLd/3u6QN8+apOGZ7pAm683bNU3ukACB/CQHe25QKre+wash7lAWrJRYOkHuUBu0apPWW64QNGAwSCau7dAsz4kFWTwtkAmXEamiA22QJ+2ka3xE7VAmSdYc6AEtECvJp2lrOCyQIoByTdDqbFAlthuLKVfsEDgVcqUTAquQD4XDH1XNqtAFRcAV1VGqECcwGZSTT2lQHOLT2pgHqJAmdLbVozZnUBo+FTGkleXQAVct3WJvZBArOGUCn0khEAITvD4juRqQDBO8PiO5GrAsOGUCn0khMAOXLd1ib2QwFT4VMaSV5fAk9LbVozZncBwi09qYB6iwJrAZlJNPaXAEhcAV1VGqMA8Fwx9VzarwNxVypRMCq7AkthuLKVfsMCIAck3Q6mxwK0mnaWs4LLAlidYc6AEtMCetpGt8RO1wCRcRqaIDbbAtj4kFWTwtsDUgMEgmru3wGzRqk9ZbrjAV7JRYOkHucCp3vsGrIe5wAIH8JAd7bnAmq83bNU3usDePmqThme6wBwfEt3/e7rAtBtaLix1usBuvM6QElO6wC8yHSvWFbrAHE/XHLa9ucBE5GE9DUu5wM+XUL5RvrjAurqPsRQYuMCwtdlzAVm3wEAzEvzcgbbAhx49EIWTtcDJwOJg7460wCymzIsodbPAd1ogB1NHssB8bPX1pQaxwDu4Ns/XaK/ATyC0BQOkrMAAJxg9qMGpwOYnCpLAxKbABK6Rf2Cwo8DqCk6ytIegwOzfeoX9m5rADCvmsyMNlMB21sgQPdOKwKxKsqcX4XrAAAAAAAAAgr0=",
+                    "path": [
+                        "_data",
+                        0,
+                        "y",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                },
+                {
+                    "data": "ui6EYTgvskA=",
+                    "path": [
+                        "_data",
+                        1,
+                        "x",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                },
+                {
+                    "data": "C5zKDwk6s0A=",
+                    "path": [
+                        "_data",
+                        1,
+                        "y",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                }
+            ]
+        },
+        "77db7105803a4cf1a6b2c3b6390d492d": {
+            "model_name": "FigureModel",
+            "model_module": "plotlywidget",
+            "model_module_version": "^0.4.0",
+            "state": {
+                "_data": [
+                    {
+                        "line": {
+                            "color": "rgb(31, 119, 180)",
+                            "dash": "dash",
+                            "width": 2
+                        },
+                        "mode": "lines",
+                        "name": "2000-01-01 12:00",
+                        "x": {
+                            "dtype": "float64",
+                            "shape": [
+                                100
+                            ]
+                        },
+                        "y": {
+                            "dtype": "float64",
+                            "shape": [
+                                100
+                            ]
+                        },
+                        "type": "scatter",
+                        "uid": "4456ffd4-e44e-11e8-aa89-a0afbda902ef"
+                    },
+                    {
+                        "marker": {
+                            "color": "rgb(31, 119, 180)",
+                            "size": 10
+                        },
+                        "mode": "markers",
+                        "name": "2000-01-01 12:00",
+                        "x": {
+                            "dtype": "float64",
+                            "shape": [
+                                1
+                            ]
+                        },
+                        "y": {
+                            "dtype": "float64",
+                            "shape": [
+                                1
+                            ]
+                        },
+                        "type": "scatter",
+                        "uid": "4456ffd5-e44e-11e8-aa89-a0afbda902ef"
+                    },
+                    {
+                        "type": "scatter",
+                        "uid": "4456ffd6-e44e-11e8-aa89-a0afbda902ef"
+                    }
+                ],
+                "_js2py_layoutDelta": {},
+                "_js2py_pointsCallback": {},
+                "_js2py_relayout": {},
+                "_js2py_restyle": {},
+                "_js2py_traceDeltas": {},
+                "_js2py_update": {},
+                "_layout": {
+                    "autosize": true,
+                    "shapes": [
+                        {
+                            "fillcolor": "#204a87",
+                            "line": {
+                                "color": "#204a87"
+                            },
+                            "opacity": 1,
+                            "type": "circle",
+                            "x0": -6378.1366,
+                            "x1": 6378.1366,
+                            "xref": "x",
+                            "y0": -6378.1366,
+                            "y1": 6378.1366,
+                            "yref": "y"
+                        }
+                    ],
+                    "xaxis": {
+                        "constrain": "domain",
+                        "title": "x (km)"
+                    },
+                    "yaxis": {
+                        "scaleanchor": "x",
+                        "title": "y (km)"
+                    }
+                },
+                "_py2js_addTraces": {},
+                "_py2js_animate": {},
+                "_py2js_deleteTraces": {},
+                "_py2js_moveTraces": {},
+                "_py2js_relayout": {},
+                "_py2js_removeLayoutProps": {},
+                "_py2js_removeTraceProps": {},
+                "_py2js_restyle": {},
+                "_py2js_update": {},
+                "_view_count": 0
+            },
+            "buffers": [
+                {
+                    "data": "/v/////5uUCoVnUScsS5QJDoUn7/I7lAxUspqE0ZuEBOjB56b6W2QJLaikjkybRAYZnTRpaIskBhPTgcscevQO8Rqm/JvKlAPwVFHbD2okCW2vphwfiWQFuTetaDrHpAWKOOjWXVhcB5qIY+mbadwIYszx2Z0qjAeB71d3yoscAAqKx0zSW3wDtxpOOW27zAJha39vphwcCs9e/KaWzEwOGbjoH1icfAO+Dz+We3ysAhKkevevHNwFy+aQxtmtDAaojnixQ/0sCgU4I3AuXTwPbGZSCDitXAQmnax+Qt18AaqSjfds3YwP2hOgWNZ9rAY0ExgID628CdmSXxsYTdwIczVQCLBN/A+////z884MAIESTCiO/gwD6QN/dmm+HAxIjsdCk/4sCGgKZsJ9riwMQGfRnBa+PAhj7tZGDz48BUoJCBeXDkwEp3OXuL4uTAHYzguyBJ5cCi99qEz6PlwJYq21s68uXAXc1MaxA05sC7I6jVDWnmwMMPZ/v7kObAn5ZTs7Gr5sDO3PV0E7nmwM7c9XQTuebAn5ZTs7Gr5sDCD2f7+5DmwLojqNUNaebAW81MaxA05sCVKttbOvLlwKD32oTPo+XAHIzguyBJ5cBKdzl7i+LkwFagkIF5cOTAhD7tZGDz48DCBn0ZwWvjwIWApmwn2uLAx4jsdCk/4sA9kDf3ZpvhwAoRJMKI7+DA+v///z884MCGM1UAiwTfwJqZJfGxhN3AYkExgID628D6oToFjWfawBmpKN92zdjAQGnax+Qt18D0xmUgg4rVwJdTgjcC5dPAaIjnixQ/0sBVvmkMbZrQwCYqR6968c3AN+Dz+We3ysDem46B9YnHwLX178ppbMTAFha39vphwcAlcaTjltu8wPKnrHTNJbfAch71d3yoscBqLM8dmdKowCeohj6Ztp3Ay6KOjWXVhcBVk3rWg6x6QPTa+mHB+JZAYwVFHbD2okD6EapvybypQGI9OByxx69AbpnTRpaIskCZ2opI5Mm0QFKMHnpvpbZAzEspqE0ZuECU6FJ+/yO5QKpWdRJyxLlA/v/////5uUA=",
+                    "path": [
+                        "_data",
+                        0,
+                        "x",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                },
+                {
+                    "data": "ulOlSs8ylz2qt2GQlW+RQOlv//uYZqFAzzKGSncDqkBYQSZwwkKxQNu+E0f+cbVAGDnO6R6LuUBKl7nh6om9QDxdU+4htcBAGlDSdRWUwkCKT7tQ4l/EQL1iOIauFsZA1o/Qw7W2x0DZTqsvSz7JQPcpoiLbq8pAutlYyOz9y0B88a6jIzPNQO6x+vVASs5AK7SaByVCz0CV3UUo6AzQQNd46D8yaNBAAIdPsJKy0EAREC/OvOvQQPYGXax1E9FApmaPWJQp0UAMkZEFAi7RQBltxSK6INFAwwnYYMoB0UDP66SjUtHQQK2SVuGEj9BANhfm7qQ80EAF9l10ELLPQHl4vuMqys5AmOk8N4jCzUCIQbIxOJzMQAsaXjVqWMtAtKEqC2z4yUCtBJqKqH3IQCb4vyOm6cZA6/bITAU+xUCADq7UfnzDQMXEzxzipsFAP/qYdiZ+v0CdfP0PEo67QKB6SyyWgbdAHfycOd9cs0DaipZAZUiuQCJEprfUt6VAXNIO+sEhmkBvBLwk1XGBQM0FvCTVcYHAsNIO+sEhmsBMRKa31LelwAKLlkBlSK7AR/ycOd9cs8C0ekssloG3wLF8/Q8SjrvAU/qYdiZ+v8DPxM8c4qbBwIIOrtR+fMPA9fbITAU+xcAw+L8jpunGwLcEmoqofcjAtqEqC2z4ycATGl41aljLwIpBsjE4nMzAoOk8N4jCzcB/eL7jKsrOwAv2XXQQss/AOhfm7qQ80MCxklbhhI/QwNPrpKNS0dDAxwnYYMoB0cAbbcUiuiDRwAyRkQUCLtHAqGaPWJQp0cD3Bl2sdRPRwBIQL86869DAAIdPsJKy0MDXeOg/MmjQwJbdRSjoDNDAKbSaByVCz8Dqsfr1QErOwHzxrqMjM83AvNlYyOz9y8D4KaIi26vKwNROqy9LPsnA0o/Qw7W2x8C+YjiGrhbGwIRPu1DiX8TAE1DSdRWUwsA5XVPuIbXAwE+XueHqib3ABznO6R6LucDQvhNH/nG1wE5BJnDCQrHAozKGSncDqsDCb//7mGahwHW3YZCVb5HA0BQ/0w43jT0=",
+                    "path": [
+                        "_data",
+                        0,
+                        "y",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                },
+                {
+                    "data": "mf4BbePvm0A=",
+                    "path": [
+                        "_data",
+                        1,
+                        "x",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                },
+                {
+                    "data": "wmVf/AvOw0A=",
+                    "path": [
+                        "_data",
+                        1,
+                        "y",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                }
+            ]
+        },
+        "2bcbb46c1a954ff38967102d72e06b3d": {
+            "model_name": "FigureModel",
+            "model_module": "plotlywidget",
+            "model_module_version": "^0.4.0",
+            "state": {
+                "_data": [
+                    {
+                        "line": {
+                            "color": "rgb(31, 119, 180)",
+                            "dash": "dash",
+                            "width": 2
+                        },
+                        "mode": "lines",
+                        "name": "2000-01-01 12:00",
+                        "x": {
+                            "dtype": "float64",
+                            "shape": [
+                                100
+                            ]
+                        },
+                        "y": {
+                            "dtype": "float64",
+                            "shape": [
+                                100
+                            ]
+                        },
+                        "type": "scatter",
+                        "uid": "45a8b418-e44e-11e8-aa89-a0afbda902ef",
+                        "visible": true
+                    },
+                    {
+                        "marker": {
+                            "color": "rgb(31, 119, 180)",
+                            "size": 10
+                        },
+                        "mode": "markers",
+                        "name": "2000-01-01 12:00",
+                        "x": {
+                            "dtype": "float64",
+                            "shape": [
+                                1
+                            ]
+                        },
+                        "y": {
+                            "dtype": "float64",
+                            "shape": [
+                                1
+                            ]
+                        },
+                        "type": "scatter",
+                        "uid": "45a8b419-e44e-11e8-aa89-a0afbda902ef"
+                    },
+                    {
+                        "type": "scatter",
+                        "uid": "45a8b41a-e44e-11e8-aa89-a0afbda902ef"
+                    }
+                ],
+                "_js2py_relayout": {},
+                "_js2py_update": {},
+                "_last_layout_edit_id": 2,
+                "_last_trace_edit_id": 2,
+                "_layout": {
+                    "autosize": true,
+                    "shapes": [
+                        {
+                            "fillcolor": "#204a87",
+                            "line": {
+                                "color": "#204a87"
+                            },
+                            "opacity": 1,
+                            "type": "circle",
+                            "x0": -6378.1366,
+                            "x1": 6378.1366,
+                            "xref": "x",
+                            "y0": -6378.1366,
+                            "y1": 6378.1366,
+                            "yref": "y"
+                        }
+                    ],
+                    "xaxis": {
+                        "constrain": "domain",
+                        "title": "x (km)"
+                    },
+                    "yaxis": {
+                        "scaleanchor": "x",
+                        "title": "y (km)"
+                    }
+                },
+                "_py2js_addTraces": {},
+                "_py2js_animate": {},
+                "_py2js_deleteTraces": {},
+                "_py2js_moveTraces": {},
+                "_py2js_relayout": {},
+                "_py2js_removeLayoutProps": {},
+                "_py2js_removeTraceProps": {},
+                "_py2js_update": {},
+                "_view_count": 1
+            },
+            "buffers": [
+                {
+                    "data": "/v/////5uUCoVnUScsS5QJDoUn7/I7lAxUspqE0ZuEBOjB56b6W2QJLaikjkybRAYZnTRpaIskBhPTgcscevQO8Rqm/JvKlAPwVFHbD2okCW2vphwfiWQFuTetaDrHpAWKOOjWXVhcB5qIY+mbadwIYszx2Z0qjAeB71d3yoscAAqKx0zSW3wDtxpOOW27zAJha39vphwcCs9e/KaWzEwOGbjoH1icfAO+Dz+We3ysAhKkevevHNwFy+aQxtmtDAaojnixQ/0sCgU4I3AuXTwPbGZSCDitXAQmnax+Qt18AaqSjfds3YwP2hOgWNZ9rAY0ExgID628CdmSXxsYTdwIczVQCLBN/A+////z884MAIESTCiO/gwD6QN/dmm+HAxIjsdCk/4sCGgKZsJ9riwMQGfRnBa+PAhj7tZGDz48BUoJCBeXDkwEp3OXuL4uTAHYzguyBJ5cCi99qEz6PlwJYq21s68uXAXc1MaxA05sC7I6jVDWnmwMMPZ/v7kObAn5ZTs7Gr5sDO3PV0E7nmwM7c9XQTuebAn5ZTs7Gr5sDCD2f7+5DmwLojqNUNaebAW81MaxA05sCVKttbOvLlwKD32oTPo+XAHIzguyBJ5cBKdzl7i+LkwFagkIF5cOTAhD7tZGDz48DCBn0ZwWvjwIWApmwn2uLAx4jsdCk/4sA9kDf3ZpvhwAoRJMKI7+DA+v///z884MCGM1UAiwTfwJqZJfGxhN3AYkExgID628D6oToFjWfawBmpKN92zdjAQGnax+Qt18D0xmUgg4rVwJdTgjcC5dPAaIjnixQ/0sBVvmkMbZrQwCYqR6968c3AN+Dz+We3ysDem46B9YnHwLX178ppbMTAFha39vphwcAlcaTjltu8wPKnrHTNJbfAch71d3yoscBqLM8dmdKowCeohj6Ztp3Ay6KOjWXVhcBVk3rWg6x6QPTa+mHB+JZAYwVFHbD2okD6EapvybypQGI9OByxx69AbpnTRpaIskCZ2opI5Mm0QFKMHnpvpbZAzEspqE0ZuECU6FJ+/yO5QKpWdRJyxLlA/v/////5uUA=",
+                    "path": [
+                        "_data",
+                        0,
+                        "x",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                },
+                {
+                    "data": "ulOlSs8ylz2qt2GQlW+RQOlv//uYZqFAzzKGSncDqkBYQSZwwkKxQNu+E0f+cbVAGDnO6R6LuUBKl7nh6om9QDxdU+4htcBAGlDSdRWUwkCKT7tQ4l/EQL1iOIauFsZA1o/Qw7W2x0DZTqsvSz7JQPcpoiLbq8pAutlYyOz9y0B88a6jIzPNQO6x+vVASs5AK7SaByVCz0CV3UUo6AzQQNd46D8yaNBAAIdPsJKy0EAREC/OvOvQQPYGXax1E9FApmaPWJQp0UAMkZEFAi7RQBltxSK6INFAwwnYYMoB0UDP66SjUtHQQK2SVuGEj9BANhfm7qQ80EAF9l10ELLPQHl4vuMqys5AmOk8N4jCzUCIQbIxOJzMQAsaXjVqWMtAtKEqC2z4yUCtBJqKqH3IQCb4vyOm6cZA6/bITAU+xUCADq7UfnzDQMXEzxzipsFAP/qYdiZ+v0CdfP0PEo67QKB6SyyWgbdAHfycOd9cs0DaipZAZUiuQCJEprfUt6VAXNIO+sEhmkBvBLwk1XGBQM0FvCTVcYHAsNIO+sEhmsBMRKa31LelwAKLlkBlSK7AR/ycOd9cs8C0ekssloG3wLF8/Q8SjrvAU/qYdiZ+v8DPxM8c4qbBwIIOrtR+fMPA9fbITAU+xcAw+L8jpunGwLcEmoqofcjAtqEqC2z4ycATGl41aljLwIpBsjE4nMzAoOk8N4jCzcB/eL7jKsrOwAv2XXQQss/AOhfm7qQ80MCxklbhhI/QwNPrpKNS0dDAxwnYYMoB0cAbbcUiuiDRwAyRkQUCLtHAqGaPWJQp0cD3Bl2sdRPRwBIQL86869DAAIdPsJKy0MDXeOg/MmjQwJbdRSjoDNDAKbSaByVCz8Dqsfr1QErOwHzxrqMjM83AvNlYyOz9y8D4KaIi26vKwNROqy9LPsnA0o/Qw7W2x8C+YjiGrhbGwIRPu1DiX8TAE1DSdRWUwsA5XVPuIbXAwE+XueHqib3ABznO6R6LucDQvhNH/nG1wE5BJnDCQrHAozKGSncDqsDCb//7mGahwHW3YZCVb5HA0BQ/0w43jT0=",
+                    "path": [
+                        "_data",
+                        0,
+                        "y",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                },
+                {
+                    "data": "mf4BbePvm0A=",
+                    "path": [
+                        "_data",
+                        1,
+                        "x",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                },
+                {
+                    "data": "wmVf/AvOw0A=",
+                    "path": [
+                        "_data",
+                        1,
+                        "y",
+                        "value"
+                    ],
+                    "encoding": "base64"
+                }
+            ]
+        }
+    }
+}
+</script>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,3 +1,6 @@
+.. raw:: html
+   :file: embed/molniya.html
+
 poliastro - Astrodynamics in Python
 ===================================
 
@@ -9,10 +12,6 @@ poliastro - Astrodynamics in Python
 in Astrodynamics and Orbital Mechanics, focusing on interplanetary applications.
 It provides a simple and intuitive API and handles physical quantities with
 units.
-
-View `source code`_ of poliastro!
-
-.. _`source code`: https://github.com/poliastro/poliastro
 
 Some of its awesome features are:
 
@@ -28,6 +27,23 @@ Some of its awesome features are:
 
 And more to come!
 
+.. code-block:: python
+
+    from poliastro.examples import molniya
+    from poliastro.plotting import plot
+
+    plot(molniya)
+
+.. raw:: html
+
+   <script type="application/vnd.jupyter.widget-view+json">
+   {
+       "version_major": 2,
+       "version_minor": 0,
+       "model_id": "2bcbb46c1a954ff38967102d72e06b3d"
+   }
+   </script>
+
 poliastro is developed by an open, international community. Release
 announcements and general discussion take place on our `mailing list`_
 and `chat`_.
@@ -36,15 +52,6 @@ and `chat`_.
 .. _`chat`: https://riot.im/app/#/room/#poliastro:matrix.org
 
 .. include:: form.rst
-
-.. figure:: _static/molniya.png
-   :align: right
-   :figwidth: 300
-   :alt: Molniya orbit
-
-   Plot of a `Molniya orbit`_ around the Earth
-   (\\(a = 26600\\,\\mathrm{km}, e = 0.75,
-   i = 63.4 \\mathrm{{}^{\\circ}} \\)).
 
 The `source code`_, `issue tracker`_ and `wiki`_ are hosted on GitHub, and all
 contributions and feedback are more than welcome. You can test poliastro in your
@@ -57,22 +64,8 @@ browser using binder, a cloud Jupyter notebook server:
 .. _`issue tracker`: https://github.com/poliastro/poliastro/issues
 .. _`wiki`: https://github.com/poliastro/poliastro/wiki/
 
-See `benchmarks`_ for the performance analysis of poliastro.
-
-.. _`benchmarks`: https://blog.poliastro.space/poliastro-benchmarks/
-
 poliastro works on recent versions of Python and is released under
 the MIT license, hence allowing commercial use of the library.
-
-.. code-block:: python
-
-    import matplotlib.pyplot as plt
-    plt.ion()
-
-    from poliastro.examples import molniya
-    from poliastro.plotting import plot
-    
-    plot(molniya)
 
 .. include:: success.rst
 

--- a/src/poliastro/plotting/__init__.py
+++ b/src/poliastro/plotting/__init__.py
@@ -1,2 +1,2 @@
-from .interactive import OrbitPlotter2D, OrbitPlotter3D
-from .common import plot, plot3d, plot_solar_system
+from .interactive import OrbitPlotter2D, OrbitPlotter3D, plot, plot3d
+from .common import plot_solar_system

--- a/src/poliastro/plotting/__init__.py
+++ b/src/poliastro/plotting/__init__.py
@@ -1,0 +1,2 @@
+from .interactive import OrbitPlotter2D, OrbitPlotter3D
+from .common import plot, plot3d, plot_solar_system

--- a/src/poliastro/plotting/common.py
+++ b/src/poliastro/plotting/common.py
@@ -38,7 +38,6 @@ def plot_solar_system(outer=True, epoch=None, plotter=OrbitPlotter2D):
         op.plot(orb, label=str(body))
 
     # Sets frame to the orbit of the Earth by default
-    # FIXME: https://github.com/poliastro/poliastro/issues/316
     op.set_frame(*Orbit.from_body_ephem(Earth, epoch).pqw())
 
     return op

--- a/src/poliastro/plotting/common.py
+++ b/src/poliastro/plotting/common.py
@@ -17,27 +17,6 @@ BODY_COLORS = {
 }
 
 
-def plot(state, label=None, color=None, plotter=OrbitPlotter2D):
-    """Quickly plots an :py:class:`~poliastro.twobody.orbit.Orbit`.
-
-    For more advanced tuning, use the :py:class:`OrbitPlotter2D` class
-    and similar ones.
-
-    """
-    op = plotter()
-    op.plot(state, label=label, color=color)
-    return op
-
-
-def plot3d(orbit, *, label=None, color=None):
-    """Plots an :py:class:`~poliastro.twobody.orbit.Orbit` in 3D.
-
-    For more advanced tuning, use the :py:class:`OrbitPlotter3D` class.
-
-    """
-    return plot(orbit, label=label, color=color, plotter=OrbitPlotter3D)
-
-
 def plot_solar_system(outer=True, epoch=None, plotter=OrbitPlotter2D):
     """
     Plots the whole solar system in one single call.

--- a/src/poliastro/plotting/common.py
+++ b/src/poliastro/plotting/common.py
@@ -25,7 +25,8 @@ def plot(state, label=None, color=None, plotter=OrbitPlotter2D):
 
     """
     op = plotter()
-    return op.plot(state, label=label, color=color)
+    op.plot(state, label=label, color=color)
+    return op
 
 
 def plot3d(orbit, *, label=None, color=None):

--- a/src/poliastro/plotting/common.py
+++ b/src/poliastro/plotting/common.py
@@ -1,13 +1,11 @@
 """ Plotting utilities.
 
 """
-from typing import List, Tuple  # flake8: noqa
-
 from poliastro.bodies import (Earth, Jupiter, Mars, Mercury, Neptune, Saturn,
                               Uranus, Venus)
 from poliastro.twobody.orbit import Orbit
 
-from .interactive import OrbitPlotter2D, OrbitPlotter3D
+from .interactive import OrbitPlotter2D
 
 
 BODY_COLORS = {

--- a/src/poliastro/plotting/common.py
+++ b/src/poliastro/plotting/common.py
@@ -1,0 +1,66 @@
+""" Plotting utilities.
+
+"""
+from typing import List, Tuple  # flake8: noqa
+
+from poliastro.bodies import (Earth, Jupiter, Mars, Mercury, Neptune, Saturn,
+                              Uranus, Venus)
+from poliastro.twobody.orbit import Orbit
+
+from .interactive import OrbitPlotter2D, OrbitPlotter3D
+
+
+BODY_COLORS = {
+    "Sun": "#ffcc00",
+    "Earth": "#204a87",
+    "Jupiter": "#ba3821",
+}
+
+
+def plot(state, label=None, color=None, plotter=OrbitPlotter2D):
+    """Quickly plots an :py:class:`~poliastro.twobody.orbit.Orbit`.
+
+    For more advanced tuning, use the :py:class:`OrbitPlotter2D` class
+    and similar ones.
+
+    """
+    op = plotter()
+    return op.plot(state, label=label, color=color)
+
+
+def plot3d(orbit, *, label=None, color=None):
+    """Plots an :py:class:`~poliastro.twobody.orbit.Orbit` in 3D.
+
+    For more advanced tuning, use the :py:class:`OrbitPlotter3D` class.
+
+    """
+    return plot(orbit, label=label, color=color, plotter=OrbitPlotter3D)
+
+
+def plot_solar_system(outer=True, epoch=None, plotter=OrbitPlotter2D):
+    """
+    Plots the whole solar system in one single call.
+
+    .. versionadded:: 0.9.0
+
+    Parameters
+    ------------
+    outer : bool, optional
+        Whether to print the outer Solar System, default to True.
+    epoch: ~astropy.time.Time, optional
+        Epoch value of the plot, default to J2000.
+    """
+    bodies = [Mercury, Venus, Earth, Mars]
+    if outer:
+        bodies.extend([Jupiter, Saturn, Uranus, Neptune])
+
+    op = plotter()
+    for body in bodies:
+        orb = Orbit.from_body_ephem(body, epoch)
+        op.plot(orb, label=str(body))
+
+    # Sets frame to the orbit of the Earth by default
+    # FIXME: https://github.com/poliastro/poliastro/issues/316
+    op.set_frame(*Orbit.from_body_ephem(Earth, epoch).pqw())
+
+    return op

--- a/src/poliastro/plotting/interactive.py
+++ b/src/poliastro/plotting/interactive.py
@@ -8,9 +8,6 @@ import numpy as np
 
 from typing import List, Tuple  # flake8: noqa
 
-import matplotlib as mpl
-import matplotlib.pyplot as plt
-
 import plotly.colors
 from plotly.offline import iplot, plot as export
 from plotly.graph_objs import Scatter3d, Surface, Layout, Scatter
@@ -19,10 +16,6 @@ from astropy import units as u
 from astropy.coordinates import CartesianRepresentation
 
 from poliastro.util import norm
-from poliastro.bodies import (Earth, Jupiter, Mars, Mercury, Neptune, Saturn,
-                              Uranus, Venus)
-from poliastro.twobody.orbit import Orbit
-from poliastro.twobody.propagation import mean_motion
 
 
 BODY_COLORS = {
@@ -32,189 +25,6 @@ BODY_COLORS = {
 }
 
 
-def plot(state, label=None, color=None):
-    """Plots an :py:class:`~poliastro.twobody.orbit.Orbit` in 2D.
-
-    For more advanced tuning, use the :py:class:`OrbitPlotter` class.
-
-    """
-    op = OrbitPlotter()
-    return op.plot(state, label=label, color=color)
-
-
-def plot3d(orbit, *, label=None, color=None):
-    """Plots an :py:class:`~poliastro.twobody.orbit.Orbit` in 3D.
-
-    For more advanced tuning, use the :py:class:`OrbitPlotter3D` class.
-
-    """
-    frame = OrbitPlotter3D()
-    frame.plot(orbit, label=label, color=color)
-    frame.show()
-
-    return frame
-
-
-class OrbitPlotter(object):
-    """OrbitPlotter class.
-
-    This class holds the perifocal plane of the first
-    :py:class:`~poliastro.twobody.orbit.Orbit` plotted in it using
-    :py:meth:`plot`, so all following
-    plots will be projected on that plane. Alternatively, you can call
-    :py:meth:`set_frame` to set the frame before plotting.
-
-    """
-
-    def __init__(self, ax=None, num_points=150, dark=False):
-        """Constructor.
-
-        Parameters
-        ----------
-        ax : ~matplotlib.axes.Axes
-            Axes in which to plot. If not given, new ones will be created.
-        num_points : int, optional
-            Number of points to use in plots, default to 150.
-        dark : bool, optional
-            If set as True, plots the orbit in Dark mode.
-        """
-        self.ax = ax
-        if not self.ax:
-            if dark:
-                with plt.style.context('dark_background'):
-                    _, self.ax = plt.subplots(figsize=(6, 6))
-            else:
-                _, self.ax = plt.subplots(figsize=(6, 6))
-        self.num_points = num_points
-        self._frame = None
-        self._attractor = None
-        self._attractor_radius = np.inf * u.km
-        self._orbits = list(tuple())  # type: List[Tuple[Orbit, str, str]]
-
-    @property
-    def orbits(self):
-        return self._orbits
-
-    def set_frame(self, p_vec, q_vec, w_vec):
-        """Sets perifocal frame.
-
-        Raises
-        ------
-        ValueError
-            If the vectors are not a set of mutually orthogonal unit vectors.
-        """
-        if not np.allclose([norm(v) for v in (p_vec, q_vec, w_vec)], 1):
-            raise ValueError("Vectors must be unit.")
-        elif not np.allclose([p_vec.dot(q_vec),
-                              q_vec.dot(w_vec),
-                              w_vec.dot(p_vec)], 0):
-            raise ValueError("Vectors must be mutually orthogonal.")
-        else:
-            self._frame = p_vec, q_vec, w_vec
-
-        if self._orbits:
-            self._redraw()
-
-    def _redraw(self):
-        for artist in self.ax.lines + self.ax.collections:
-            artist.remove()
-        self._attractor = None
-        for orbit, label, color in self._orbits:
-            self.plot(orbit, label, color)
-        self.ax.relim()
-        self.ax.autoscale()
-
-    def plot_trajectory(self, trajectory, *, label=None, color=None):
-        """Plots a precomputed trajectory.
-
-        Parameters
-        ----------
-        trajectory : ~astropy.coordinates.BaseRepresentation, ~astropy.coordinates.BaseCoordinateFrame
-            Trajectory to plot.
-
-        """
-        lines = []
-        rr = trajectory.represent_as(CartesianRepresentation).xyz.transpose()
-        x, y = self._project(rr)
-        a, = self.ax.plot(x.to(u.km).value, y.to(u.km).value, '--', color=color, label=label)
-        lines.append(a)
-        if label:
-            a.set_label(label)
-            self.ax.legend(bbox_to_anchor=(1.05, 1), title="Names and epochs")
-
-        return lines
-
-    def set_attractor(self, attractor):
-        """Sets plotting attractor.
-
-        Parameters
-        ----------
-        attractor : ~poliastro.bodies.Body
-            Central body.
-
-        """
-        if self._attractor is None:
-            self._attractor = attractor
-
-        elif attractor is not self._attractor:
-            raise NotImplementedError("Attractor has already been set to {}.".format(self._attractor.name))
-
-    def _project(self, rr):
-        rr_proj = rr - rr.dot(self._frame[2])[:, None] * self._frame[2]
-        x = rr_proj.dot(self._frame[0])
-        y = rr_proj.dot(self._frame[1])
-        return x, y
-
-    def _redraw_attractor(self, min_radius=0 * u.km):
-        radius = max(self._attractor.R.to(u.km), min_radius.to(u.km))
-        color = BODY_COLORS.get(self._attractor.name, "#999999")
-
-        for attractor in self.ax.findobj(match=mpl.patches.Circle):
-            attractor.remove()
-
-        if radius < self._attractor_radius:
-            self._attractor_radius = radius
-
-        self.ax.add_patch(mpl.patches.Circle((0, 0), self._attractor_radius.value, lw=0, color=color))
-
-    def plot(self, orbit, label=None, color=None, method=mean_motion):
-        """Plots state and osculating orbit in their plane.
-        """
-        if not self._frame:
-            self.set_frame(*orbit.pqw())
-
-        self.set_attractor(orbit.attractor)
-        self._redraw_attractor(orbit.r_p * 0.15)  # Arbitrary Threshhold
-        positions = orbit.sample(self.num_points, method)
-
-        x0, y0 = self._project(orbit.r[None])
-        # Plot current position
-        l, = self.ax.plot(x0.to(u.km).value, y0.to(u.km).value,
-                          'o', mew=0, color=color)
-
-        if (orbit, label, l.get_color()) not in self._orbits:
-            self._orbits.append((orbit, label, l.get_color()))
-
-        lines = self.plot_trajectory(trajectory=positions, color=l.get_color())
-        lines.append(l)
-
-        if label:
-            # This will apply the label to either the point or the osculating
-            # orbit depending on the last plotted line, as they share variable
-            if not self.ax.get_legend():
-                size = self.ax.figure.get_size_inches() + [8, 0]
-                self.ax.figure.set_size_inches(size)
-            label = _generate_label(orbit, label)
-            l.set_label(label)
-            self.ax.legend(bbox_to_anchor=(1.05, 1), title="Names and epochs")
-
-        self.ax.set_xlabel("$x$ (km)")
-        self.ax.set_ylabel("$y$ (km)")
-        self.ax.set_aspect(1)
-
-        return lines
-
-
 def _generate_label(orbit, label):
     orbit.epoch.out_subfmt = 'date_hm'
     label_ = '{}'.format(orbit.epoch.iso)
@@ -222,6 +32,16 @@ def _generate_label(orbit, label):
         label_ += ' ({})'.format(label)
 
     return label_
+
+
+def _generate_circle(radius, center, num=500):
+    u1 = np.linspace(0, 2 * np.pi, num)
+    x_center, y_center, z_center = center
+
+    xx = x_center + radius * np.cos(u1)
+    yy = y_center + radius * np.sin(u1)
+
+    return xx, yy
 
 
 def _generate_sphere(radius, center, num=20):
@@ -424,16 +244,6 @@ class OrbitPlotter3D(_BaseOrbitPlotter):
         self._data.append(trace)
 
 
-def _generate_circle(radius, center, num=500):
-    u1 = np.linspace(0, 2 * np.pi, num)
-    x_center, y_center, z_center = center
-
-    xx = x_center + radius * np.cos(u1)
-    yy = y_center + radius * np.sin(u1)
-
-    return xx, yy
-
-
 class OrbitPlotter2D(_BaseOrbitPlotter):
     """OrbitPlotter2D class.
 
@@ -493,32 +303,3 @@ class OrbitPlotter2D(_BaseOrbitPlotter):
             mode="lines",  # Boilerplate
         )
         self._data.append(trace)
-
-
-def plot_solar_system(outer=True, epoch=None):
-    """
-    Plots the whole solar system in one single call.
-
-    .. versionadded:: 0.9.0
-
-    Parameters
-    ------------
-    outer : bool, optional
-        Whether to print the outer Solar System, default to True.
-    epoch: ~astropy.time.Time, optional
-        Epoch value of the plot, default to J2000.
-    """
-    bodies = [Mercury, Venus, Earth, Mars]
-    if outer:
-        bodies.extend([Jupiter, Saturn, Uranus, Neptune])
-
-    op = OrbitPlotter()
-    for body in bodies:
-        orb = Orbit.from_body_ephem(body, epoch)
-        op.plot(orb, label=str(body))
-
-    # Sets frame to the orbit of the Earth by default
-    # TODO: Wait until https://github.com/poliastro/poliastro/issues/316
-    # op.set_frame(*Orbit.from_body_ephem(Earth, epoch).pqw())
-
-    return op

--- a/src/poliastro/plotting/interactive.py
+++ b/src/poliastro/plotting/interactive.py
@@ -113,9 +113,6 @@ class _BaseOrbitPlotter:
 
         self._plot_trajectory(trajectory, str(label), color, False)
 
-    def _plot_point(self, radius, color, name, center=[0, 0, 0] * u.km):
-        return self._plot_sphere(radius, color, name, center)
-
     def _plot_trajectory(self, trajectory, label, color, dashed):
         raise NotImplementedError
 
@@ -196,6 +193,12 @@ class OrbitPlotter3D(_BaseOrbitPlotter):
                 aspectmode="data",  # Important!
             ),
         )
+
+    def _plot_point(self, radius, color, name, center=[0, 0, 0] * u.km):
+        # We use _plot_sphere here because it's not easy to specify the size of a marker
+        # in data units instead of pixels, see
+        # https://stackoverflow.com/q/47086547
+        return self._plot_sphere(radius, color, name, center)
 
     def _plot_sphere(self, radius, color, name, center=[0, 0, 0] * u.km):
         xx, yy, zz = _generate_sphere(radius, center)

--- a/src/poliastro/plotting/interactive.py
+++ b/src/poliastro/plotting/interactive.py
@@ -303,3 +303,26 @@ class OrbitPlotter2D(_BaseOrbitPlotter):
             mode="lines",  # Boilerplate
         )
         self._data.append(trace)
+
+
+def plot(state, label=None, color=None, plotter=OrbitPlotter2D):
+    """Quickly plots an :py:class:`~poliastro.twobody.orbit.Orbit`.
+
+    For more advanced tuning, use the :py:class:`OrbitPlotter2D` class
+    and similar ones.
+
+    """
+    op = plotter()
+    op.plot(state, label=label, color=color)
+    op.show()
+
+    return op
+
+
+def plot3d(orbit, *, label=None, color=None):
+    """Plots an :py:class:`~poliastro.twobody.orbit.Orbit` in 3D.
+
+    For more advanced tuning, use the :py:class:`OrbitPlotter3D` class.
+
+    """
+    return plot(orbit, label=label, color=color, plotter=OrbitPlotter3D)

--- a/src/poliastro/plotting/interactive.py
+++ b/src/poliastro/plotting/interactive.py
@@ -136,7 +136,7 @@ class _BaseOrbitPlotter:
 
         self._plot_trajectory(trajectory, label, color, True)
         # Plot required 2D/3D shape in the position of the body
-        radius = min(self._attractor_radius * 0.5, (norm(orbit.r) - orbit.attractor.R) * 0.3)  # Arbitrary thresholds
+        radius = min(self._attractor_radius * 0.5, (norm(orbit.r) - orbit.attractor.R) * 0.5)  # Arbitrary thresholds
         shape = self._plot_point(radius, color, label, center=orbit.r)
         self._data.append(shape)
 

--- a/src/poliastro/plotting/interactive.py
+++ b/src/poliastro/plotting/interactive.py
@@ -34,16 +34,6 @@ def _generate_label(orbit, label):
     return label_
 
 
-def _generate_circle(radius, center, num=500):
-    u1 = np.linspace(0, 2 * np.pi, num)
-    x_center, y_center, z_center = center
-
-    xx = x_center + radius * np.cos(u1)
-    yy = y_center + radius * np.sin(u1)
-
-    return xx, yy
-
-
 def _generate_sphere(radius, center, num=20):
     u1 = np.linspace(0, 2 * np.pi, num)
     v1 = u1.copy()

--- a/src/poliastro/plotting/static.py
+++ b/src/poliastro/plotting/static.py
@@ -186,7 +186,7 @@ class OrbitPlotter(object):
         x0, y0 = self._project(orbit.r[None])
         # Plot current position
         line, = self.ax.plot(x0.to(u.km).value, y0.to(u.km).value,
-                          'o', mew=0, color=color)
+                             'o', mew=0, color=color)
 
         lines = self.plot_trajectory(trajectory=positions, color=line.get_color())
         lines.append(line)

--- a/src/poliastro/plotting/static.py
+++ b/src/poliastro/plotting/static.py
@@ -12,6 +12,7 @@ from astropy import units as u
 from astropy.coordinates import CartesianRepresentation
 
 from poliastro.util import norm
+from poliastro.twobody import Orbit
 from poliastro.twobody.propagation import mean_motion
 
 

--- a/src/poliastro/plotting/static.py
+++ b/src/poliastro/plotting/static.py
@@ -1,0 +1,205 @@
+""" Plotting utilities.
+
+"""
+import numpy as np
+
+from typing import List, Tuple  # flake8: noqa
+
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+
+from astropy import units as u
+from astropy.coordinates import CartesianRepresentation
+
+from poliastro.util import norm
+from poliastro.twobody.propagation import mean_motion
+
+
+BODY_COLORS = {
+    "Sun": "#ffcc00",
+    "Earth": "#204a87",
+    "Jupiter": "#ba3821",
+}
+
+
+def _generate_label(orbit, label):
+    orbit.epoch.out_subfmt = 'date_hm'
+    label_ = '{}'.format(orbit.epoch.iso)
+    if label:
+        label_ += ' ({})'.format(label)
+
+    return label_
+
+
+def _generate_sphere(radius, center, num=20):
+    u1 = np.linspace(0, 2 * np.pi, num)
+    v1 = u1.copy()
+    uu, vv = np.meshgrid(u1, v1)
+
+    x_center, y_center, z_center = center
+
+    xx = x_center + radius * np.cos(uu) * np.sin(vv)
+    yy = y_center + radius * np.sin(uu) * np.sin(vv)
+    zz = z_center + radius * np.cos(vv)
+
+    return xx, yy, zz
+
+
+class OrbitPlotter(object):
+    """OrbitPlotter class.
+
+    This class holds the perifocal plane of the first
+    :py:class:`~poliastro.twobody.orbit.Orbit` plotted in it using
+    :py:meth:`plot`, so all following
+    plots will be projected on that plane. Alternatively, you can call
+    :py:meth:`set_frame` to set the frame before plotting.
+
+    """
+
+    def __init__(self, ax=None, num_points=150, dark=False):
+        """Constructor.
+
+        Parameters
+        ----------
+        ax : ~matplotlib.axes.Axes
+            Axes in which to plot. If not given, new ones will be created.
+        num_points : int, optional
+            Number of points to use in plots, default to 150.
+        dark : bool, optional
+            If set as True, plots the orbit in Dark mode.
+        """
+        self.ax = ax
+        if not self.ax:
+            if dark:
+                with plt.style.context('dark_background'):
+                    _, self.ax = plt.subplots(figsize=(6, 6))
+            else:
+                _, self.ax = plt.subplots(figsize=(6, 6))
+        self.num_points = num_points
+        self._frame = None
+        self._attractor = None
+        self._attractor_radius = np.inf * u.km
+        self._orbits = list(tuple())  # type: List[Tuple[Orbit, str]]
+
+    @property
+    def orbits(self):
+        return self._orbits
+
+    def set_frame(self, p_vec, q_vec, w_vec):
+        """Sets perifocal frame.
+
+        Raises
+        ------
+        ValueError
+            If the vectors are not a set of mutually orthogonal unit vectors.
+        """
+        if not np.allclose([norm(v) for v in (p_vec, q_vec, w_vec)], 1):
+            raise ValueError("Vectors must be unit.")
+        elif not np.allclose([p_vec.dot(q_vec),
+                              q_vec.dot(w_vec),
+                              w_vec.dot(p_vec)], 0):
+            raise ValueError("Vectors must be mutually orthogonal.")
+        else:
+            self._frame = p_vec, q_vec, w_vec
+
+        if self._orbits:
+            self._redraw()
+
+    def _redraw(self):
+        for artist in self.ax.lines + self.ax.collections:
+            artist.remove()
+        self._attractor = None
+        for orbit, label in self._orbits:
+            self.plot(orbit, label)
+        self.ax.relim()
+        self.ax.autoscale()
+
+    def plot_trajectory(self, trajectory, *, label=None, color=None):
+        """Plots a precomputed trajectory.
+
+        Parameters
+        ----------
+        trajectory : ~astropy.coordinates.BaseRepresentation, ~astropy.coordinates.BaseCoordinateFrame
+            Trajectory to plot.
+
+        """
+        lines = []
+        rr = trajectory.represent_as(CartesianRepresentation).xyz.transpose()
+        x, y = self._project(rr)
+        a, = self.ax.plot(x.to(u.km).value, y.to(u.km).value, '--', color=color, label=label)
+        lines.append(a)
+        if label:
+            a.set_label(label)
+            self.ax.legend(bbox_to_anchor=(1.05, 1), title="Names and epochs")
+
+        return lines
+
+    def set_attractor(self, attractor):
+        """Sets plotting attractor.
+
+        Parameters
+        ----------
+        attractor : ~poliastro.bodies.Body
+            Central body.
+
+        """
+        if self._attractor is None:
+            self._attractor = attractor
+
+        elif attractor is not self._attractor:
+            raise NotImplementedError("Attractor has already been set to {}.".format(self._attractor.name))
+
+    def _project(self, rr):
+        rr_proj = rr - rr.dot(self._frame[2])[:, None] * self._frame[2]
+        x = rr_proj.dot(self._frame[0])
+        y = rr_proj.dot(self._frame[1])
+        return x, y
+
+    def _redraw_attractor(self, min_radius=0 * u.km):
+        radius = max(self._attractor.R.to(u.km), min_radius.to(u.km))
+        color = BODY_COLORS.get(self._attractor.name, "#999999")
+
+        for attractor in self.ax.findobj(match=mpl.patches.Circle):
+            attractor.remove()
+
+        if radius < self._attractor_radius:
+            self._attractor_radius = radius
+
+        self.ax.add_patch(mpl.patches.Circle((0, 0), self._attractor_radius.value, lw=0, color=color))
+
+    def plot(self, orbit, label=None, color=None, method=mean_motion):
+        """Plots state and osculating orbit in their plane.
+        """
+        if not self._frame:
+            self.set_frame(*orbit.pqw())
+
+        if (orbit, label) not in self._orbits:
+            self._orbits.append((orbit, label))
+
+        self.set_attractor(orbit.attractor)
+        self._redraw_attractor(orbit.r_p * 0.15)  # Arbitrary Threshhold
+        positions = orbit.sample(self.num_points, method)
+
+        x0, y0 = self._project(orbit.r[None])
+        # Plot current position
+        l, = self.ax.plot(x0.to(u.km).value, y0.to(u.km).value,
+                          'o', mew=0, color=color)
+
+        lines = self.plot_trajectory(trajectory=positions, color=l.get_color())
+        lines.append(l)
+
+        if label:
+            # This will apply the label to either the point or the osculating
+            # orbit depending on the last plotted line, as they share variable
+            if not self.ax.get_legend():
+                size = self.ax.figure.get_size_inches() + [8, 0]
+                self.ax.figure.set_size_inches(size)
+            label = _generate_label(orbit, label)
+            l.set_label(label)
+            self.ax.legend(bbox_to_anchor=(1.05, 1), title="Names and epochs")
+
+        self.ax.set_xlabel("$x$ (km)")
+        self.ax.set_ylabel("$y$ (km)")
+        self.ax.set_aspect(1)
+
+        return lines

--- a/src/poliastro/plotting/static.py
+++ b/src/poliastro/plotting/static.py
@@ -85,6 +85,10 @@ class OrbitPlotter(object):
     def orbits(self):
         return self._orbits
 
+    def _set_legend(self, line, label):
+        line.set_label(label)
+        self.ax.legend(loc="upper left", bbox_to_anchor=(1.05, 1), title="Names and epochs")
+
     def set_frame(self, p_vec, q_vec, w_vec):
         """Sets perifocal frame.
 
@@ -126,11 +130,10 @@ class OrbitPlotter(object):
         lines = []
         rr = trajectory.represent_as(CartesianRepresentation).xyz.transpose()
         x, y = self._project(rr)
-        a, = self.ax.plot(x.to(u.km).value, y.to(u.km).value, '--', color=color, label=label)
-        lines.append(a)
+        line, = self.ax.plot(x.to(u.km).value, y.to(u.km).value, '--', color=color, label=label)
+        lines.append(line)
         if label:
-            a.set_label(label)
-            self.ax.legend(bbox_to_anchor=(1.05, 1), title="Names and epochs")
+            self._set_legend(line, label)
 
         return lines
 
@@ -182,11 +185,11 @@ class OrbitPlotter(object):
 
         x0, y0 = self._project(orbit.r[None])
         # Plot current position
-        l, = self.ax.plot(x0.to(u.km).value, y0.to(u.km).value,
+        line, = self.ax.plot(x0.to(u.km).value, y0.to(u.km).value,
                           'o', mew=0, color=color)
 
-        lines = self.plot_trajectory(trajectory=positions, color=l.get_color())
-        lines.append(l)
+        lines = self.plot_trajectory(trajectory=positions, color=line.get_color())
+        lines.append(line)
 
         if label:
             # This will apply the label to either the point or the osculating
@@ -195,8 +198,7 @@ class OrbitPlotter(object):
                 size = self.ax.figure.get_size_inches() + [8, 0]
                 self.ax.figure.set_size_inches(size)
             label = _generate_label(orbit, label)
-            l.set_label(label)
-            self.ax.legend(bbox_to_anchor=(1.05, 1), title="Names and epochs")
+            self._set_legend(line, label)
 
         self.ax.set_xlabel("$x$ (km)")
         self.ax.set_ylabel("$y$ (km)")

--- a/src/poliastro/plotting/static.py
+++ b/src/poliastro/plotting/static.py
@@ -203,3 +203,13 @@ class OrbitPlotter(object):
         self.ax.set_aspect(1)
 
         return lines
+
+
+def plot(state, label=None, color=None):
+    """Plots an :py:class:`~poliastro.twobody.orbit.Orbit` in 2D.
+
+    For more advanced tuning, use the :py:class:`OrbitPlotter` class.
+
+    """
+    op = OrbitPlotter()
+    return op.plot(state, label=label, color=color)

--- a/src/poliastro/tests/test_plotting.py
+++ b/src/poliastro/tests/test_plotting.py
@@ -10,7 +10,9 @@ from poliastro.bodies import Earth, Mars, Jupiter
 
 from poliastro.twobody.orbit import Orbit
 
-from poliastro.plotting import OrbitPlotter, plot_solar_system
+from poliastro.plotting.static import OrbitPlotter
+from poliastro.plotting.interactive import OrbitPlotter2D
+from poliastro.plotting.common import plot_solar_system
 
 
 def test_orbitplotter_has_axes():
@@ -78,7 +80,7 @@ def test_color():
 ])
 def test_plot_solar_system(outer, expected):
     assert len(plot_solar_system(outer).orbits) == expected
-    assert isinstance(plot_solar_system(), OrbitPlotter)
+    assert isinstance(plot_solar_system(), OrbitPlotter2D)
 
 
 def test_plot_trajectory_sets_label():

--- a/src/poliastro/tests/test_plotting2d.py
+++ b/src/poliastro/tests/test_plotting2d.py
@@ -72,7 +72,7 @@ def test_plot_trajectory_plots_a_trajectory():
     assert frame._attractor == Sun
 
 
-@mock.patch("poliastro.plotting.iplot")
+@mock.patch("poliastro.plotting.interactive.iplot")
 @mock.patch.object(OrbitPlotter2D, '_prepare_plot')
 def test_show_calls_prepare_plot(mock_prepare_plot, mock_iplot):
     m = OrbitPlotter2D()
@@ -84,7 +84,7 @@ def test_show_calls_prepare_plot(mock_prepare_plot, mock_iplot):
     mock_prepare_plot.assert_called_once_with()
 
 
-@mock.patch("poliastro.plotting.export")
+@mock.patch("poliastro.plotting.interactive.export")
 @mock.patch.object(OrbitPlotter2D, '_prepare_plot')
 def test_savefig_calls_prepare_plot(mock_prepare_plot, mock_export):
     m = OrbitPlotter2D()

--- a/src/poliastro/tests/test_plotting3d.py
+++ b/src/poliastro/tests/test_plotting3d.py
@@ -88,7 +88,7 @@ def test_plot_trajectory_plots_a_trajectory():
     assert frame._attractor == Sun
 
 
-@mock.patch("poliastro.plotting.iplot")
+@mock.patch("poliastro.plotting.interactive.iplot")
 @mock.patch.object(OrbitPlotter3D, '_prepare_plot')
 def test_show_calls_prepare_plot(mock_prepare_plot, mock_iplot):
     m = OrbitPlotter3D()
@@ -100,7 +100,7 @@ def test_show_calls_prepare_plot(mock_prepare_plot, mock_iplot):
     mock_prepare_plot.assert_called_once_with()
 
 
-@mock.patch("poliastro.plotting.export")
+@mock.patch("poliastro.plotting.interactive.export")
 @mock.patch.object(OrbitPlotter3D, '_prepare_plot')
 def test_savefig_calls_prepare_plot(mock_prepare_plot, mock_export):
     m = OrbitPlotter3D()


### PR DESCRIPTION
Addresses #338.

Now trying to import OrbitPlotter directly from poliastro.plotting
fails, because it's the "old" backend and users are encouraged to
use OrbitPlotter2D and OrbitPlotter3D instead, which use plotly
and not matplotlib behind the scenes.

This does not address:

* Updates in documentation
* Failing test because OrbitPlotter2D has no set_frame method (#480)
* Test simplification and refactoring (#448 and #447)

Also, notice that #281 should be fixed first.