### PR TITLE
Mark tests that use remote data

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -81,6 +81,7 @@ dev =
     pycodestyle
     pytest>=3.2
     pytest-cov<2.6.0
+    pytest-doctestplus
     pytest-mpl
     pytest-mypy
     pytest-remotedata

--- a/setup.cfg
+++ b/setup.cfg
@@ -93,8 +93,11 @@ dev =
 [tool:pytest]
 norecursedirs =
     .git
+    .tox
     dist
+    env
     build
+    venv
 python_files =
     test_*.py
 doctest_plus = disabled

--- a/src/poliastro/core/util.py
+++ b/src/poliastro/core/util.py
@@ -92,17 +92,14 @@ def transform(vec, angle, axis):
 def norm(vec):
     r"""Returns the norm of a 3 dimension vector.
 
-
     .. math::
 
         \left \| \vec{v} \right \| = \sqrt{\sum_{i=1}^{n}v_{i}^2}
 
     Parameters
     ----------
-
     vec: ndarray
         Dimension 3 vector.
-
 
     Examples
     --------
@@ -111,7 +108,6 @@ def norm(vec):
     1.7320508075688772
 
     """
-
     vec = 1.0 * vec  # Cast to float
     return np.sqrt(vec.dot(vec))
 
@@ -135,7 +131,6 @@ def cross(a, b):
 
     Parameters
     ----------
-
     a : ndarray
         3 Dimension vector.
     b : ndarray
@@ -154,7 +149,6 @@ def cross(a, b):
     https://github.com/numba/numba/issues/2978
 
     """
-
     return np.array(
         (
             a[1] * b[2] - a[2] * b[1],

--- a/src/poliastro/core/util.py
+++ b/src/poliastro/core/util.py
@@ -106,9 +106,7 @@ def norm(vec):
 
     Examples
     --------
-    >>> from poliastro.core.util import norm
-    >>> from astropy import units as u
-    >>> vec = [1, 1, 1] * u.m
+    >>> vec = np.array([1, 1, 1])
     >>> norm(vec)
     1.7320508075688772
 
@@ -145,10 +143,8 @@ def cross(a, b):
 
     Examples
     --------
-    >>> from poliastro.core.util import cross
-    >>> from astropy import units as u
-    >>> i = [1, 0, 0] * u.m
-    >>> j = [0, 1, 0] * u.m
+    >>> i = np.array([1., 0., 0.])
+    >>> j = np.array([0., 1., 0.])
     >>> cross(i, j)
     array([0., 0., 1.])
 

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -550,7 +550,7 @@ class Orbit(object):
         Examples
         --------
         >>> from poliastro.twobody.orbit import Orbit
-        >>> apophis_orbit = Orbit.from_sbdb('apophis')
+        >>> apophis_orbit = Orbit.from_sbdb('apophis')  # doctest: +REMOTE_DATA
         """
 
         obj = SBDB.query(name, full_precision=True, **kargs)


### PR DESCRIPTION
In Debian, we run the build time and CI tests without access to the internet. This makes some of the poliastro tests fail.

To handle this, there is the "pytest-remotedata" package (and the "pytest-doctestplus" package for doctests) that add a "remotedata" option to pytest. Both packages are already pulled with the "astropy-helpers" package. This patch adds the options on the necessary places.

Would you consider applying this to make my life easier here? Thanks!