### PR TITLE
Fix typo in CZML user guide

### DIFF
--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -480,7 +480,7 @@ Specify the starting and ending epoch, as well as the number of sample points (t
 
     start_epoch = iss.epoch
     end_epoch = iss.epoch + molniya.period
-    N = 10
+    sample_points = 10
 
     extractor = CZMLExtractor(start_epoch, end_epoch, sample_points)
 


### PR DESCRIPTION
Note: This typo is already fixed in the [examples/CZML Tutorial.ipynb](https://github.com/poliastro/poliastro/blob/master/docs/source/examples/CZML%20Tutorial.ipynb).

(OT: The tutorial duplicates the user guide but is more complete (ideally it should be the other way around imo), although it's still missing some steps on how to conveniently write `extractor.packets` to json files). I'll try to create a proper MR when I figured out how to ues poliastro+czml in a convenient way (planning to use it for matching navarea warnings to last orbits / plotting).