### PR TITLE
Improve error message for Orbit.from_body_ephem(Pluto)

### DIFF
--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -369,54 +369,50 @@ class Orbit(object):
     @classmethod
     def from_body_ephem(cls, body, epoch=None):
         """Return osculating `Orbit` of a body at a given time."""
+
         # TODO: https://github.com/poliastro/poliastro/issues/445
+
         if body.name == "Pluto":
             raise NotImplementedError(
                 """Default Ephemeris selected. To change it, please do
+                >>> solar_system_ephemeris.set('de432s')"""
+            )
 
-            >>> solar_system_ephemeris.set('de432s')
+        if not epoch:
+            epoch = time.Time.now().tdb
 
-            """
+        elif epoch.scale != "tdb":
+            epoch = epoch.tdb
+            warn(
+                "Input time was converted to scale='tdb' with value "
+                "{}. Use Time(..., scale='tdb') instead.".format(epoch.tdb.value),
+                TimeScaleWarning,
+            )
+
+        r, v = get_body_barycentric_posvel(body.name, epoch)
+
+        if body == Moon:
+            # TODO: The attractor is in fact the Earth-Moon Barycenter
+            icrs_cart = r.with_differentials(v.represent_as(CartesianDifferential))
+            gcrs_cart = (
+                ICRS(icrs_cart)
+                .transform_to(GCRS(obstime=epoch))
+                .represent_as(CartesianRepresentation)
+            )
+            ss = cls.from_vectors(
+                Earth,
+                gcrs_cart.xyz.to(u.km),
+                gcrs_cart.differentials["s"].d_xyz.to(u.km / u.day),
+                epoch,
             )
 
         else:
-            if not epoch:
-                epoch = time.Time.now().tdb
+            # TODO: The attractor is not really the Sun, but the Solar System
+            # Barycenter
+            ss = cls.from_vectors(Sun, r.xyz.to(u.km), v.xyz.to(u.km / u.day), epoch)
+            ss._frame = ICRS()  # Hack!
 
-            elif epoch.scale != "tdb":
-                epoch = epoch.tdb
-                warn(
-                    "Input time was converted to scale='tdb' with value "
-                    "{}. Use Time(..., scale='tdb') instead.".format(epoch.tdb.value),
-                    TimeScaleWarning,
-                )
-
-            r, v = get_body_barycentric_posvel(body.name, epoch)
-
-            if body == Moon:
-                # TODO: The attractor is in fact the Earth-Moon Barycenter
-                icrs_cart = r.with_differentials(v.represent_as(CartesianDifferential))
-                gcrs_cart = (
-                    ICRS(icrs_cart)
-                    .transform_to(GCRS(obstime=epoch))
-                    .represent_as(CartesianRepresentation)
-                )
-                ss = cls.from_vectors(
-                    Earth,
-                    gcrs_cart.xyz.to(u.km),
-                    gcrs_cart.differentials["s"].d_xyz.to(u.km / u.day),
-                    epoch,
-                )
-
-            else:
-                # TODO: The attractor is not really the Sun, but the Solar System
-                # Barycenter
-                ss = cls.from_vectors(
-                    Sun, r.xyz.to(u.km), v.xyz.to(u.km / u.day), epoch
-                )
-                ss._frame = ICRS()  # Hack!
-
-            return ss
+        return ss
 
     @classmethod
     def from_horizons(

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -4,12 +4,12 @@ import numpy as np
 from astropy import time, units as u
 from astropy.coordinates import (
     GCRS,
-    solar_system_ephemeris,
     ICRS,
     Angle,
     CartesianDifferential,
     CartesianRepresentation,
     get_body_barycentric_posvel,
+    solar_system_ephemeris,
 )
 from astroquery.jplhorizons import Horizons
 from astroquery.jplsbdb import SBDB
@@ -374,8 +374,16 @@ class Orbit(object):
         """
         # TODO: https://github.com/poliastro/poliastro/issues/445
         if body.name.lower() not in solar_system_ephemeris.bodies:
-            error_message="Wrong ephemeris selected, cannot load " + str(body.name) + " data, as " + str(body.name) + " is not a part of selected ephemeris. "  
-            error_message+="Do run this command before calling from_body_ephem ------> solar_system_ephemeris.set('XXXXX') ------> where XXXXX contains the ephemeris having " + str(body.name) + " as one of its objects"
+            error_message = (
+                "Wrong ephemeris selected, cannot load "
+                + str(body.name)
+                + " data, as "
+                + str(body.name)
+                + " is not a part of selected ephemeris. Do run this command before calling from_body_ephem ------> solar_system_ephemeris.set('XXXXX') ------> where XXXXX contains the ephemeris having "
+                + str(body.name)
+                + " as one of its objects"
+            )
+
             raise KeyError(error_message)
         else:
             if not epoch:
@@ -408,12 +416,12 @@ class Orbit(object):
             else:
                 # TODO: The attractor is not really the Sun, but the Solar System
                 # Barycenter
