### PR TITLE
Create custom CZML packets

### DIFF
--- a/src/poliastro/czml/czml_extract_default_params.py
+++ b/src/poliastro/czml/czml_extract_default_params.py
@@ -36,3 +36,12 @@ DEFAULTS = {
         "material": {"solidColor": {"color": {"rgba": [255, 255, 0, 255]}}},
     },
 }
+
+CUSTOM_PACKET = {
+    "id": "custom_properties",
+    "properties": {
+        "custom_attractor": False,
+        "ellipsoid": [{"array": [0, 0, 0]}],
+        "map_url": "",
+    },
+}

--- a/src/poliastro/czml/extract_czml.py
+++ b/src/poliastro/czml/extract_czml.py
@@ -7,8 +7,7 @@ from astropy import units as u
 from astropy.coordinates import CartesianRepresentation
 from astropy.time import Time, TimeDelta
 
-from poliastro.czml.czml_extract_default_params import CUSTOM_PACKET
-from poliastro.czml.czml_extract_default_params import DEFAULTS
+from poliastro.czml.czml_extract_default_params import CUSTOM_PACKET, DEFAULTS
 from poliastro.twobody.propagation import propagate
 
 

--- a/src/poliastro/czml/extract_czml.py
+++ b/src/poliastro/czml/extract_czml.py
@@ -31,8 +31,8 @@ class CZMLExtractor:
             add_orbit()
         """
         self.czml = dict()  # type: Dict[int, Any]
-        self.cust_czml = dict()
-        self.cust_czml[-1] = copy.deepcopy(CUSTOM_PACKET)  # type: Dict[int, Any]
+        self.cust_czml = dict()  # type: Dict[int, Any]
+        self.cust_czml[-1] = copy.deepcopy(CUSTOM_PACKET)
         self.cust_prop = [ellipsoid, pr_map]
 
         self.orbits = []  # type: List[Any]

--- a/src/poliastro/czml/extract_czml.py
+++ b/src/poliastro/czml/extract_czml.py
@@ -7,6 +7,7 @@ from astropy import units as u
 from astropy.coordinates import CartesianRepresentation
 from astropy.time import Time, TimeDelta
 
+from poliastro.czml.czml_extract_default_params import CUSTOM_PACKET
 from poliastro.czml.czml_extract_default_params import DEFAULTS
 from poliastro.twobody.propagation import propagate
 
@@ -14,7 +15,7 @@ from poliastro.twobody.propagation import propagate
 class CZMLExtractor:
     """A class for extracting orbitary data to Cesium"""
 
-    def __init__(self, start_epoch, end_epoch, N):
+    def __init__(self, start_epoch, end_epoch, N, ellipsoid=None, pr_map=None):
         """
         Orbital constructor
 
@@ -31,6 +32,10 @@ class CZMLExtractor:
             add_orbit()
         """
         self.czml = dict()  # type: Dict[int, Any]
+        self.cust_czml = dict()
+        self.cust_czml[-1] = copy.deepcopy(CUSTOM_PACKET)  # type: Dict[int, Any]
+        self.cust_prop = [ellipsoid, pr_map]
+
         self.orbits = []  # type: List[Any]
         self.N = N
         self.i = 0
@@ -38,9 +43,12 @@ class CZMLExtractor:
         self.start_epoch = CZMLExtractor.format_date(start_epoch)
         self.end_epoch = CZMLExtractor.format_date(end_epoch)
 
+        if sum([c is None for c in self.cust_prop]) == 0:
+            self._change_custom_params(*self.cust_prop)
+
         self._init_czml_()
 
-    def parse_dict_tuples(self, path, tups):
+    def parse_dict_tuples(self, path, tups, dict=None):
         """
         Parameters
         ----------
@@ -48,11 +56,17 @@ class CZMLExtractor:
             Dictionary path to insert to
         tups : list (val, val)
             Tuples to be assigned
+        dict: dictionary
+            Referenced dictionary
         """
 
         # We only want to pass a reference czml, then by modifying our reference, we'll be modifying our base dictionary
         # which allows us to walk through a path of arbitrary length
-        curr = self.czml
+        if dict is None:
+            curr = self.czml
+        else:
+            curr = dict
+
         for p in path:
             curr = curr.setdefault(p, {})
         for t in tups:
@@ -129,6 +143,27 @@ class CZMLExtractor:
                 ("step", "SYSTEM_CLOCK_MULTIPLIER"),
             ],
         )
+
+    def _change_custom_params(self, ellipsoid, pr_map):
+        """
+        Change the custom properties package.
+
+        Parameters
+        ----------
+        ellipsoid: list(int)
+            Defines the attractor ellipsoid. The list must have three numbers
+            representing the radii in the x, y and z axis
+        pr_map: str
+            A URL to the projection of the defined ellipsoid (UV map)
+        """
+        self.cust_czml[-1]["properties"]["ellipsoid"][0]["array"] = ellipsoid
+        self.parse_dict_tuples(
+            [-1, "properties"], [("custom_attractor", True)], dict=self.cust_czml
+        )
+        self.parse_dict_tuples(
+            [-1, "properties"], [("map_url", pr_map)], dict=self.cust_czml
+        )
+        return
 
     def _change_id_params_(self, i, o_id=None, name=None, description=None):
         """
@@ -229,9 +264,11 @@ class CZMLExtractor:
         """
         if ext_location:
             with open(ext_location, "w+") as fp:
-                fp.write(json.dumps(list(self.czml.values())))
+                fp.write(
+                    json.dumps(list(self.czml.values()) + list(self.cust_czml.values()))
+                )
 
-        return json.dumps(list(self.czml.values()))
+        return json.dumps(list(self.czml.values()) + list(self.cust_czml.values()))
 
     def add_orbit(
         self,

--- a/src/poliastro/tests/test_czml.py
+++ b/src/poliastro/tests/test_czml.py
@@ -10,6 +10,26 @@ from poliastro.examples import iss, molniya
 from poliastro.twobody.propagation import propagate
 
 
+def test_czml_custom_packet():
+    start_epoch = iss.epoch
+    end_epoch = iss.epoch + molniya.period
+
+    sample_points = 10
+
+    ellipsoidr = [6373100, 6373100, 6373100]
+    pr_map_url = (
+        "https://upload.wikimedia.org/wikipedia/commons/c/c4/Earthmap1000x500compac.jpg"
+    )
+
+    extractor = CZMLExtractor(
+        start_epoch, end_epoch, sample_points, ellipsoid=ellipsoidr, pr_map=pr_map_url
+    )
+
+    # Test that custom packet parameters where set correctly
+    assert extractor.cust_czml[-1]["properties"]["ellipsoid"][0]["array"] == ellipsoidr
+    assert extractor.cust_czml[-1]["properties"]["map_url"] == pr_map_url
+
+
 def test_czml_add_orbit():
     start_epoch = iss.epoch
     end_epoch = iss.epoch + molniya.period


### PR DESCRIPTION
Add the ability to create custom CZML packets to work with the Sandcastle [template](https://github.com/poliastro/cesium-app/blob/master/poliastro-demo.js)

It currently accepts two parameters:

``ellipsoid`` : which defines the shape of the attractor

``pr_map``: which is the path to the ellipsoid's UV map

Note that resizing objects needs a bit more work, but this refers to the Cesium app and shouldn't have an impact on the extractor's code