### PR TITLE
Update information on required packages

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -4,16 +4,15 @@ Getting started
 Requirements
 ------------
 
-poliastro requires the following Python packages:
+poliastro requires a number of Python packages, notably:
 
-* NumPy, for basic numerical routines
 * Astropy, for physical units and time handling
-* numba (optional), for accelerating the code
+* NumPy, for basic numerical routines
 * jplephem, for the planetary ephemerides using SPICE kernels
-* Plotly, for interactive orbit plotting
 * matplotlib, for static orbit plotting
+* numba (when using CPython), for accelerating the code
+* Plotly, for interactive orbit plotting
 * SciPy, for root finding and numerical propagation
-* pytest, for running the tests from the package
 
 poliastro is usually tested on Linux, Windows and OS X on Python
 3.5, 3.6 and 3.7 against latest NumPy.
@@ -95,7 +94,9 @@ If you face any further issues, you can refer to the `installation guide by Plot
 Testing
 -------
 
-If installed correctly, the tests can be run using pytest::
+If you want to test poliastro after installing it, you should also install
+pytest with either ``conda install pytest`` or ``pip install pytest``. Then
+you can run the tests to verify everything is working::
 
   $ python -c "import poliastro.testing; poliastro.testing.test()"
   ===================================== test session starts =====================================
@@ -106,6 +107,6 @@ If installed correctly, the tests can be run using pytest::
   ========= 738 passed, 3 skipped, 5 xfailed, 1 xpassed, 13 warnings in 392.12 seconds ==========
   $
 
-If for some reason any test fails, please report it in the `issue tracker`_.
+If for some reason any test fails, please report it with details of your environment in the `issue tracker`_.
 
 .. _`issue tracker`: https://github.com/poliastro/poliastro/issues

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,10 @@ with open(os.path.join("src", "poliastro", "__init__.py")) as fp:
     exec(fp.read(), version)
 
 
+with open("README.rst", encoding="utf-8") as fp:
+    long_description = fp.read()
+
+
 # http://blog.ionelmc.ro/2014/05/25/python-packaging/
 setup(
     name="poliastro",
@@ -30,34 +34,34 @@ setup(
     ],
     python_requires=">=3.5",
     install_requires=[
-        "numpy",
         "astropy>=3.1,<4.*",
-        "matplotlib>=2.0,!=3.0.1",
-        "jplephem",
-        "scipy>=1.0",
+        "astroquery>=0.3.8",
         "beautifulsoup4>=4.5.3",
+        "jplephem",
+        "matplotlib>=2.0,!=3.0.1",
         "numba>=0.39 ; implementation_name=='cpython'",
-        "requests",
+        "numpy",
         "pandas",
         "plotly>=3.6,<4.*",
-        "astroquery>=0.3.8",
+        "requests",
+        "scipy>=1.0",
     ],
     extras_require={
         "jupyter": ["notebook", "ipywidgets>=7.0"],
         "dev": [
             "black ; python_version>='3.6'",
             "coverage",
+            "ipykernel",
+            "ipython>=5.0",
+            "ipywidgets>=7.0",
             "isort",
-            "pytest>=3.2",
-            "pytest-cov<2.6.0",
+            "jupyter-client",
+            "nbsphinx",
             "pycodestyle",
+            "pytest-cov<2.6.0",
+            "pytest>=3.2",
             "sphinx",
             # "sphinx_rtd_theme",  # Use https://github.com/Juanlu001/sphinx_rtd_theme/archive/js-head.zip
-            "nbsphinx",
-            "ipython>=5.0",
-            "jupyter-client",
-            "ipykernel",
-            "ipywidgets>=7.0",
         ],
     },
     packages=find_packages("src"),
@@ -79,7 +83,7 @@ setup(
         "Topic :: Scientific/Engineering :: Physics",
         "Topic :: Scientific/Engineering :: Astronomy",
     ],
-    long_description=open("README.rst", encoding="utf-8").read(),
+    long_description=long_description,
     include_package_data=True,
     zip_safe=False,
 )


### PR DESCRIPTION
* Alphabetize lists so they are easier to compare
* Stop mentioning pytest in the list of required packages, since it is optional. Instead mention it in the testing section, for those users that want to run the tests.
* Avoid leaving file handle open when getting `long_description` in `setup.py`