-                ss = cls.from_vectors(Sun, r.xyz.to(u.km), v.xyz.to(u.km / u.day), epoch)
+                ss = cls.from_vectors(
+                    Sun, r.xyz.to(u.km), v.xyz.to(u.km / u.day), epoch
+                )
                 ss._frame = ICRS()  # Hack!
 
             return ss
-            
-
 
     @classmethod
     def from_horizons(

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -379,11 +379,8 @@ class Orbit(object):
             and body.name.lower() not in solar_system_ephemeris.bodies
         ):
             raise KeyError(
-                """These bodies can not be found in the "builtin" ephemeris. Please change the ephemeris.
-                >>> from astropy.coordinates import solar_system_ephemeris
+                """These bodies can not be found in the "builtin" ephemeris. Tochange the ephemeri,. do
                 >>> solar_system_ephemeris.set('jpl')"""
-
-                >>> solar_system_ephemeris.set('de432s')"""
             )
 
         if not epoch:

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -374,7 +374,9 @@ class Orbit(object):
         """
         # TODO: https://github.com/poliastro/poliastro/issues/445
         if body.name.lower() not in solar_system_ephemeris.bodies:
-            raise KeyError("Wrong ephemeris selected, cannot load " + str(body.name) + " data as " + str(body.name) + " is not a part of selected ephemeris")
+            error_message="Wrong ephemeris selected, cannot load " + str(body.name) + " data, as " + str(body.name) + " is not a part of selected ephemeris. "  
+            error_message+="Do run this command before calling from_body_ephem ------> solar_system_ephemeris.set('XXXXX') ------> where XXXXX contains the ephemeris having " + str(body.name) + " as one of its objects"
+            raise KeyError(error_message)
         else:
             if not epoch:
                 epoch = time.Time.now().tdb

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -379,7 +379,7 @@ class Orbit(object):
             and body.name.lower() not in solar_system_ephemeris.bodies
         ):
             raise KeyError(
-                """These bodies can not be found in the "builtin" ephemeris. Tochange the ephemeri,. do
+                """These bodies can not be found in the "builtin" ephemeris. To change the ephemeris, do
                 >>> solar_system_ephemeris.set('jpl')"""
             )
 

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -369,9 +369,7 @@ class Orbit(object):
 
     @classmethod
     def from_body_ephem(cls, body, epoch=None):
-        """Return osculating `Orbit` of a body at a given time.
-
-        """
+        """Return osculating `Orbit` of a body at a given time."""
         # TODO: https://github.com/poliastro/poliastro/issues/445
         if body.name.lower() not in solar_system_ephemeris.bodies:
             error_message = (
@@ -383,7 +381,6 @@ class Orbit(object):
                 + str(body.name)
                 + " as one of its objects"
             )
-
             raise KeyError(error_message)
         else:
             if not epoch:
@@ -395,9 +392,7 @@ class Orbit(object):
                     "{}. Use Time(..., scale='tdb') instead.".format(epoch.tdb.value),
                     TimeScaleWarning,
                 )
-
             r, v = get_body_barycentric_posvel(body.name, epoch)
-
             if body == Moon:
                 # TODO: The attractor is in fact the Earth-Moon Barycenter
                 icrs_cart = r.with_differentials(v.represent_as(CartesianDifferential))
@@ -412,7 +407,6 @@ class Orbit(object):
                     gcrs_cart.differentials["s"].d_xyz.to(u.km / u.day),
                     epoch,
                 )
-
             else:
                 # TODO: The attractor is not really the Sun, but the Solar System
                 # Barycenter

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -9,6 +9,7 @@ from astropy.coordinates import (
     CartesianDifferential,
     CartesianRepresentation,
     get_body_barycentric_posvel,
+    solar_system_ephemeris,
 )
 from astroquery.jplhorizons import Horizons
 from astroquery.jplsbdb import SBDB
@@ -372,7 +373,7 @@ class Orbit(object):
 
         # TODO: https://github.com/poliastro/poliastro/issues/445
 
-        if body.name == "Pluto":
+        if (body.name == "Pluto" and body.name.lower() not in solar_system_ephemeris.bodies):
             raise NotImplementedError(
                 """Default Ephemeris selected. To change it, please do
                 >>> solar_system_ephemeris.set('de432s')"""

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -378,7 +378,7 @@ class Orbit(object):
             body.name == "Pluto"
             and body.name.lower() not in solar_system_ephemeris.bodies
         ):
