### PR TITLE
Fix Plotly graphs in Read the Docs once and for all

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
-# Used for beta.mybinder.org
+# Used for beta.mybinder.org and Read the Docs
 https://github.com/poliastro/poliastro/archive/master.zip
+# Fix Plotly graphs, see https://github.com/rtfd/readthedocs.org/issues/4367
+https://github.com/Juanlu001/sphinx_rtd_theme/archive/js-head.zip


### PR DESCRIPTION
Fix #281 for real, once and for all. See https://github.com/rtfd/readthedocs.org/issues/4367 for details.