### PR TITLE
Minimal error in docstring

### DIFF
--- a/src/poliastro/core/perturbations.py
+++ b/src/poliastro/core/perturbations.py
@@ -110,7 +110,7 @@ def atmospheric_drag(t0, state, k, R, C_D, A, m, H0, rho0):
     H0 : float
         atmospheric scale height, (km)
     rho0: float
-        the exponent density pre-factor, (kg / m^3)
+        the exponent density pre-factor, (kg / km^3)
 
     Note
     ----


### PR DESCRIPTION
Solves #780 

The function requires that user introduced the air's density in [kg/km3]. However the docstring claimed to be input in [kg/m3]. This pull request solves this minimal issue :relaxed:  