### PR TITLE
Sampler for any Orbit attribute

### DIFF
--- a/src/poliastro/tests/tests_twobody/test_orbit.py
+++ b/src/poliastro/tests/tests_twobody/test_orbit.py
@@ -52,6 +52,7 @@ from poliastro.twobody.orbit import (
     PatchedConicsWarning,
     TimeScaleWarning,
 )
+from poliastro.util import time_range
 
 
 @pytest.fixture()
@@ -1041,3 +1042,10 @@ def test_time_to_anomaly():
     tof = iss_180.time_to_anomaly(0 * u.deg)
 
     assert_quantity_allclose(tof, expected_tof)
+
+
+def test_orbit_sampler():
+    t_span = time_range(iss.epoch, end=iss.epoch + 24 * u.h)
+    expected_r = [iss.propagate(t).r for t in t_span]
+    r_span = iss.sample_attr("r", t_span)
+    assert_quantity_allclose(r_span[2], expected_r[2])

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -1190,6 +1190,47 @@ class Orbit(object):
             )
             return cartesian
 
+    def _sample_attr(self, orbit_attr, time):
+        """ Single attribute sampler.
+
+        Parameters
+        ----------
+        orbit_attr: str
+            String representing Orbit's attribute.
+        time: ~astropy.units.Quantity
+            Time at which property wants to be known.
+
+        Returns
+        -------
+        attr: ~astropy.units.Quantity
+            Attribute value.
+        """
+
+        new_orbit = self.propagate(time)
+        return getattr(new_orbit, orbit_attr)
+
+    def sample_attr(self, orbit_attr, time_span):
+        """ Returns any sampled attribute for a given sampled time span.
+
+        Parameters
+        ----------
+        orbit_attr: str
+            Orbit's attribute name to be sampled.
+        time_span: ~poliastro.util.time_range
+            Time span for sampling the attribute.
+
+        Returns
+        -------
+        attr_sampled: list
+            List containing each value for the attribute along time.
+        """
+
+        vec_sample_attr = np.vectorize(
+            self._sample_attr, otypes=[list], excluded=["orbit_attr"]
+        )
+        attr_sampled = vec_sample_attr(orbit_attr, time_span)
+        return attr_sampled
+
     def _generate_time_values(self, nu_vals):
         # Subtract current anomaly to start from the desired point
         ecc = self.ecc.value


### PR DESCRIPTION
This is just a possible implementation by making use of `np.vectorize` function. The desired attribute should be passed as string. This works in the following way:

```python
from poliastro.util import time_range
t_span = time_range(ss.epoch, end=ss.epoch + 24 * u.h)
nu_span = ss.sample_attr("nu", t_span)
``` 

This was developed to solve #380 :+1: 