### PR TITLE
Advance nbconvert

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -118,6 +118,10 @@ intersphinx_mapping = {
 }
 
 #Nbsphinx configuration
+# See https://github.com/jupyter/nbconvert/issues/878#issuecomment-419655951
+# Should not be needed after nbconvert 5.5 is out
+nbsphinx_kernel_name = "python3"
+
 if os.environ.get('READTHEDOCS') == 'True':
     nbsphinx_execute = 'never'
 else:

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
             "pycodestyle",
             "sphinx",
             # "sphinx_rtd_theme",  # Use https://github.com/rtfd/sphinx_rtd_theme/tree/a42c4d74
-            "nbconvert<5.4",
             "nbsphinx",
             "ipython>=5.0",
             "jupyter-client",


### PR DESCRIPTION
We pinned the nbconvert version after we discovered https://github.com/jupyter/nbconvert/issues/878#issuecomment-419655951. However, after removing the use of my fork of sphinx_rtd_theme in #510, it seems that the Plotly plots don't show again. Let's see if this fixes the problem.