### PR TITLE
Added Virtual Environments to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,12 @@ build
 
 __pycache__/
 .eggs/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/


### PR DESCRIPTION
Since the gitignore did not have any folders for virtual environments ignored by default, I have added the some most used ones.

These have been taken from github's default [python .gitignore](https://github.com/github/gitignore/blob/f731569cfcc1dbe475f2d160e1e1e582c7cfe2a6/Python.gitignore#L91).