### PR TITLE
Fix #549: Add a automatic issue closing bot

### DIFF
--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,0 +1,14 @@
+# Configuration for probot-no-response - https://github.com/probot/no-response
+
+# Number of days of inactivity before an Issue is closed for lack of response
+daysUntilClose: 10
+# Label requiring a response
+responseRequiredLabel: Support
+# Comment to post when closing an Issue for lack of response. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed because there has been no response
+  to our request for more information from the original author. With only the
+  information that is currently in the issue, we don't have enough information
+  to take action. Moreover, the problems discussed in the issue may not be 
+  directly from poliastro. If you still face this problem, reopen the issue or
+  comment on it. We would be happy to help again!  

--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,9 +1,9 @@
 # Configuration for probot-no-response - https://github.com/probot/no-response
 
 # Number of days of inactivity before an Issue is closed for lack of response
-daysUntilClose: 10
+daysUntilClose: 14
 # Label requiring a response
-responseRequiredLabel: more-info-needed
+responseRequiredLabel: Support
 # Comment to post when closing an Issue for lack of response. Set to `false` to disable
 closeComment: >
   This issue has been automatically closed because there has been no response

--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -3,7 +3,7 @@
 # Number of days of inactivity before an Issue is closed for lack of response
 daysUntilClose: 10
 # Label requiring a response
-responseRequiredLabel: Support
+responseRequiredLabel: more-info-needed
 # Comment to post when closing an Issue for lack of response. Set to `false` to disable
 closeComment: >
   This issue has been automatically closed because there has been no response


### PR DESCRIPTION
Works when label: `more-info-needed` is present on an issue, and user does not reply in 10 days!