### PR TITLE
Add ground stations

### DIFF
--- a/src/poliastro/czml/czml_extract_default_params.py
+++ b/src/poliastro/czml/czml_extract_default_params.py
@@ -1,4 +1,5 @@
 PIC_SATELLITE = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAADJSURBVDhPnZHRDcMgEEMZjVEYpaNklIzSEfLfD4qNnXAJSFWfhO7w2Zc0Tf9QG2rXrEzSUeZLOGm47WoH95x3Hl3jEgilvDgsOQUTqsNl68ezEwn1vae6lceSEEYvvWNT/Rxc4CXQNGadho1NXoJ+9iaqc2xi2xbt23PJCDIB6TQjOC6Bho/sDy3fBQT8PrVhibU7yBFcEPaRxOoeTwbwByCOYf9VGp1BYI1BA+EeHhmfzKbBoJEQwn1yzUZtyspIQUha85MpkNIXB7GizqDEECsAAAAASUVORK5CYII="
+PIC_GROUNDSTATION = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACvSURBVDhPrZDRDcMgDAU9GqN0lIzijw6SUbJJygUeNQgSqepJTyHG91LVVpwDdfxM3T9TSl1EXZvDwii471fivK73cBFFQNTT/d2KoGpfGOpSIkhUpgUMxq9DFEsWv4IXhlyCnhBFnZcFEEuYqbiUlNwWgMTdrZ3JbQFoEVG53rd8ztG9aPJMnBUQf/VFraBJeWnLS0RfjbKyLJA8FkT5seDYS1Qwyv8t0B/5C2ZmH2/eTGNNBgMmAAAAAElFTkSuQmCC"
 
 DEFAULTS = {
     "id": "1",
@@ -35,6 +36,35 @@ DEFAULTS = {
         "resolution": 120,
         "material": {"solidColor": {"color": {"rgba": [255, 255, 0, 255]}}},
     },
+}
+
+GROUNDSTATION_DEFAULTS = {
+    "id": "1",
+    "name": "NAME",
+    "availability": "0000-00-00T00:00:00Z/0000-00-00T00:00:00Z",
+    "description": "DESCRIPTION",
+    "billboard": {
+        "eyeOffset": {"cartesian": [0, 0, 0]},
+        "horizontalOrigin": "CENTER",
+        "image": PIC_GROUNDSTATION,
+        "pixelOffset": {"cartesian2": [0, 0]},
+        "scale": 1.5,
+        "show": True,
+        "verticalOrigin": "CENTER",
+    },
+    "label": {
+        "fillColor": {"rgba": [0, 0, 0, 255]},
+        "font": "11pt Lucida Console",
+        "horizontalOrigin": "LEFT",
+        "outlineColor": {"rgba": [0, 0, 0, 255]},
+        "outlineWidth": 0,
+        "pixelOffset": {"cartesian2": [0, 0]},
+        "show": True,
+        "style": "FILL_AND_OUTLINE",
+        "text": "TEXT",
+        "verticalOrigin": "CENTER",
+    },
+    "position": {"cartesian": [0, 0, 0]},
 }
 
 CUSTOM_PACKET = {

--- a/src/poliastro/czml/extract_czml.py
+++ b/src/poliastro/czml/extract_czml.py
@@ -338,7 +338,9 @@ class CZMLExtractor:
 
         if label_fill_color is not None:
             self.parse_dict_tuples(
-                [i, "label", "fillColor"], [("rgba", label_fill_color)], dict=self.gs_czml
+                [i, "label", "fillColor"],
+                [("rgba", label_fill_color)],
+                dict=self.gs_czml,
             )
         if label_outline_color is not None:
             self.parse_dict_tuples(
@@ -360,9 +362,7 @@ class CZMLExtractor:
             )
 
     def add_ground_station(
-        self,r(
-        molniya.epoch,
-        molniya.epoch
+        self,
         pos,
         id_name=None,
         id_description=None,

--- a/src/poliastro/czml/extract_czml.py
+++ b/src/poliastro/czml/extract_czml.py
@@ -535,4 +535,3 @@ class CZMLExtractor:
             ISO 8601 - compliant date
         """
         return Time(date, format="isot")
-

--- a/src/poliastro/czml/extract_czml.py
+++ b/src/poliastro/czml/extract_czml.py
@@ -381,6 +381,8 @@ class CZMLExtractor:
             Orbit to be added
         pos: list [int]
             coordinates of ground station
+            [x y z] cartesian coordinates
+            [u v] ellipsoidal coordinates (0 elevation)
 
         Id parameters:
         -------------
@@ -404,6 +406,18 @@ class CZMLExtractor:
         label_show: bool
             Indicates whether the label is visible
         """
+        if len(pos) == 2:
+            u, v = pos
+            if self.cust_prop[0]:
+                a, b = self.cust_prop[0][:1]  # get semi-major and semi-minor axises
+            else:
+                a, b = 6378137.0, 6378137.0
+            N = a / np.sqrt(1 - (1 - (a / b) ** 2) * np.sqrt(np.sin(u)))
+            x = N * np.cos(u) * np.cos(v)
+            y = N * np.cos(u) * np.sin(v)
+            z = (N * (a / b) ** 2) * np.sin(u)
+            pos = x, y, z
+
         self._init_ground_station_packet_(self.gs_n, pos)
         self._change_ground_station_params_(
             id_name=id_name,

--- a/src/poliastro/czml/extract_czml.py
+++ b/src/poliastro/czml/extract_czml.py
@@ -12,6 +12,7 @@ from poliastro.czml.czml_extract_default_params import (
     DEFAULTS,
     GROUNDSTATION_DEFAULTS,
 )
+from poliastro.czml.utils import ellipsoidal_to_cartesian
 from poliastro.twobody.propagation import propagate
 
 
@@ -412,11 +413,7 @@ class CZMLExtractor:
                 a, b = self.cust_prop[0][:1]  # get semi-major and semi-minor axises
             else:
                 a, b = 6378137.0, 6378137.0
-            N = a / np.sqrt(1 - (1 - (a / b) ** 2) * np.sqrt(np.sin(u)))
-            x = N * np.cos(u) * np.cos(v)
-            y = N * np.cos(u) * np.sin(v)
-            z = (N * (a / b) ** 2) * np.sin(u)
-            pos = x, y, z
+            pos = ellipsoidal_to_cartesian(a, b, u, v)
 
         self._init_ground_station_packet_(self.gs_n, pos)
         self._change_ground_station_params_(

--- a/src/poliastro/czml/utils.py
+++ b/src/poliastro/czml/utils.py
@@ -1,0 +1,32 @@
+import numpy as np
+
+
+def ellipsoidal_to_cartesian(a, b, lat, lon):
+    """
+
+    Converts ellipsoidal coordinates (assuming zero elevation)
+    to the cartesian.
+
+    Parameters
+    ----------
+    a: float
+        semi-major axis
+    b: float
+        semi-minor axis
+    lat: float
+        latitude
+    lon: float
+        longtitude
+
+    Returns
+    -------
+    3d Cartesian coordinates in the form (x, y, z)
+    """
+
+    # radius of curvature
+    cr = a / np.sqrt(1 - (1 - (a / b) ** 2) * np.sin(lat) ** 2)
+
+    x = cr * np.cos(lat) * np.cos(lon)
+    y = cr * np.cos(lat) * np.sin(lon)
+    z = (a / b) ** 2 * cr * np.sin(lat)
+    return [x, y, z]

--- a/src/poliastro/czml/utils.py
+++ b/src/poliastro/czml/utils.py
@@ -29,4 +29,4 @@ def ellipsoidal_to_cartesian(a, b, lat, lon):
     x = cr * np.cos(lat) * np.cos(lon)
     y = cr * np.cos(lat) * np.sin(lon)
     z = (a / b) ** 2 * cr * np.sin(lat)
-    return [x, y, z]
+    return x, y, z

--- a/src/poliastro/tests/test_czml.py
+++ b/src/poliastro/tests/test_czml.py
@@ -76,26 +76,30 @@ def test_czml_ground_station():
     extractor = CZMLExtractor(start_epoch, end_epoch, sample_points)
 
     extractor.add_ground_station(
-        [1216469.9, -4736121.7, 4081386.9],
+        [32 * u.degree, 62 * u.degree],
         id_name="GS",
         label_fill_color=[120, 120, 120, 255],
         label_text="GS test",
     )
 
-    extractor.add_ground_station([0.70930, 0.40046], label_show=False)
+    extractor.add_ground_station([0.70930 * u.rad, 0.40046 * u.rad], label_show=False)
 
-    assert extractor.gs_czml[0]["id"] == "GS0"
+    assert extractor.czml["GS0"]["id"] == "GS0"
     assert (
-        extractor.gs_czml[0]["availability"]
+        extractor.czml["GS0"]["availability"]
         == "2013-03-18T12:00:00.000/2013-03-18T23:59:35.108"
     )
-    assert extractor.gs_czml[0]["name"] == "GS"
-    assert extractor.gs_czml[0]["label"]["fillColor"]["rgba"] == [120, 120, 120, 255]
-    assert extractor.gs_czml[0]["label"]["text"] == "GS test"
-    assert extractor.gs_czml[0]["label"]["show"] is True
+    assert extractor.czml["GS0"]["name"] == "GS"
+    assert extractor.czml["GS0"]["label"]["fillColor"]["rgba"] == [120, 120, 120, 255]
+    assert extractor.czml["GS0"]["label"]["text"] == "GS test"
+    assert extractor.czml["GS0"]["label"]["show"] is True
+
+    cords = [2539356.1623202674, 4775834.339416022, 3379897.6662185807]
+    for i, j in zip(extractor.czml["GS0"]["position"]["cartesian"], cords):
+        assert_allclose(i, j, rtol=1e-4)
 
     cords = [4456924.997008477, 1886774.8000006324, 4154098.219336245]
-    for i, j in zip(extractor.gs_czml[1]["position"]["cartesian"], cords):
+    for i, j in zip(extractor.czml["GS1"]["position"]["cartesian"], cords):
         assert_allclose(i, j, rtol=1e-4)
 
 

--- a/src/poliastro/tests/test_czml.py
+++ b/src/poliastro/tests/test_czml.py
@@ -67,6 +67,32 @@ def test_czml_add_orbit():
     assert extractor.czml[1]["path"]["show"]["boolean"] is False
 
 
+def test_czml_ground_station():
+    start_epoch = iss.epoch
+    end_epoch = iss.epoch + molniya.period
+
+    sample_points = 10
+
+    extractor = CZMLExtractor(start_epoch, end_epoch, sample_points)
+
+    extractor.add_ground_station(
+        [1216469.9, -4736121.7, 4081386.9],
+        id_name="GS",
+        label_fill_color=[120, 120, 120, 255],
+        label_text="GS test",
+    )
+
+    assert extractor.gs_czml[0]["id"] == "GS0"
+    assert (
+        extractor.gs_czml[0]["availability"]
+        == "2013-03-18T12:00:00.000/2013-03-18T23:59:35.108"
+    )
+    assert extractor.gs_czml[0]["name"] == "GS"
+    assert extractor.gs_czml[0]["label"]["fillColor"]["rgba"] == [120, 120, 120, 255]
+    assert extractor.gs_czml[0]["label"]["text"] == "GS test"
+    assert extractor.gs_czml[0]["label"]["show"] is True
+
+
 def test_czml_invalid_orbit_epoch_error():
     start_epoch = molniya.epoch
     end_epoch = molniya.epoch + molniya.period

--- a/src/poliastro/tests/test_czml.py
+++ b/src/poliastro/tests/test_czml.py
@@ -82,6 +82,8 @@ def test_czml_ground_station():
         label_text="GS test",
     )
 
+    extractor.add_ground_station([0.70930, 0.40046], label_show=False)
+
     assert extractor.gs_czml[0]["id"] == "GS0"
     assert (
         extractor.gs_czml[0]["availability"]
@@ -91,6 +93,10 @@ def test_czml_ground_station():
     assert extractor.gs_czml[0]["label"]["fillColor"]["rgba"] == [120, 120, 120, 255]
     assert extractor.gs_czml[0]["label"]["text"] == "GS test"
     assert extractor.gs_czml[0]["label"]["show"] is True
+
+    cords = [4456924.997008477, 1886774.8000006324, 4154098.219336245]
+    for i, j in zip(extractor.gs_czml[1]["position"]["cartesian"], cords):
+        assert_allclose(i, j, rtol=1e-4)
 
 
 def test_czml_invalid_orbit_epoch_error():


### PR DESCRIPTION
This is a draft PR attempting to add ground stations. Currently, it only adds the ground station markers (and the respective customization). The position is currently defined as simple xyz coordinates (with the point of origin being the center of the body), however I feel like there should be an option of specifying the coordinates by the latitude/longitude of the ellipsoid (this also assures that the station lies on the body). We could either implement pseudo-polymorphism (simply check the length of the ``pos`` array (``Cartesian coordinates`` if ``3``, ``Elliptical coordinates`` if ``2``) or get rid of Cartesian coordinates altogether. 

Edit: After discussing with @Juanlu001, we decided that it would be better to limit the scope of the PR to simply visualizing ground station without adding any functionality yet.