### PR TITLE
Use sphinx-notfound-page extension to build a nice 404 page

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,6 +44,7 @@ extensions = [
     'IPython.sphinxext.ipython_console_highlighting',
     'sphinx.ext.mathjax',  # Maths visualization
     'sphinx.ext.graphviz',  # Dependency diagrams
+    'notfound.extension',
 ]
 
 # Custom configuration

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,6 +77,7 @@ dev =
     pytest-mpl
     sphinx
     sphinx_rtd_theme>=0.4.3
+    sphinx-notfound-page
     tox
 
 [tool:pytest]


### PR DESCRIPTION
When Read the Docs finds a 404.html page in the project it will serve it instead the default one.

The extension installed, takes care about all the links being generated properly (absolute) so the page can be served at any URL where the page is not found.

![Screenshot_2019-06-12_13-00-57](https://user-images.githubusercontent.com/244656/59346241-23bc9500-8d12-11e9-85df-73b21ebfa43a.png)

> NOTE: there are some extra configurations that can be tweaked in case you want to change the default message: https://sphinx-notfound-page.readthedocs.io/en/latest/configuration.html