### PR TITLE
Hohmann time to pericenter

### DIFF
--- a/src/poliastro/maneuver.py
+++ b/src/poliastro/maneuver.py
@@ -97,8 +97,12 @@ class Maneuver(object):
             Final altitude of the orbit
         """
 
-        if orbit_i.nu is not 0 * u.deg:
+        # Propagate till periapsis
+        if orbit_i.nu != 0 * u.deg:
+            t_pericenter = orbit_i.time_to_anomaly(0 * u.deg)
             orbit_i = orbit_i.propagate_to_anomaly(0 * u.deg)
+        else:
+            t_pericenter = 0 * u.s
 
         # Initial orbit data
         k = orbit_i.attractor.k
@@ -141,7 +145,9 @@ class Maneuver(object):
 
         t_trans = np.pi * np.sqrt(a_trans ** 3 / k)
 
-        return cls((0 * u.s, dv_a), (t_trans, dv_b))
+        return cls(
+            (t_pericenter.decompose(), dv_a.decompose()), (t_trans.decompose(), dv_b.decompose())
+        )
 
     @classmethod
     def bielliptic(cls, orbit_i, r_b, r_f):
@@ -184,8 +190,13 @@ class Maneuver(object):
         r_f: astropy.unit.Quantity
             Final altitude of the orbit
         """
-        if orbit_i.nu is not 0 * u.deg:
+
+        # Propagate till periapsis
+        if orbit_i.nu != 0 * u.deg:
+            t_pericenter = orbit_i.time_to_anomaly(0 * u.deg)
             orbit_i = orbit_i.propagate_to_anomaly(0 * u.deg)
+        else:
+            t_pericenter = 0 * u.s
 
         # Initial orbit data
         k = orbit_i.attractor.k
@@ -234,7 +245,11 @@ class Maneuver(object):
         t_trans1 = np.pi * np.sqrt(a_trans1 ** 3 / k)
         t_trans2 = np.pi * np.sqrt(a_trans2 ** 3 / k)
 
-        return cls((0 * u.s, dv_a), (t_trans1, dv_b), (t_trans2, dv_c))
+        return cls(
+            (t_pericenter.decompose(), dv_a.decompose()),
+            (t_trans1.decompose(), dv_b.decompose()),
+            (t_trans2.decompose(), dv_c.decompose()),
+        )
 
     @classmethod
     def lambert(cls, orbit_i, orbit_f, method=lambert_izzo, short=True, **kwargs):
@@ -269,7 +284,10 @@ class Maneuver(object):
         else:
             dv_a, dv_b = sols[-1]
 
