### PR TITLE
Use canonical units in core functions

### DIFF
--- a/src/poliastro/examples.py
+++ b/src/poliastro/examples.py
@@ -46,3 +46,12 @@ churi = Orbit.from_classical(
     time.Time("2015-11-05 12:00", scale="utc"),
 )
 """Comet 67P/Churyumov–Gerasimenko orbit example"""
+
+
+# TODO: Make epoch explicit
+halley = Orbit.from_vectors(
+    Sun,
+    [-9018878.63569932, -94116054.79839276, 22619058.69943215] * u.km,
+    [-49.95092305, -12.94843055, -4.29251577] * u.km / u.s,
+)
+"""Halley's comet orbit example"""

--- a/src/poliastro/tests/tests_twobody/test_angles.py
+++ b/src/poliastro/tests/tests_twobody/test_angles.py
@@ -208,8 +208,7 @@ def test_eccentric_to_true_range2pi(E, ecc):
 
 
 def test_convert_between_coe_and_rv_is_transitive(classical):
-    k = Earth.k.to(u.km ** 3 / u.s ** 2).value  # u.km**3 / u.s**2
-    res = rv2coe(k, *coe2rv(k, *classical))
+    res = rv2coe(*coe2rv(*classical))
     assert_allclose(res, classical)
 
 
@@ -219,24 +218,24 @@ def test_convert_between_coe_and_mee_is_transitive(classical):
 
 
 def test_convert_coe_and_rv_circular(circular):
-    k, expected_res = circular
-    res = rv2coe(k, *coe2rv(k, *expected_res))
+    _, expected_res = circular
+    res = rv2coe(*coe2rv(*expected_res))
     assert_allclose(res, expected_res, atol=1e-8)
 
 
 def test_convert_coe_and_rv_hyperbolic(hyperbolic):
-    k, expected_res = hyperbolic
-    res = rv2coe(k, *coe2rv(k, *expected_res))
+    _, expected_res = hyperbolic
+    res = rv2coe(*coe2rv(*expected_res))
     assert_allclose(res, expected_res, atol=1e-8)
 
 
 def test_convert_coe_and_rv_equatorial(equatorial):
-    k, expected_res = equatorial
-    res = rv2coe(k, *coe2rv(k, *expected_res))
+    _, expected_res = equatorial
+    res = rv2coe(*coe2rv(*expected_res))
     assert_allclose(res, expected_res, atol=1e-8)
 
 
 def test_convert_coe_and_rv_circular_equatorial(circular_equatorial):
-    k, expected_res = circular_equatorial
-    res = rv2coe(k, *coe2rv(k, *expected_res))
+    _, expected_res = circular_equatorial
+    res = rv2coe(*coe2rv(*expected_res))
     assert_allclose(res, expected_res, atol=1e-8)


### PR DESCRIPTION
First attempt to fix #707.

* Introduced new Halley orbit example (this can be splitted off this PR)
* All tests passing except for long propagation with Kepler
* Pending moving Hohmann and bielliptic calculations to fast functions
* Pending more uniform unit conversion