### PR TITLE
Revert rtd fork

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
             pip install numpy --quiet
             pip install . --quiet
             pip install .[dev] --quiet
-            pip install https://github.com/Juanlu001/sphinx_rtd_theme/archive/js-head.zip
+            pip install https://github.com/rtfd/sphinx_rtd_theme/archive/a42c4d74fec660835393a4c9b1e7cb9e654ccc90.zip
 
       - run:
           name: run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,6 @@ jobs:
             pip install numpy --quiet
             pip install . --quiet
             pip install .[dev] --quiet
-            pip install https://github.com/rtfd/sphinx_rtd_theme/archive/a42c4d74fec660835393a4c9b1e7cb9e654ccc90.zip
 
       - run:
           name: run tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 # Used for beta.mybinder.org and Read the Docs
 https://github.com/poliastro/poliastro/archive/master.zip
 # Fix Plotly graphs, see https://github.com/rtfd/readthedocs.org/issues/4367
-https://github.com/rtfd/sphinx_rtd_theme/archive/a42c4d74fec660835393a4c9b1e7cb9e654ccc90.zip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # Used for beta.mybinder.org and Read the Docs
 https://github.com/poliastro/poliastro/archive/master.zip
 # Fix Plotly graphs, see https://github.com/rtfd/readthedocs.org/issues/4367
-https://github.com/Juanlu001/sphinx_rtd_theme/archive/js-head.zip
+https://github.com/rtfd/sphinx_rtd_theme/archive/a42c4d74fec660835393a4c9b1e7cb9e654ccc90.zip

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
             "pytest-cov<2.6.0",
             "pytest>=3.2",
             "sphinx",
-            # "sphinx_rtd_theme",  # Use https://github.com/rtfd/sphinx_rtd_theme/tree/a42c4d74
+            "sphinx_rtd_theme>=0.4.3",
         ],
     },
     packages=find_packages("src"),

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
             "pytest-cov<2.6.0",
             "pytest>=3.2",
             "sphinx",
-            # "sphinx_rtd_theme",  # Use https://github.com/Juanlu001/sphinx_rtd_theme/archive/js-head.zip
+            # "sphinx_rtd_theme",  # Use https://github.com/rtfd/sphinx_rtd_theme/tree/a42c4d74
         ],
     },
     packages=find_packages("src"),


### PR DESCRIPTION
This tries to solve #579. The `.js` were keep as said in this issue.