### PR TITLE
Plotting docs update

### DIFF
--- a/docs/source/api/safe/bodies.rst
+++ b/docs/source/api/safe/bodies.rst
@@ -1,4 +1,4 @@
-Bodies Module
+Bodies module
 =============
 
 .. automodule:: poliastro.bodies

--- a/docs/source/api/safe/constants.rst
+++ b/docs/source/api/safe/constants.rst
@@ -1,4 +1,4 @@
-Constants Module
+Constants module
 ================
 
 .. automodule:: poliastro.constants

--- a/docs/source/api/safe/plotting/core.rst
+++ b/docs/source/api/safe/plotting/core.rst
@@ -1,5 +1,14 @@
 Core module
 ===========
 
+This module contains the basic classes for plottings in
+2-dimensions and 3-dimensions:
+
+.. graphviz::
+
+   digraph {
+      "poliastro.plotting.core" -> "OrbitPlotter3D", "OrbitPlotter2D" ;
+   }
+
 .. automodule:: poliastro.plotting.core
     :members:

--- a/docs/source/api/safe/plotting/core.rst
+++ b/docs/source/api/safe/plotting/core.rst
@@ -1,0 +1,5 @@
+Core module
+===========
+
+.. automodule:: poliastro.plotting.core
+    :members:

--- a/docs/source/api/safe/plotting/misc.rst
+++ b/docs/source/api/safe/plotting/misc.rst
@@ -1,0 +1,5 @@
+Misc module
+===========
+
+.. automodule:: poliastro.plotting.misc
+    :members:

--- a/docs/source/api/safe/plotting/misc.rst
+++ b/docs/source/api/safe/plotting/misc.rst
@@ -1,5 +1,8 @@
 Misc module
 ===========
 
+The :py:mod:`poliastro.plotting.misc` module contains different
+miscellaneous related to plotting, such as plotting the solar system:
+
 .. automodule:: poliastro.plotting.misc
     :members:

--- a/docs/source/api/safe/plotting/plotting_index.rst
+++ b/docs/source/api/safe/plotting/plotting_index.rst
@@ -1,0 +1,13 @@
+Plotting module
+===============
+
+The :py:mod:`poliastro.plotting` contains a set of submodules in which the basic classes
+and functions afor plotting orbit objects are described.
+
+.. toctree::
+    :maxdepth: 1
+
+    core
+    misc
+    static
+    util

--- a/docs/source/api/safe/plotting/plotting_index.rst
+++ b/docs/source/api/safe/plotting/plotting_index.rst
@@ -2,9 +2,19 @@ Plotting module
 ===============
 
 The :py:mod:`poliastro.plotting` contains a set of submodules in which the basic classes
-and functions afor plotting orbit objects are described.
+and functions afor plotting orbit objects are described. This module contains the following
+submodules:
+
+.. graphviz::
+
+   digraph {
+      "poliastro.plotting" -> "core", "misc", "static", "util";
+   }
+
+
 
 .. toctree::
+    :hidden:
     :maxdepth: 1
 
     core

--- a/docs/source/api/safe/plotting/static.rst
+++ b/docs/source/api/safe/plotting/static.rst
@@ -1,5 +1,10 @@
 Static module
 =============
 
+The :py:mod:`poliastro.plotting.static` module contains the basic
+class `StaticOrbitPlotter` that is used in by other modules of the
+:py:mod:`poliastro.plotting`.
+
+
 .. automodule:: poliastro.plotting.static
     :members:

--- a/docs/source/api/safe/plotting/static.rst
+++ b/docs/source/api/safe/plotting/static.rst
@@ -1,0 +1,5 @@
+Static module
+=============
+
+.. automodule:: poliastro.plotting.static
+    :members:

--- a/docs/source/api/safe/plotting/util.rst
+++ b/docs/source/api/safe/plotting/util.rst
@@ -1,0 +1,5 @@
+Util module
+=============
+
+.. automodule:: poliastro.plotting.util
+    :members:

--- a/docs/source/api/safe/plotting/util.rst
+++ b/docs/source/api/safe/plotting/util.rst
@@ -1,5 +1,10 @@
 Util module
 =============
 
+The :py:mod:`poliastro.plotting.util` module contains some
+utilities such us drawing the circles or spheres to represent
+the different celestial bodies.
+
+
 .. automodule:: poliastro.plotting.util
     :members:

--- a/docs/source/api/safe/safe_index.rst
+++ b/docs/source/api/safe/safe_index.rst
@@ -9,7 +9,7 @@ OOP nature.
 .. graphviz:: 
     
     digraph {
-        "poliastro" -> "twobody", "threebody", "bodies", "neos", "iod", "constants", "coordinates", "examples", "frames",
+        "poliastro" -> "twobody", "threebody", "bodies", "neos", "plotting", "iod", "constants", "coordinates", "examples", "frames",
                        "maneuver"
 
     }
@@ -22,6 +22,7 @@ OOP nature.
     threebody/threebody_index
     bodies
     neos/neos_index
+    plotting/plotting_index
     iod/iod_index
     constants
     coordinates


### PR DESCRIPTION
Due to the new `plotting` module, documentation was out of date. This pull request tries to solve this issue by including all the `rst files` for each of the submodules and following the same structure for the general documentation.

I also modified the `bodies`and `constants` header title. Just changed the `Module` to `module` to make sure all the different sections look the same way. This was my fault in the last PR about documentation.