### PR TITLE
Perifocal frame and plotter set_frame

### DIFF
--- a/src/poliastro/plotting/misc.py
+++ b/src/poliastro/plotting/misc.py
@@ -27,15 +27,16 @@ def _plot_bodies(orbit_plotter, outer=True, epoch=None):
 
 
 def _plot_solar_system_2d(outer=True, epoch=None, interactive=False):
-    pqw = Orbit.from_body_ephem(Earth, epoch).pqw()
     if interactive:
         orbit_plotter = (
             OrbitPlotter2D()
         )  # type: Union[OrbitPlotter2D, StaticOrbitPlotter]
-        orbit_plotter.set_frame(*pqw)
+        orbit_plotter.set_frame(*Orbit.from_body_ephem(Earth, epoch).pqw())
     else:
         orbit_plotter = StaticOrbitPlotter()
-        orbit_plotter.set_frame(*pqw)
+        orbit_plotter.set_frame(
+            Orbit.from_body_ephem(Earth, epoch).get_perifocal_frame()
+        )
 
     _plot_bodies(orbit_plotter, outer, epoch)
 

--- a/src/poliastro/tests/tests_plotting/test_static.py
+++ b/src/poliastro/tests/tests_plotting/test_static.py
@@ -1,6 +1,6 @@
-import astropy.units as u
 import matplotlib.pyplot as plt
 import pytest
+from astropy.coordinates import ICRS
 
 from poliastro.bodies import Earth, Jupiter, Mars
 from poliastro.examples import iss
@@ -16,12 +16,10 @@ def test_orbitplotter_has_axes():
 
 def test_set_frame():
     op = StaticOrbitPlotter()
-    p = [1, 0, 0] * u.one
-    q = [0, 1, 0] * u.one
-    w = [0, 0, 1] * u.one
-    op.set_frame(p, q, w)
+    frame = ICRS
+    op.set_frame(frame)
 
-    assert op._frame == (p, q, w)
+    assert op._frame == frame
 
 
 def test_axes_labels_and_title():
@@ -98,7 +96,7 @@ def test_set_frame_plots_same_colors():
     jupiter = Orbit.from_body_ephem(Jupiter)
     op.plot(jupiter)
     colors1 = [orb[2] for orb in op.trajectories]
-    op.set_frame(*jupiter.pqw())
+    op.set_frame(jupiter.get_perifocal_frame())
     colors2 = [orb[2] for orb in op.trajectories]
     assert colors1 == colors2
 
@@ -114,7 +112,7 @@ def test_redraw_keeps_trajectories():
 
     assert len(op.trajectories) == 2
 
-    op.set_frame(*mars.pqw())
+    op.set_frame(mars.get_perifocal_frame())
 
     assert len(op.trajectories) == 2
 

--- a/src/poliastro/tests/tests_twobody/test_orbit.py
+++ b/src/poliastro/tests/tests_twobody/test_orbit.py
@@ -605,9 +605,7 @@ def test_orbit_from_horizons_has_expected_elements():
         epoch,
     )
     ss1 = Orbit.from_horizons(name="Ceres", epoch=epoch)
-    assert ss.pqw()[0].value.all() == ss1.pqw()[0].value.all()
-    assert ss.r_a == ss1.r_a
-    assert ss.a == ss1.a
+    assert ss.classical() == ss1.classical()
 
 
 @pytest.mark.remote_data


### PR DESCRIPTION
This is a proof of concept of how a `*Plotter.set_frame` could work. I am not very happy with the implementation, but to be honest working with Astropy frames is a little bit hacky at times :) Before merging this, I would like to:

* [ ] Test the Geocentric Solar Ecliptic (GSE) frame that @shreyasbapat implemented a while ago to reproduce [these beautiful plots](https://github.com/poliastro/poliastro/issues/335#issue-302625991)
* [ ] Add more image tests (now that we know how they work) to make this robust in the face of redraws
* [ ] Clean the implementation
* [ ] Evaluate a better name? Perhaps we can use `get_pqw` or `get_pqw_frame` instead of `get_perifocal_frame`. Thoughts?
* [ ] Translate functionality to interactive plotters for consistency
* [ ] Deprecate `orbit.pqw`