### PR TITLE
Update plotting documentation

### DIFF
--- a/docs/source/api/safe/plotting.rst
+++ b/docs/source/api/safe/plotting.rst
@@ -1,5 +1,0 @@
-Plotting module
-===============
-
-.. automodule:: poliastro.plotting
-    :members:

--- a/docs/source/api/safe/plotting/plotting_index.rst
+++ b/docs/source/api/safe/plotting/plotting_index.rst
@@ -8,7 +8,7 @@ submodules:
 .. graphviz::
 
    digraph {
-      "poliastro.plotting" -> "core", "misc", "static", "util";
+      "poliastro.plotting" -> "core", "misc", "porkchop", "static", "util";
    }
 
 
@@ -19,5 +19,6 @@ submodules:
 
     core
     misc
+    porkchop
     static
     util

--- a/docs/source/api/safe/plotting/porkchop.rst
+++ b/docs/source/api/safe/plotting/porkchop.rst
@@ -1,0 +1,10 @@
+Porkchop module
+===============
+
+This module contains the function that enables the user to make porkchop plots
+between two `pliastro.bodies.Body` instances. Other parameters to customize the
+plots such us setting the maximum C3 or showing the time lines can be passed to
+this function.
+
+.. automodule:: poliastro.plotting.porkchop
+    :members:

--- a/docs/source/api/safe/safe_index.rst
+++ b/docs/source/api/safe/safe_index.rst
@@ -29,5 +29,4 @@ OOP nature.
     examples
     frames
     maneuver
-    plotting
     util


### PR DESCRIPTION
This PR tries to solve  #531, since there was an `rst` file that I forgot to remove in the last documentation update. It also adds the file associated to the porkchop function.