-        return cls((0 * u.s, dv_a - orbit_i.v), (tof.to(u.s), orbit_f.v - dv_b))
+        return cls(
+            (0 * u.s, (dv_a - orbit_i.v).decompose()),
+            (tof.to(u.s), (orbit_f.v - dv_b).decompose()),
+        )
 
     def get_total_time(self):
         """Returns total time of the maneuver.

--- a/src/poliastro/maneuver.py
+++ b/src/poliastro/maneuver.py
@@ -146,7 +146,8 @@ class Maneuver(object):
         t_trans = np.pi * np.sqrt(a_trans ** 3 / k)
 
         return cls(
-            (t_pericenter.decompose(), dv_a.decompose()), (t_trans.decompose(), dv_b.decompose())
+            (t_pericenter.decompose(), dv_a.decompose()),
+            (t_trans.decompose(), dv_b.decompose()),
         )
 
     @classmethod

--- a/src/poliastro/tests/test_maneuver.py
+++ b/src/poliastro/tests/test_maneuver.py
@@ -44,37 +44,53 @@ def test_maneuver_impulse():
     assert man.impulses[0] == (0 * u.s, dv)
 
 
-def test_hohmann_maneuver():
+@pytest.mark.parametrize("nu", [0, 180] * u.deg)
+def test_hohmann_maneuver(nu):
     # Data from Vallado, example 6.1
     alt_i = 191.34411 * u.km
     alt_f = 35781.34857 * u.km
-    ss_i = Orbit.circular(Earth, alt_i)
+    _a = 0 * u.deg
+    ss_i = Orbit.from_classical(
+        Earth, Earth.R + alt_i, ecc=0 * u.one, inc=_a, raan=_a, argp=_a, nu=nu
+    )
+
+    # Expected output
     expected_dv = 3.935224 * u.km / u.s
+    expected_t_pericenter = ss_i.time_to_anomaly(0 * u.deg)
     expected_t_trans = 5.256713 * u.h
+    expected_total_time = expected_t_pericenter + expected_t_trans
 
     man = Maneuver.hohmann(ss_i, Earth.R + alt_f)
     assert_quantity_allclose(man.get_total_cost(), expected_dv, rtol=1e-5)
-    assert_quantity_allclose(man.get_total_time(), expected_t_trans, rtol=1e-5)
+    assert_quantity_allclose(man.get_total_time(), expected_total_time, rtol=1e-5)
 
     assert_quantity_allclose(
         ss_i.apply_maneuver(man).ecc, 0 * u.one, atol=1e-14 * u.one
     )
 
 
-def test_bielliptic_maneuver():
+@pytest.mark.parametrize("nu", [0, 180] * u.deg)
+def test_bielliptic_maneuver(nu):
     # Data from Vallado, example 6.2
     alt_i = 191.34411 * u.km
     alt_b = 503873.0 * u.km
     alt_f = 376310.0 * u.km
-    ss_i = Orbit.circular(Earth, alt_i)
+    _a = 0 * u.deg
+    ss_i = Orbit.from_classical(
+        Earth, Earth.R + alt_i, ecc=0 * u.one, inc=_a, raan=_a, argp=_a, nu=nu
+    )
+
+    # Expected output
     expected_dv = 3.904057 * u.km / u.s
+    expected_t_pericenter = ss_i.time_to_anomaly(0 * u.deg)
     expected_t_trans = 593.919803 * u.h
+    expected_total_time = expected_t_pericenter + expected_t_trans
 
     man = Maneuver.bielliptic(ss_i, Earth.R + alt_b, Earth.R + alt_f)
 
     assert_allclose(ss_i.apply_maneuver(man).ecc, 0 * u.one, atol=1e-12 * u.one)
     assert_quantity_allclose(man.get_total_cost(), expected_dv, rtol=1e-5)
-    assert_quantity_allclose(man.get_total_time(), expected_t_trans, rtol=1e-6)
+    assert_quantity_allclose(man.get_total_time(), expected_total_time, rtol=1e-6)
 
 
 def test_apply_maneuver_correct_dimensions():

--- a/src/poliastro/tests/tests_twobody/test_orbit.py
+++ b/src/poliastro/tests/tests_twobody/test_orbit.py
@@ -1033,3 +1033,11 @@ def test_orbit_change_attractor_open():
 
     assert len(record) == 1
     assert "Leaving the SOI of the current attractor" in record[0].message.args[0]
+
+
+def test_time_to_anomaly():
+    expected_tof = iss.period / 2
+    iss_180 = iss.propagate_to_anomaly(180 * u.deg)
+    tof = iss_180.time_to_anomaly(0 * u.deg)
+
+    assert_quantity_allclose(tof, expected_tof)

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -17,7 +17,6 @@ from astroquery.jplsbdb import SBDB
 from poliastro.bodies import Earth, Moon, Sun
 from poliastro.constants import J2000
 from poliastro.core.angles import nu_to_M as nu_to_M_fast
-from poliastro.core.elements import rv2coe
 from poliastro.frames import Planes, get_frame
 from poliastro.threebody.soi import laplace_radius
 from poliastro.twobody.angles import E_to_nu, M_to_nu, nu_to_M


### PR DESCRIPTION
Tries to solve #740 and #731 . This pull request includes:

* New orbit class method: `time_to_anomaly`
* Propagates `hohmann` and `bielliptic` to pericenter and adds that `time of flight` in the `Maneuver` instance.
* Makes use of `Quantity.decompose()` to avoid weird behavior with units inside `Maneuver` instances.

