### PR TITLE
Tox for testing: docs, py3X and coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,10 @@ jobs:
 
     working_directory: ~/repo
 
+    environment:
+      PIP_PREFER_BINARY: true
+      PIP_PROGRESS_BAR: off
+
     steps:
       - checkout
 
@@ -27,6 +31,7 @@ jobs:
 
     environment:
       PIP_PREFER_BINARY: true
+      PIP_PROGRESS_BAR: off
 
     steps:
       - checkout
@@ -64,6 +69,7 @@ jobs:
 
     environment:
       PIP_PREFER_BINARY: true
+      PIP_PROGRESS_BAR: off
 
     steps:
       - checkout
@@ -97,6 +103,7 @@ jobs:
 
     environment:
       PIP_PREFER_BINARY: true
+      PIP_PROGRESS_BAR: off
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
 
     environment:
       PIP_PREFER_BINARY: true
-      PIP_PROGRESS_BAR: off
+      PIP_PROGRESS_BAR: "off"
 
     steps:
       - checkout
@@ -31,7 +31,7 @@ jobs:
 
     environment:
       PIP_PREFER_BINARY: true
-      PIP_PROGRESS_BAR: off
+      PIP_PROGRESS_BAR: "off"
 
     steps:
       - checkout
@@ -69,7 +69,7 @@ jobs:
 
     environment:
       PIP_PREFER_BINARY: true
-      PIP_PROGRESS_BAR: off
+      PIP_PROGRESS_BAR: "off"
 
     steps:
       - checkout
@@ -103,7 +103,7 @@ jobs:
 
     environment:
       PIP_PREFER_BINARY: true
-      PIP_PROGRESS_BAR: off
+      PIP_PROGRESS_BAR: "off"
 
     steps:
       - checkout

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,40 +1,45 @@
-# The only current way of using OS X virtual machines in Travis CI
-# is setting up a generic environment
-# This is not a problem because Python will be installed through conda
-
-language: generic
-os: osx
-
-branches:
-  only:
-    - master
-    - 0.3.x
-    - 0.4.x
-    - 0.5.x
-    - 0.6.x
-    - 0.7.x
-    - 0.8.x
-    - 0.9.x
-    - 0.10.x
-    - 0.11.x
-    - 0.12.x
-
+language: python
+dist: xenial
 env:
   global:
-    - MPLBACKEND="Agg"
-
+    - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
+    - SEGFAULT_SIGNALS=all
+matrix:
+  include:
+    - python: '3.6'
+      env:
+        - TOXENV=check
+    - python: '3.6'
+      env:
+        - TOXENV=docs
+    - python: '3.5'
+      env:
+        - TOXENV=py35,report,codecov
+    - python: '3.6'
+      env:
+        - TOXENV=py36,report,codecov
+    - python: '3.7'
+      env:
+        - TOXENV=py37,report,codecov
+    - python: 'pypy3.5-6.0'
+      env:
+        - TOXENV=pypy3,report,codecov
 before_install:
-  - HOMEBREW_NO_AUTO_UPDATE=1 brew install python3
-  - python3 -m venv venv
-  - source venv/bin/activate
-  - python3 -m pip install --upgrade pip
-
+  - python --version
+  - uname -a
+  - lsb_release -a
 install:
-  - pip install numpy  # Required
-  - pip install .  # Test installation correctness
-  - pip install .[dev]  # Test development dependencies
-
+  - pip install tox
+  - virtualenv --version
+  - easy_install --version
+  - pip --version
+  - tox --version
 script:
