### PR TITLE
Add heliosynchronous orbits

### DIFF
--- a/src/poliastro/tests/tests_twobody/test_orbit.py
+++ b/src/poliastro/tests/tests_twobody/test_orbit.py
@@ -696,6 +696,40 @@ def test_geostationary_non_existence_condition(attractor, period, hill_radius):
     )
 
 
+def test_heliosynchronous_orbit_enough_arguments():
+    with pytest.raises(ValueError) as excinfo:
+        Orbit.heliosynchronous(a=None, ecc=None, inc=None)
+
+    assert (
+        "At least two parameters of the set {a, ecc, inc} are required."
+        in excinfo.exconly()
+    )
+
+
+def test_heliosynchronous_orbit_inc():
+    # Vallado, example 11-2a
+    expected_ecc = 0 * u.one
+    expected_a = 800 * u.km + Earth.R
+    expected_inc = 98.6 * u.deg
+    ss0 = Orbit.heliosynchronous(a=expected_a, ecc=expected_ecc)
+
+    assert_quantity_allclose(ss0.inc, expected_inc, rtol=1e-4)
+    assert_quantity_allclose(ss0.a, expected_a)
+    assert_quantity_allclose(ss0.ecc, expected_ecc)
+
+
+def test_heliosynchronous_orbit_a():
+    # Vallado, example 11-2b
+    expected_ecc = 0.2 * u.one
+    expected_inc = 98.6 * u.deg
+    expected_a = 7346.846 * u.km
+    ss0 = Orbit.heliosynchronous(ecc=expected_ecc, inc=expected_inc)
+
+    assert_quantity_allclose(ss0.inc, expected_inc, rtol=1e-4)
+    assert_quantity_allclose(ss0.a, expected_a, rtol=1e-5)
+    assert_quantity_allclose(ss0.ecc, expected_ecc)
+
+
 def test_perigee_and_apogee():
     expected_r_a = 500 * u.km
     expected_r_p = 300 * u.km

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -682,6 +682,99 @@ class Orbit(object):
         return cls.circular(attractor, altitude)
 
     @classmethod
+    def heliosynchronous(
+        cls,
+        a=None,
+        ecc=None,
+        inc=None,
+        raan=0 * u.deg,
+        argp=0 * u.deg,
+        nu=0 * u.deg,
+        epoch=J2000,
+        plane=Planes.EARTH_EQUATOR,
+    ):
+        r""" Solves for a Sun-Synchronous orbit. These orbits make use of the J2
+        perturbation to precess in order to be always towards Sun. At least
+        two parameters of the set {a, ecc, inc} are needed in order to solve
+        for these kind of orbits. Relationships among them are given by:
+
+        .. math::
+            \begin{align}
+                a &= \left (\frac{-3R_{\bigoplus}J_{2}\sqrt{\mu}\cos(i)}{2\dot{\Omega}(1-e^2)^2}  \right ) ^ {\frac{2}{7}}\\
+                e &= \sqrt{1 - \sqrt{\frac{-3R_{\bigoplus}J_{2}\sqrt{\mu}cos(i)}{2a^{\frac{7}{2}}\dot{\Omega}}}}\\
+                i &= \arccos{\left ( \frac{-2a^{\frac{7}{2}}\dot{\Omega}(1-e^2)^2}{3R_{\bigoplus}J_{2}\sqrt{\mu}} \right )}\\
+            \end{align}
+
+        Parameters
+        ----------
+        a: ~astropy.units.Quantity
+            Semi-major axis.
+        ecc: ~astropy.units.Quantity
+            Eccentricity.
+        inc: ~astropy.units.Quantity
+            Inclination.
+        raan : ~astropy.units.Quantity
+            Right ascension of the ascending node.
+        argp : ~astropy.units.Quantity
+            Argument of the pericenter.
+        nu : ~astropy.units.Quantity
+            True anomaly.
+        epoch : ~astropy.time.Time, optional
+            Epoch, default to J2000.
+        plane : ~poliastro.frames.Planes
+            Fundamental plane of the frame.
+        """
+
+        # Constants for Sun-Synchronours Orbits (SSO)
+        n_sunsync = 1.991063853e-7 * u.one / u.s
+        R_earth = Earth.R
+        k_earth = Earth.k
+        J2_earth = Earth.J2
+
+        if (a is None) and (ecc is None) and (inc is None):
+            # We check sufficient number of parameters
+            raise ValueError(
+                "At least two parameters of the set {a, ecc, inc} are required."
+            )
+        elif a is None and (ecc is not None) and (inc is not None):
+            # Semi-major axis is the unknown variable
+            a = (
+                -3
+                * R_earth ** 2
+                * J2_earth
+                * np.sqrt(k_earth)
+                / (2 * n_sunsync * (1 - ecc ** 2) ** 2)
+                * np.cos(inc)
+            ) ** (2 / 7)
+        elif ecc is None and (a is not None) and (inc is not None):
+            # Eccentricity is the unknown variable
+            ecc = np.sqrt(
+                1
+                - np.sqrt(
+                    -3
+                    * R_earth ** 2
+                    * J2_earth
+                    * np.sqrt(k_earth)
+                    * np.cos(inc)
+                    / (2 * a ** (7 / 2) * n_sunsync)
+                )
+            )
+        elif inc is None and (ecc is not None) and (a is not None):
+            # Inclination is the unknown variable
+            inc = np.arccos(
+                -2
+                * a ** (7 / 2)
+                * n_sunsync
+                * (1 - ecc ** 2) ** 2
+                / (3 * R_earth ** 2 * J2_earth * np.sqrt(k_earth))
+            )
+        ss = cls.from_classical(
+            Earth, a, ecc, inc, raan, argp, nu, epoch=epoch.tdb, plane=plane
+        )
+
+        return ss
+
+    @classmethod
     @u.quantity_input(p=u.m, inc=u.rad, raan=u.rad, argp=u.rad, nu=u.rad)
     def parabolic(
         cls, attractor, p, inc, raan, argp, nu, epoch=J2000, plane=Planes.EARTH_EQUATOR


### PR DESCRIPTION
With this pull request, a new orbit creation method regarding `SSO orbits` is added. It contains also some tests coming from Vallado 11-2. 

The `if...elif...else` implementation was the only idea that came to my mind when working with these kind of orbits since just two of the three following parameters `{a, ecc, inc}` are needed in order to define them.