### PR TITLE
Changed CONTRIBUTING.rst

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -109,7 +109,7 @@ These are some succint steps to set up a development environment:
 3. `Fork poliastro <https://help.github.com/articles/fork-a-repo/>`_.
 4. `Clone your fork <https://help.github.com/articles/cloning-a-repository/>`_.
 5. Install it in development mode using
-   :code:`pip install --editable /path/to/poliastro/[dev]` (this means that the
+   :code:`pip3 install --editable /absolute_path_to_above_cloned_poliastro_repo` (this means that the
    installed code will change as soon as you change it in the download
    location).
 6. Create a new branch.


### PR DESCRIPTION
As per setup.cfg, installation requires python>=3.5. So, 'pip3' should be used instead of 'pip'. At times using pip might throw an error. 
Also, during my installation, I tried using relative path but it throws an error and when I tried with the absolute path everything worked fine. I don't know, if I made some blunder in relative path case, due to which I was getting the error. But, in similar scenarios, it is always a good practice to ask people to use an absolute path in the documentation. As this will be less prone to human error. So, I made changes corresponding to this also.