### PR TITLE
Additional orbit properties

### DIFF
--- a/src/poliastro/tests/tests_twobody/test_orbit.py
+++ b/src/poliastro/tests/tests_twobody/test_orbit.py
@@ -721,12 +721,12 @@ def test_expected_mean_anomaly():
     orbit = Orbit.from_classical(attractor, a, ecc, _a, _a, _a, nu)
     orbit_M = orbit.M
 
-    assert_allclose(orbit_M.value, expected_mean_anomaly.value, rtol=1e-2)
+    assert_quantity_allclose(orbit_M.value, expected_mean_anomaly.value, rtol=1e-2)
 
 
 def test_expected_angular_momentum():
     # Example from Curtis
-    expected_ang_mom = 72472 * u.km ** 2
+    expected_ang_mag = 72472 * u.km ** 2
 
     attractor = Earth
 
@@ -736,9 +736,9 @@ def test_expected_angular_momentum():
     nu = 120 * u.deg
 
     orbit = Orbit.from_classical(attractor, a, ecc, _a, _a, _a, nu)
-    orbit_h_mom = orbit.h_mom
+    orbit_h_mag = orbit.h_mag
 
-    assert_allclose(orbit_h_mom.value, expected_ang_mom.value, rtol=1e-2)
+    assert_quantity_allclose(orbit_h_mag.value, expected_ang_mag.value, rtol=1e-2)
 
 
 def test_expected_last_perifocal_passage():
@@ -755,7 +755,7 @@ def test_expected_last_perifocal_passage():
     orbit = Orbit.from_classical(attractor, a, ecc, _a, _a, _a, nu)
     orbit_t_p = orbit.t_p
 
-    assert_allclose(orbit_t_p.value, expected_t_p.value, rtol=1e-2)
+    assert_quantity_allclose(orbit_t_p.value, expected_t_p.value, rtol=1e-2)
 
 
 def test_convert_from_rv_to_coe():

--- a/src/poliastro/tests/tests_twobody/test_orbit.py
+++ b/src/poliastro/tests/tests_twobody/test_orbit.py
@@ -707,6 +707,57 @@ def test_perigee_and_apogee():
     assert_allclose(ss.r_p.to(u.km).value, expected_r_p.to(u.km).value)
 
 
+def test_expected_mean_anomaly():
+    # Example from Curtis
+    expected_mean_anomaly = 77.93 * u.deg
+
+    attractor = Earth
+
+    _a = 1.0 * u.deg  # Unused angle
+    a = 15300 * u.km
+    ecc = 0.37255 * u.one
+    nu = 120 * u.deg
+
+    orbit = Orbit.from_classical(attractor, a, ecc, _a, _a, _a, nu)
+    orbit_M = orbit.M
+
+    assert_allclose(orbit_M.value, expected_mean_anomaly.value, rtol=1e-2)
+
+
+def test_expected_angular_momentum():
+    # Example from Curtis
+    expected_ang_mom = 72472 * u.km ** 2
+
+    attractor = Earth
+
+    _a = 1.0 * u.deg  # Unused angle
+    a = 15300 * u.km
+    ecc = 0.37255 * u.one
+    nu = 120 * u.deg
+
+    orbit = Orbit.from_classical(attractor, a, ecc, _a, _a, _a, nu)
+    orbit_h_mom = orbit.h_mom
+
+    assert_allclose(orbit_h_mom.value, expected_ang_mom.value, rtol=1e-2)
+
+
+def test_expected_last_perifocal_passage():
+    # Example from Curtis
+    expected_t_p = 4077 * u.s
+
+    attractor = Earth
+
+    _a = 1.0 * u.deg  # Unused angle
+    a = 15300 * u.km
+    ecc = 0.37255 * u.one
+    nu = 120 * u.deg
+
+    orbit = Orbit.from_classical(attractor, a, ecc, _a, _a, _a, nu)
+    orbit_t_p = orbit.t_p
+
+    assert_allclose(orbit_t_p.value, expected_t_p.value, rtol=1e-2)
+
+
 def test_convert_from_rv_to_coe():
     # Data from Vallado, example 2.6
     attractor = Earth

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -217,10 +217,10 @@ class Orbit(object):
         return h_vec
 
     @property
-    def h_mom(self):
-        """Angular momentum. """
-        h_mom = np.linalg.norm(self.h_vec) * u.km ** 2
-        return h_mom
+    def h_mag(self):
+        """Specific angular momentum. """
+        h_mag = norm(self.h_vec)
+        return h_mag
 
     @property
     def arglat(self):

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -217,10 +217,27 @@ class Orbit(object):
         return h_vec
 
     @property
+    def h_mom(self):
+        """Angular momentum. """
+        h_mom = np.linalg.norm(self.h_vec) * u.km ** 2
+        return h_mom
+
+    @property
     def arglat(self):
         """Argument of latitude. """
         arglat = (self.argp + self.nu) % (360 * u.deg)
         return arglat
+
+    @property
+    def M(self):
+        """Mean anomaly. """
+        return nu_to_M(self.nu, self.ecc)
+
+    @property
+    def t_p(self):
+        """Elapsed time since latest perifocal passage. """
+        t_p = self.period * self.M / (360 * u.deg)
+        return t_p
 
     @classmethod
     @u.quantity_input(r=u.m, v=u.m / u.s)


### PR DESCRIPTION
Adds 3 orbit properties:

* Angular momentum

* Mean anomaly

* Time elapsed from last perifocal passage

* Tests taken from Curtis, H. D. (2005). Orbital mechanics for engineering students, p115, Example 3.1