### PR TITLE
Add RAAN from LTAN calculation to SSO calculation

### DIFF
--- a/src/poliastro/tests/tests_twobody/test_orbit.py
+++ b/src/poliastro/tests/tests_twobody/test_orbit.py
@@ -696,6 +696,40 @@ def test_geostationary_non_existence_condition(attractor, period, hill_radius):
     )
 
 
+def test_heliosynchronous_orbit_enough_arguments():
+    with pytest.raises(ValueError) as excinfo:
+        Orbit.heliosynchronous(a=None, ecc=None, inc=None)
+
+    assert (
+        "At least two parameters of the set {a, ecc, inc} are required."
+        in excinfo.exconly()
+    )
+
+
+def test_heliosynchronous_orbit_inc():
+    # Vallado, example 11-2a
+    expected_ecc = 0 * u.one
+    expected_a = 800 * u.km + Earth.R
+    expected_inc = 98.6 * u.deg
+    ss0 = Orbit.heliosynchronous(a=expected_a, ecc=expected_ecc)
+
+    assert_quantity_allclose(ss0.inc, expected_inc, rtol=1e-4)
+    assert_quantity_allclose(ss0.a, expected_a)
+    assert_quantity_allclose(ss0.ecc, expected_ecc)
+
+
+def test_heliosynchronous_orbit_a():
+    # Vallado, example 11-2b
+    expected_ecc = 0.2 * u.one
+    expected_inc = 98.6 * u.deg
+    expected_a = 7346.846 * u.km
+    ss0 = Orbit.heliosynchronous(ecc=expected_ecc, inc=expected_inc)
+
+    assert_quantity_allclose(ss0.inc, expected_inc, rtol=1e-4)
+    assert_quantity_allclose(ss0.a, expected_a, rtol=1e-5)
+    assert_quantity_allclose(ss0.ecc, expected_ecc)
+
+
 def test_perigee_and_apogee():
     expected_r_a = 500 * u.km
     expected_r_p = 300 * u.km

--- a/src/poliastro/twobody/angles.py
+++ b/src/poliastro/twobody/angles.py
@@ -1,8 +1,10 @@
 """Angles and anomalies.
 
 """
-from astropy import units as u
+import numpy as np
+from astropy import coordinates, units as u
 