-  - pytest -vv  # Test against installed code
-
-sudo: false
+  - tox -v
+after_failure:
+  - more .tox/log/* | cat
+  - more .tox/*/log/* | cat
+notifications:
+  email:
+    on_success: always
+    on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
-language: python
-dist: xenial
-env:
-  global:
-    - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
-    - SEGFAULT_SIGNALS=all
+# The only current way of using OS X virtual machines in Travis CI
+# is setting up a generic environment
+# This is not a problem because Python will be installed through conda
+
+language: generic
+ox: osx
 matrix:
   include:
     - python: '3.6'
@@ -14,16 +14,16 @@ matrix:
         - TOXENV=docs
     - python: '3.5'
       env:
-        - TOXENV=py35,report,codecov
+        - TOXENV=py35
     - python: '3.6'
       env:
-        - TOXENV=py36,report,codecov
+        - TOXENV=py36
     - python: '3.7'
       env:
-        - TOXENV=py37,report,codecov
+        - TOXENV=py37
     - python: 'pypy3.5-6.0'
       env:
-        - TOXENV=pypy3,report,codecov
+        - TOXENV=pypy3
 before_install:
   - python --version
   - uname -a
@@ -35,11 +35,4 @@ install:
   - pip --version
   - tox --version
 script:
-  - tox -v
-after_failure:
-  - more .tox/log/* | cat
-  - more .tox/*/log/* | cat
-notifications:
-  email:
-    on_success: always
-    on_failure: always
+  - tox

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,46 +21,25 @@ branches:
 environment:
   matrix:
     - TOXENV: check
-      TOXPYTHON: C:\Python36\python.exe
-      PYTHON_HOME: C:\Python36
-      PYTHON_VERSION: '3.6'
-      PYTHON_ARCH: '64'
+      PYTHON: C:\Python36\python.exe
 
     - TOXENV: 'py36'
-      TOXPYTHON: C:\Python36-x64\python.exe
-      PYTHON_HOME: C:\Python36-x64
-      PYTHON_VERSION: '3.6'
-      PYTHON_ARCH: '64'
+      PYTHON: C:\Python36-x64\python.exe
 
     - TOXENV: 'py37'
-      TOXPYTHON: C:\Python37-x64\python.exe
-      PYTHON_HOME: C:\Python37-x64
-      PYTHON_VERSION: '3.7'
-      PYTHON_ARCH: '64'
+      PYTHON: C:\Python37-x64\python.exe
 
 init:
   - ps: echo $env:TOXENV
   - ps: ls C:\Python*
 
 install:
-  - "set PYTHON_BIN=C:\\Python36-x64\\python.exe"
-  - "set PIP_BIN=C:\\Python36-x64\\Scripts\\pip.exe"
-
-  # Check that we have the expected version of Python
-  - "%PYTHON_BIN% --version"
-
   # Install dependencies
-
-  - "%PYTHON_BIN% -m pip install --upgrade pip"
-  - "%PYTHON_BIN% -m pip install -U pytest"
-  - "%PIP_BIN% install .[dev] --prefer-binary" # Test installation correctnessinstall:
-
-  - '%TOXPYTHON% --version'
-  - '%PYTHON_HOME%\Scripts\pip --version'
-  - '%TOXPYTHON% -m pip install tox'
-  - '%TOXPYTHON% -m pip install -U pytest'
+  - '%PYTHON% --version'
+  - "%PYTHON% -m pip install --upgrade pip"
+  - '%PYTHON% -m pip install tox'
 
 build: off
 
 test_script:
-  - '%WITH_COMPILER% %PYTHON_HOME%\Scripts\tox'
+  - '%WITH_COMPILER% %PYTHON% -m tox'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,8 +18,29 @@ branches:
     - 0.11.x
     - 0.12.x
 
-matrix:
-  fast_finish: true
+environment:
+  matrix:
+    - TOXENV: check
+      TOXPYTHON: C:\Python36\python.exe
+      PYTHON_HOME: C:\Python36
+      PYTHON_VERSION: '3.6'
+      PYTHON_ARCH: '64'
+
+    - TOXENV: 'py36'
+      TOXPYTHON: C:\Python36-x64\python.exe
+      PYTHON_HOME: C:\Python36-x64
+      PYTHON_VERSION: '3.6'
+      PYTHON_ARCH: '64'
+
+    - TOXENV: 'py37'
+      TOXPYTHON: C:\Python37-x64\python.exe
+      PYTHON_HOME: C:\Python37-x64
+      PYTHON_VERSION: '3.7'
+      PYTHON_ARCH: '64'
+
+init:
+  - ps: echo $env:TOXENV
+  - ps: ls C:\Python*
 
 install:
   - "set PYTHON_BIN=C:\\Python36-x64\\python.exe"
@@ -29,12 +50,17 @@ install:
   - "%PYTHON_BIN% --version"
 
   # Install dependencies
-  - "choco install pandoc"
 
   - "%PYTHON_BIN% -m pip install --upgrade pip"
-  - "%PIP_BIN% install .[dev] --prefer-binary"  # Test installation correctness
+  - "%PYTHON_BIN% -m pip install -U pytest"
+  - "%PIP_BIN% install .[dev] --prefer-binary" # Test installation correctnessinstall:
+
+  - '%TOXPYTHON% --version'
+  - '%PYTHON_HOME%\Scripts\pip --version'
+  - '%TOXPYTHON% -m pip install tox'
+  - '%TOXPYTHON% -m pip install -U pytest'
 
 build: off
 
 test_script:
-  - "%PYTHON_BIN% -m pytest -vv"  # Test against installed code
+  - '%WITH_COMPILER% %PYTHON_HOME%\Scripts\tox'

--- a/setup.cfg
+++ b/setup.cfg
@@ -89,29 +89,3 @@ markers =
     filterwarnings
     mpl_image_compare
 
-[flake8]
-ignore = E203, E266, E501, W503
-max-line-length = 80
-max-complexity = 18
-select = B,C,E,F,W,T4,B9
-
-[tool:tox]
-envlist =
-    check
-
-[testenv:check]
-deps =
-    black
-    docutils
-    isort
-    flake8
-    mypy
-    pygments
-skip_install = true
-usedevelop = false
-commands =
-    python setup.py check --strict --metadata --restructuredtext
-    flake8 src setup.py
-    isort --check-only --diff --recursive --project poliastro --section-default THIRDPARTY src setup.py
-    black --check src setup.py
-    mypy --ignore-missing-imports --check-untyped-defs --no-strict-optional src

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,11 @@
 [metadata]
 name = poliastro
+description = Python package for Orbital Mechanics
+long_description = file: README.rst
 version = 0.13.dev0
+license = MIT
 author = Juan Luis Cano
 author_email = hello@juanlu.space
-license = MIT
-description = Python package for Orbital Mechanics
 keywords =
     aero
     aerospace
@@ -15,7 +16,10 @@ keywords =
     orbital mechanics
 url = https://blog.poliastro.space/
 download_url = https://github.com/poliastro/poliastro
-long_description = file: README.rst
+project_urls =
+    Source=https://github.com/poliastro/poliastro
+    Tracker=https://github.com/poliastro/poliastro/issues
+platforms = any
 classifiers =
     Development Status :: 4 - Beta
     Intended Audience :: Education
@@ -37,6 +41,7 @@ package_dir=
 	=src
 packages = find:
 zip_safe = False
+python_requires = >=3.5
 install_requires =
     astropy>=3.1,<4.*
     astroquery>=0.3.9
@@ -48,7 +53,6 @@ install_requires =
     plotly>=3.6,<4.*
     scipy>=1.0
 include_package_data = True
-python_requires = >=3.5
 
 [options.packages.find]
 where = src
@@ -60,19 +64,23 @@ console_scripts = poliastro = poliastro.cli:main
 jupyter = notebook; ipywidgets>=7.0
 dev =
     black ; python_version>='3.6'
-    coverage
     ipykernel
     ipython>=5.0
     ipywidgets>=7.0
     isort
     jupyter-client
-    nbsphinx
+
+testing =
+    coverage
     pycodestyle
     pytest-cov<2.6.0
     pytest>=3.2
+    pytest-mpl
+
+docs =
     sphinx
     sphinx_rtd_theme>=0.4.3
-    pytest-mpl
+    nbsphinx
 
 [tool:pytest]
 norecursedirs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,20 +64,16 @@ console_scripts = poliastro = poliastro.cli:main
 jupyter = notebook; ipywidgets>=7.0
 dev =
     black ; python_version>='3.6'
+    coverage
     ipykernel
     ipython>=5.0
     ipywidgets>=7.0
     isort
     jupyter-client
-
-testing =
-    coverage
+    nbsphinx
     pycodestyle
     pytest-cov<2.6.0
     pytest>=3.2
-    pytest-mpl
-
-docs =
     sphinx
     sphinx_rtd_theme>=0.4.3
     nbsphinx

--- a/setup.cfg
+++ b/setup.cfg
@@ -89,3 +89,8 @@ markers =
     filterwarnings
     mpl_image_compare
 
+[flake8]
+ignore = E203, E266, E501, W503
+max-line-length = 80
+max-complexity = 18
+select = B,C,E,F,W,T4,B9

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,10 @@ setenv =
 passenv =
     *
 usedevelop = false
-whitelist_externals = pytest, coverage, pytest-cov<2.6.0
+deps =
+    pytest-cov	
+    ipywidgets
+skip_install = false
 commands =
     {posargs:pytest --cov --cov-report=term-missing -vv src/poliastro/tests}
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ setenv =
 passenv =
     *
 usedevelop = false
-whitelist_externals = pytest
+whitelist_externals = pytest, coverage, pytest-cov<2.6.0
 commands =
     {posargs:pytest --cov --cov-report=term-missing -vv src/poliastro/tests}
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,12 +12,12 @@ envlist =
 
 [testenv]
 basepython =
-    pypy: {env:TOXPYTHON:pypy}
-    pypy3: {env:TOXPYTHON:pypy3}
-    py35: {env:TOXPYTHON:python3.5}
-    {py36,docs}: {env:TOXPYTHON:python3.6}
-    py37: {env:TOXPYTHON:python3.7}
-    {clean,check}: {env:TOXPYTHON:python3}
+    pypy: {env:PYTHON:pypy}
+    pypy3: {env:PYTHON:pypy3}
+    py35: {env:PYTHON:python3.5}
+    {py36,docs}: {env:PYTHON:python3.6}
+    py37: {env:PYTHON:python3.7}
+    {clean,check}: {env:PYTHON:python3}
 setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes
@@ -25,7 +25,7 @@ passenv =
     *
 usedevelop = false
 deps =
-    pytest-cov	
+    pytest-cov
     ipywidgets
 skip_install = false
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,94 @@
+; a generative tox configuration, see: https://tox.readthedocs.io/en/latest/config.html#generative-envlist
+
+[tox]
+envlist =
+    clean,
+    docs,
+    {py35,py36,py37,pypy,pypy3},
+    flake8,
+    report
+
+[testenv]
+basepython =
+    pypy: {env:TOXPYTHON:pypy}
+    pypy3: {env:TOXPYTHON:pypy3}
+    py35: {env:TOXPYTHON:python3.5}
+    {py36,docs,spell}: {env:TOXPYTHON:python3.6}
+    py37: {env:TOXPYTHON:python3.7}
+    {clean,check,report,codecov}: {env:TOXPYTHON:python3}
+setenv =
+    PYTHONPATH={toxinidir}/tests
+    PYTHONUNBUFFERED=yes
+passenv =
+    *
+usedevelop = false
+deps =
+    astropy>=3.1,<4.*
+    astroquery>=0.3.9
+    jplephem
+    matplotlib>=2.0,!=3.0.1
+    numba>=0.39
+    numpy
+    pandas
+    plotly>=3.6,<4.*
+    scipy>=1.0
+commands =
+    {posargs:pytest --cov --cov-report=term-missing -vv src/poliastro/tests}
+
+[testenv:check]
+deps =
+    black
+    docutils
+    isort
+    flake8
+    mypy
+    pygments
+skip_install = true
+usedevelop = false
+commands =
+    python setup.py check --strict --metadata --restructuredtext
+    flake8 src setup.py
+    isort --check-only --diff --recursive --project poliastro --section-default THIRDPARTY src setup.py
+    black --check src setup.py
+    mypy --ignore-missing-imports --check-untyped-defs --no-strict-optional src
+
+[testenv:docs]
+description = invoke sphinx-build to build the HTML docs
+extras = docs
+commands = sphinx-build -d "{toxworkdir}/docs_doctree" docs/source "{toxworkdir}/docs_out" --color -W -bhtml
+
+[testenv:codecov]
+deps =
+    codecov
+skip_install = true
+commands =
+    coverage xml --ignore-errors
+    codecov []
+
+[flake8]
+ignore = E203, E266, E501, W503
+max-line-length = 80
+max-complexity = 18
+select = B,C,E,F,W,T4,B9
+
+[testenv:flake8]
+basepython = python3
+skip_install = true
+deps =
+    flake8
+    flake8-docstrings>=0.2.7
+    flake8-import-order>=0.9
+    pep8-naming
+    flake8-colors
+commands = flake8 src/flake8/ tests/ setup.py
+
+[testenv:report]
+deps = coverage
+skip_install = true
+commands =
+    coverage report
+
+[testenv:clean]
+commands = coverage erase
+skip_install = true
+deps = coverage

--- a/tox.ini
+++ b/tox.ini
@@ -1,50 +1,44 @@
-; a generative tox configuration, see: https://tox.readthedocs.io/en/latest/config.html#generative-envlist
-
 [tox]
+description = list of environments againts tox runs the tests
 envlist =
     clean,
+    check,
     docs,
-    {py35,py36,py37,pypy,pypy3},
-    flake8,
-    report
+    py35,
+    py36
+    py37
+    pypy,
+    pypy3
 
 [testenv]
 basepython =
     pypy: {env:TOXPYTHON:pypy}
     pypy3: {env:TOXPYTHON:pypy3}
     py35: {env:TOXPYTHON:python3.5}
-    {py36,docs,spell}: {env:TOXPYTHON:python3.6}
+    {py36,docs}: {env:TOXPYTHON:python3.6}
     py37: {env:TOXPYTHON:python3.7}
-    {clean,check,report,codecov}: {env:TOXPYTHON:python3}
+    {clean,check}: {env:TOXPYTHON:python3}
 setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes
 passenv =
     *
 usedevelop = false
-deps =
-    astropy>=3.1,<4.*
-    astroquery>=0.3.9
-    jplephem
-    matplotlib>=2.0,!=3.0.1
-    numba>=0.39
-    numpy
-    pandas
-    plotly>=3.6,<4.*
-    scipy>=1.0
+whitelist_externals = pytest
 commands =
     {posargs:pytest --cov --cov-report=term-missing -vv src/poliastro/tests}
 
+
 [testenv:check]
+description = this environments checks for flake8, black, isort and poliastro code style
 deps =
-    black
-    docutils
-    isort
-    flake8
-    mypy
-    pygments
+	black
+	docutils
+	isort
+	flake8
+	mypy
+	pygments
 skip_install = true
-usedevelop = false
 commands =
     python setup.py check --strict --metadata --restructuredtext
     flake8 src setup.py
@@ -52,43 +46,15 @@ commands =
     black --check src setup.py
     mypy --ignore-missing-imports --check-untyped-defs --no-strict-optional src
 
+
 [testenv:docs]
 description = invoke sphinx-build to build the HTML docs
-extras = docs
+extras =  docs
+whitelist_externals = sphinx-build
 commands = sphinx-build -d "{toxworkdir}/docs_doctree" docs/source "{toxworkdir}/docs_out" --color -W -bhtml
-
-[testenv:codecov]
-deps =
-    codecov
-skip_install = true
-commands =
-    coverage xml --ignore-errors
-    codecov []
-
-[flake8]
-ignore = E203, E266, E501, W503
-max-line-length = 80
-max-complexity = 18
-select = B,C,E,F,W,T4,B9
-
-[testenv:flake8]
-basepython = python3
-skip_install = true
-deps =
-    flake8
-    flake8-docstrings>=0.2.7
-    flake8-import-order>=0.9
-    pep8-naming
-    flake8-colors
-commands = flake8 src/flake8/ tests/ setup.py
-
-[testenv:report]
-deps = coverage
-skip_install = true
-commands =
-    coverage report
 
 [testenv:clean]
 commands = coverage erase
 skip_install = true
 deps = coverage
+


### PR DESCRIPTION
This file runs tests on docs, different python environments and coverage. However, there are some warnings I was not able to solve by my own:

* As far as I read py35, pypy and pypy3 are raising `InterpreterNotFound` errors since tox is not able to find this environments in Anaconda.
* There is also an error coming from graphviz from the docs: `dot command 'dot' cannot be run (needed for graphviz output), check the graphviz_dot setting`

I also found that by applying `isort -rc --atomic .` it is possible to format all the code when running `tox` :relaxed: 