### PR TITLE
Update docs/contributing.rst

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -118,4 +118,4 @@ These are some succinct steps to set up a development environment:
 For more detailed explanations, please check out the `Astropy development docs`__.
 
 .. _`flit`: https://github.com/takluyver/flit
-.. __: http://docs.astropy.org/en/stable/development/workflow/development_workflow.html
+.. __: https://docs.astropy.org/en/stable/development/workflow/development_workflow.html

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -104,15 +104,18 @@ These are some succint steps to set up a development environment:
 2. `Register to GitHub <https://github.com/>`_.
 3. `Fork poliastro <https://help.github.com/articles/fork-a-repo/>`_.
 4. `Clone your fork <https://help.github.com/articles/cloning-a-repository/>`_.
-5. Install it in development mode using
-   :code:`pip install --editable /path/to/poliastro/[dev]` (this means that the
+5. Install `flit`_ using
+   :code:`python -m pip install flit`
+6. Change into the local checkout of your repository and install it in development mode using
+   :code:`flit install --symlink` (:code:`--symlink` means that the
    installed code will change as soon as you change it in the download
    location).
-6. Create a new branch.
-7. Make changes and commit.
-8. `Push to your fork <https://help.github.com/articles/pushing-to-a-remote/>`_.
-9. `Open a pull request! <https://help.github.com/articles/creating-a-pull-request/>`_
+7. Create a new branch.
+8. Make changes and commit.
+9. `Push to your fork <https://help.github.com/articles/pushing-to-a-remote/>`_.
+10. `Open a pull request! <https://help.github.com/articles/creating-a-pull-request/>`_
 
 For more detailed explanations, please check out the `Astropy development docs`__.
 
+.. _`flit`: https://github.com/takluyver/flit
 .. __: http://docs.astropy.org/en/stable/development/workflow/development_workflow.html

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -98,7 +98,7 @@ library.
 Development environment
 -----------------------
 
-These are some succint steps to set up a development environment:
+These are some succinct steps to set up a development environment:
 
 1. `Install git <https://git-scm.com/>`_ on your computer.
 2. `Register to GitHub <https://github.com/>`_.


### PR DESCRIPTION
Three commits updating the contributing guide as discussed via matrix.

some small note:
The new installation method using `flit install --symlink` might break on Windows, where `flit install --pth-file` might be a better option (see [docs: flit install --pth-file option](https://flit.readthedocs.io/en/latest/cmdline.html#cmdoption-flit-install-pth-file)).