### PR TITLE
Use sphinx-hoverxref in docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,7 +45,14 @@ extensions = [
     'sphinx.ext.mathjax',  # Maths visualization
     'sphinx.ext.graphviz',  # Dependency diagrams
     'notfound.extension',
+    'hoverxref.extension',
 ]
+
+# Hoverxref Extension
+hoverxref_auto_ref = True
+hoverxref_mathjax = True
+hoverxref_domains = ['py']
+
 
 # Custom configuration
 autodoc_member_order = 'bysource'

--- a/setup.cfg
+++ b/setup.cfg
@@ -87,6 +87,7 @@ dev =
     pytest-remotedata
     sphinx
     sphinx_rtd_theme @ https://github.com/Juanlu001/sphinx_rtd_theme/archive/avoid-require-redefinition.zip
+    sphinx-hoverxref @ https://github.com/readthedocs/sphinx-hoverxref/archive/master.zip
     sphinx-notfound-page
     tox
 


### PR DESCRIPTION
`sphinx-hoverxref` allows to show embeded content (from a different page) in a tooltip when the reader "hovers" on a cross-reference.

It currently support `:ref:` roles and Python Domain (`:py:class:`, etc).

![screenshot-poliastro-humitos readthedocs io-2019 09 06-15_19_32](https://user-images.githubusercontent.com/244656/64431138-1e28de00-d0ba-11e9-9f3e-cb94eeca582b.png)

This PR installs and configure this extension to be used in poliastro's documentation.

You can see a rendered version of this documentation using the extension at https://poliastro-humitos.readthedocs.io/en/hoverxref/ and an example for the tooltips in this exact page https://poliastro-humitos.readthedocs.io/en/hoverxref/api/safe/maneuver.html#poliastro.maneuver.Maneuver

> NOTE: the current status of the extension is Beta because it's not widely tested, but there are not known issues that could affect poliastro at the moment. Feel free to "not merge" or "close" or report any issue you think it's required before merging.