+from poliastro import constants
 from poliastro.core.angles import (
     D_to_M as D_to_M_fast,
     D_to_nu as D_to_nu_fast,
@@ -351,3 +353,67 @@ def fp_angle(nu, ecc):
 
     """
     return (fp_angle_fast(nu.to(u.rad).value, ecc.value) * u.rad).to(nu.unit)
+
+
+@u.quantity_input(ltan=u.hourangle)
+def raan_from_ltan(epoch, ltan=12.0):
+    """RAAN angle from LTAN for SSO around the earth
+
+    Parameters
+    ----------
+    epoch : ~astropy.time.Time
+         Value of time to calculate the RAAN for
+    ltan: ~astropy.units.Quantity
+         Decimal hour between 0 and 24
+
+    Returns
+    -------
+    RAAN: ~astropy.units.Quantity
+        Right ascension of the ascending node angle in GCRS
+
+    Note
+    ----
+    Calculations of the sun mean longitude and equation of time
+    follow "Fundamentals of Astrodynamics and Applications"
+    Fourth edition by Vallado, David A.
+    """
+
+    T_UT1 = ((epoch.ut1 - constants.J2000).value / 36525.0) * u.deg
+    T_TDB = ((epoch.tdb - constants.J2000).value / 36525.0) * u.deg
+
+    # Apparent sun position
+    sun_position = coordinates.get_sun(epoch)
+
+    # Calculate the sun apparent local time
+    salt = sun_position.ra + 12 * u.hourangle
+
+    # Use the equation of time to calculate the mean sun local time (fictional sun without anomalies)
+
+    # sun mean anomaly
+    M_sun = 357.5291092 * u.deg + 35999.05034 * T_TDB
+
+    # sun mean longitude
+    l_sun = 280.460 * u.deg + 36000.771 * T_UT1
+    l_ecliptic_part2 = 1.914666471 * u.deg * np.sin(
+        M_sun
+    ) + 0.019994643 * u.deg * np.sin(2 * M_sun)
+    l_ecliptic = l_sun + l_ecliptic_part2
+
+    eq_time = (
+        -l_ecliptic_part2
+        + 2.466 * u.deg * np.sin(2 * l_ecliptic)
+        - 0.0053 * u.deg * np.sin(4 * l_ecliptic)
+    )
+
+    # Calculate sun mean local time
+
+    smlt = salt + eq_time
+
+    # Desired angle between sun and ascending node
+    alpha = (coordinates.Angle(ltan).wrap_at(24 * u.hourangle) - 12 * u.hourangle).to(
+        u.rad
+    )
+
+    # Use the mean sun local time calculate needed RAAN for given LTAN
+    raan = smlt + alpha
+    return raan

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -682,6 +682,99 @@ class Orbit(object):
         return cls.circular(attractor, altitude)
 
     @classmethod
+    def heliosynchronous(
+        cls,
+        a=None,
+        ecc=None,
+        inc=None,
+        raan=0 * u.deg,
+        argp=0 * u.deg,
+        nu=0 * u.deg,
+        epoch=J2000,
+        plane=Planes.EARTH_EQUATOR,
+    ):
+        r""" Solves for a Sun-Synchronous orbit. These orbits make use of the J2
+        perturbation to precess in order to be always towards Sun. At least
+        two parameters of the set {a, ecc, inc} are needed in order to solve
+        for these kind of orbits. Relationships among them are given by:
+
+        .. math::
+            \begin{align}
+                a &= \left (\frac{-3R_{\bigoplus}J_{2}\sqrt{\mu}\cos(i)}{2\dot{\Omega}(1-e^2)^2}  \right ) ^ {\frac{2}{7}}\\
+                e &= \sqrt{1 - \sqrt{\frac{-3R_{\bigoplus}J_{2}\sqrt{\mu}cos(i)}{2a^{\frac{7}{2}}\dot{\Omega}}}}\\
+                i &= \arccos{\left ( \frac{-2a^{\frac{7}{2}}\dot{\Omega}(1-e^2)^2}{3R_{\bigoplus}J_{2}\sqrt{\mu}} \right )}\\
+            \end{align}
+
+        Parameters
+        ----------
+        a: ~astropy.units.Quantity
+            Semi-major axis.
+        ecc: ~astropy.units.Quantity
+            Eccentricity.
+        inc: ~astropy.units.Quantity
+            Inclination.
+        raan : ~astropy.units.Quantity
+            Right ascension of the ascending node.
+        argp : ~astropy.units.Quantity
+            Argument of the pericenter.
+        nu : ~astropy.units.Quantity
+            True anomaly.
+        epoch : ~astropy.time.Time, optional
+            Epoch, default to J2000.
+        plane : ~poliastro.frames.Planes
+            Fundamental plane of the frame.
+        """
+
+        # Constants for Sun-Synchronours Orbits (SSO)
+        n_sunsync = 1.991063853e-7 * u.one / u.s
+        R_earth = Earth.R
+        k_earth = Earth.k
+        J2_earth = Earth.J2
+
+        if (a is None) and (ecc is None) and (inc is None):
+            # We check sufficient number of parameters
+            raise ValueError(
+                "At least two parameters of the set {a, ecc, inc} are required."
+            )
+        elif a is None and (ecc is not None) and (inc is not None):
+            # Semi-major axis is the unknown variable
+            a = (
+                -3
+                * R_earth ** 2
+                * J2_earth
+                * np.sqrt(k_earth)
+                / (2 * n_sunsync * (1 - ecc ** 2) ** 2)
+                * np.cos(inc)
+            ) ** (2 / 7)
+        elif ecc is None and (a is not None) and (inc is not None):
+            # Eccentricity is the unknown variable
+            ecc = np.sqrt(
+                1
+                - np.sqrt(
+                    -3
+                    * R_earth ** 2
+                    * J2_earth
+                    * np.sqrt(k_earth)
+                    * np.cos(inc)
+                    / (2 * a ** (7 / 2) * n_sunsync)
+                )
+            )
+        elif inc is None and (ecc is not None) and (a is not None):
+            # Inclination is the unknown variable
+            inc = np.arccos(
+                -2
+                * a ** (7 / 2)
+                * n_sunsync
+                * (1 - ecc ** 2) ** 2
+                / (3 * R_earth ** 2 * J2_earth * np.sqrt(k_earth))
+            )
+        ss = cls.from_classical(
+            Earth, a, ecc, inc, raan, argp, nu, epoch=epoch.tdb, plane=plane
+        )
+
+        return ss
+
+    @classmethod
     @u.quantity_input(p=u.m, inc=u.rad, raan=u.rad, argp=u.rad, nu=u.rad)
     def parabolic(
         cls, attractor, p, inc, raan, argp, nu, epoch=J2000, plane=Planes.EARTH_EQUATOR


### PR DESCRIPTION
This uses PR #747 to also add the RAAN from LTAN calculation and 
use LTAN to dervice current RAAN to be further propagated with J2 perturbations.