-            raise NotImplementedError(
+            raise KeyError(
                 """Default Ephemeris selected. To change it, please do
                 >>> solar_system_ephemeris.set('de432s')"""
             )

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -4,6 +4,7 @@ import numpy as np
 from astropy import time, units as u
 from astropy.coordinates import (
     GCRS,
+    solar_system_ephemeris,
     ICRS,
     Angle,
     CartesianDifferential,
@@ -372,7 +373,9 @@ class Orbit(object):
 
         """
         # TODO: https://github.com/poliastro/poliastro/issues/445
-        try:    
+        if body.name.lower() not in solar_system_ephemeris.bodies:
+            raise KeyError("Wrong ephemeris selected, cannot load " + str(body.name) + " data as " + str(body.name) + " is not a part of selected ephemeris")
+        else:
             if not epoch:
                 epoch = time.Time.now().tdb
             elif epoch.scale != "tdb":
@@ -407,9 +410,7 @@ class Orbit(object):
                 ss._frame = ICRS()  # Hack!
 
             return ss
-        except KeyError:
-            import sys
-            sys.exit("new error message here")
+            
 
 
     @classmethod

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -372,40 +372,45 @@ class Orbit(object):
 
         """
         # TODO: https://github.com/poliastro/poliastro/issues/445
-        if not epoch:
-            epoch = time.Time.now().tdb
-        elif epoch.scale != "tdb":
-            epoch = epoch.tdb
-            warn(
-                "Input time was converted to scale='tdb' with value "
-                "{}. Use Time(..., scale='tdb') instead.".format(epoch.tdb.value),
-                TimeScaleWarning,
-            )
+        try:    
+            if not epoch:
+                epoch = time.Time.now().tdb
+            elif epoch.scale != "tdb":
+                epoch = epoch.tdb
+                warn(
+                    "Input time was converted to scale='tdb' with value "
+                    "{}. Use Time(..., scale='tdb') instead.".format(epoch.tdb.value),
+                    TimeScaleWarning,
+                )
 
-        r, v = get_body_barycentric_posvel(body.name, epoch)
+            r, v = get_body_barycentric_posvel(body.name, epoch)
 
-        if body == Moon:
-            # TODO: The attractor is in fact the Earth-Moon Barycenter
-            icrs_cart = r.with_differentials(v.represent_as(CartesianDifferential))
-            gcrs_cart = (
-                ICRS(icrs_cart)
-                .transform_to(GCRS(obstime=epoch))
-                .represent_as(CartesianRepresentation)
-            )
-            ss = cls.from_vectors(
-                Earth,
-                gcrs_cart.xyz.to(u.km),
-                gcrs_cart.differentials["s"].d_xyz.to(u.km / u.day),
-                epoch,
-            )
+            if body == Moon:
+                # TODO: The attractor is in fact the Earth-Moon Barycenter
+                icrs_cart = r.with_differentials(v.represent_as(CartesianDifferential))
+                gcrs_cart = (
+                    ICRS(icrs_cart)
+                    .transform_to(GCRS(obstime=epoch))
+                    .represent_as(CartesianRepresentation)
+                )
+                ss = cls.from_vectors(
+                    Earth,
+                    gcrs_cart.xyz.to(u.km),
+                    gcrs_cart.differentials["s"].d_xyz.to(u.km / u.day),
+                    epoch,
+                )
 
-        else:
-            # TODO: The attractor is not really the Sun, but the Solar System
-            # Barycenter
-            ss = cls.from_vectors(Sun, r.xyz.to(u.km), v.xyz.to(u.km / u.day), epoch)
-            ss._frame = ICRS()  # Hack!
+            else:
+                # TODO: The attractor is not really the Sun, but the Solar System
+                # Barycenter
+                ss = cls.from_vectors(Sun, r.xyz.to(u.km), v.xyz.to(u.km / u.day), epoch)
+                ss._frame = ICRS()  # Hack!
 
-        return ss
+            return ss
+        except KeyError:
+            import sys
+            sys.exit("new error message here")
+
 
     @classmethod
     def from_horizons(

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -379,7 +379,10 @@ class Orbit(object):
             and body.name.lower() not in solar_system_ephemeris.bodies
         ):
             raise KeyError(
-                """Default Ephemeris selected. To change it, please do
+                """These bodies can not be found in the "builtin" ephemeris. Please change the ephemeris.
+                >>> from astropy.coordinates import solar_system_ephemeris
+                >>> solar_system_ephemeris.set('jpl')"""
+
                 >>> solar_system_ephemeris.set('de432s')"""
             )
 

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -369,11 +369,15 @@ class Orbit(object):
 
     @classmethod
     def from_body_ephem(cls, body, epoch=None):
+
         """Return osculating `Orbit` of a body at a given time."""
 
         # TODO: https://github.com/poliastro/poliastro/issues/445
 
-        if (body.name == "Pluto" and body.name.lower() not in solar_system_ephemeris.bodies):
+        if (
+            body.name == "Pluto"
+            and body.name.lower() not in solar_system_ephemeris.bodies
+        ):
             raise NotImplementedError(
                 """Default Ephemeris selected. To change it, please do
                 >>> solar_system_ephemeris.set('de432s')"""


### PR DESCRIPTION
as per issue #401 
I have changed the error message which appear when Orbit.from_body_ephem(Object) runs with the name  of the Object which is not there in the selected Ephemeris

such as pluto is not there in the default ephemeris,
so now it shows the following error message
 -----------------------------------------------------------------------------------------------

KeyError - Wrong ephemeris selected, cannot load Pluto data, as Pluto is not a part of selected ephemeris. Do run this command before calling from_body_ephem ------> solar_system_ephemeris.set ('XXXXX') ------> where XXXXX contains the ephemeris having Pluto as one of its objects"


-----------------------------------------------------------------------------------------------------
 pls review #401 