### PR TITLE
Prefer wheels in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            python3 -m pip install tox --quiet
+            python3 -m pip install tox
 
       - run:
           name: check quality
@@ -37,8 +37,8 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install --upgrade pip
-            pip install . --quiet
-            pip install .[dev] --quiet
+            pip install .
+            pip install .[dev]
 
       - run:
           name: run tests
@@ -74,7 +74,7 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install --upgrade pip
-            pip install --editable .[dev] --quiet
+            pip install --editable .[dev]
 
       - run:
           name: run coverage
@@ -86,7 +86,7 @@ jobs:
           name: publish coverage
           command: |
             . venv/bin/activate
-            pip install codecov --quiet
+            pip install codecov
             codecov
 
   docs:
@@ -108,7 +108,7 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install --upgrade pip
-            pip install .[dev] --quiet
+            pip install .[dev]
             pip install https://github.com/Juanlu001/sphinx_rtd_theme/archive/js-head.zip
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,9 @@ jobs:
 
     working_directory: ~/repo
 
+    environment:
+      PIP_PREFER_BINARY: true
+
     steps:
       - checkout
 
@@ -59,6 +62,9 @@ jobs:
 
     working_directory: ~/repo
 
+    environment:
+      PIP_PREFER_BINARY: true
+
     steps:
       - checkout
 
@@ -88,6 +94,9 @@ jobs:
       - image: circleci/python:3.6
 
     working_directory: ~/repo
+
+    environment:
+      PIP_PREFER_BINARY: true
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
+            pip install --upgrade pip
             pip install numpy --quiet
             pip install . --quiet
             pip install .[dev] --quiet
@@ -73,6 +74,7 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
+            pip install --upgrade pip
             pip install numpy --quiet
             pip install --editable .[dev] --quiet
 
@@ -107,6 +109,7 @@ jobs:
             sudo apt update && sudo apt install --no-install-recommends pandoc texlive texlive-latex-extra texlive-fonts-recommended dvipng graphviz
             python3 -m venv venv
             . venv/bin/activate
+            pip install --upgrade pip
             pip install .[dev] --quiet
             pip install https://github.com/Juanlu001/sphinx_rtd_theme/archive/js-head.zip
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,6 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install --upgrade pip
-            pip install numpy --quiet
             pip install . --quiet
             pip install .[dev] --quiet
 
@@ -75,7 +74,6 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install --upgrade pip
-            pip install numpy --quiet
             pip install --editable .[dev] --quiet
 
       - run:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,8 +31,8 @@ install:
   # Install dependencies
   - "choco install pandoc"
 
-  - "%PIP_BIN% install numpy"
-  - "%PIP_BIN% install .[dev]"  # Test installation correctness
+  - "%PYTHON_BIN% -m pip install --upgrade pip"
+  - "%PIP_BIN% install .[dev] --prefer-binary"  # Test installation correctness
 
 build: off
 


### PR DESCRIPTION
This avoids CI failures when there is a new version of a dependency but the wheel was not uploaded to PyPI.