### PR TITLE
Changes in orbit_from_name in datacom5.py

### DIFF
--- a/docs/source/examples/Using NEOS package.ipynb
+++ b/docs/source/examples/Using NEOS package.ipynb
@@ -302,8 +302,8 @@
     }
    ],
    "source": [
-    "atira = dastcom5.orbit_from_name(\"atira\")[0]  # NEO\n",
-    "wikipedia = dastcom5.orbit_from_name(\"wikipedia\")[0]  # Asteroid, but not NEO.\n",
+    "atira = dastcom5.orbit_from_name(\"atira\")  # NEO\n",
+    "wikipedia = dastcom5.orbit_from_name(\"wikipedia\")  # Asteroid, but not NEO.\n",
     "\n",
     "frame = OrbitPlotter2D()\n",
     "frame.plot(atira, label=\"Atira (NEO)\")\n",

--- a/src/poliastro/neos/dastcom5.py
+++ b/src/poliastro/neos/dastcom5.py
@@ -339,7 +339,7 @@ def orbit_from_name(name):
     orbits = []
     for record in records:
         orbits.append(orbit_from_record(record))
-    return orbits
+    return orbits[0]
 
 
 def orbit_from_record(record):


### PR DESCRIPTION

According to  `orbit_from_name`  function description
```python
"""Return :py:class:`~poliastro.twobody.orbit.Orbit` given a name.
Retrieve info from JPL DASTCOM5 database.
Parameters
----------
name : str
NEO name.
Returns
-------
orbit : list (~poliastro.twobody.orbit.Orbit)
NEO orbits.
"""
```
it returns poliastro.twobody.orbit.Orbit class . It actually returns a list of class objects that needs to be indexed while retrieving the orbit from that list in order to plot.
Plotting the orbit without indexing the value returned by orbit_from_name is producing following error. Traceback has been provided below.

Traceback (most recent call last):

*File "/Users/pswaldia1/poliastro/src/poliastro/neos/dastcom5.py",* line *595, in < module >*
*frame.plot(orbit_from_name('Atira'))*
*File "/anaconda3/envs/virtual_platform/lib/python3.5/site*
*packages/poliastro/plotting/static.py", line 216, in plot*
*self.set_frame(*orbit.pqw())*
*AttributeError: 'list' object has no attribute 'pqw'*

According to me there is no requirement of sending the list since we are only returning one orbit at a time . This pull request solves this by returning already indexed list containing a single orbit class (in the function iteself).This would be more convenient for the users as it was for me.