### PR TITLE
Add mean elements to bodies, remove from_body_ephem

### DIFF
--- a/src/poliastro/bodies.py
+++ b/src/poliastro/bodies.py
@@ -111,6 +111,15 @@ class Body(
         R = R * reference.R
         return cls(parent, k, name, symbol, R, **kwargs)
 
+    def get_mean_orbit(self, epoch=None):
+        # TODO: Change structure to avoid circular imports
+        from poliastro.ephem import get_mean_orbit
+
+        if epoch is None:
+            epoch = constants.J2000
+
+        return get_mean_orbit(self, epoch)
+
 
 class SolarSystemBody(Body):
     pass

--- a/src/poliastro/ephem.py
+++ b/src/poliastro/ephem.py
@@ -9,6 +9,128 @@ from astropy.coordinates import (
 from astropy.time import Time
 from scipy.interpolate import interp1d
 
+from .bodies import Earth, Jupiter, Mars, Mercury, Neptune, Pluto, Saturn, Uranus, Venus
+from .constants import J2000
+from .frames import Planes
+from .twobody.angles import M_to_nu
+from .twobody.orbit import Orbit
+
+# Source: https://ssd.jpl.nasa.gov/?planet_pos
+MEAN_ELEMENTS_1800AD_2050AD = {
+    Mercury: {
+        "a": (0.38709927, 0.00000037),
+        "ecc": (0.20563593, 0.00001906),
+        "inc": (7.00497902, -0.00594749),
+        "meanlon": (252.25032350, 149472.67411175),
+        "lonper": (77.45779628, 0.16047689),
+        "node": (48.33076593, -0.12534081),
+    },
+    Venus: {
+        "a": (0.72333566, 3.9e-06),
+        "ecc": (0.00677672, -4.107e-05),
+        "inc": (3.39467605, -0.0007889),
+        "meanlon": (181.9790995, 58517.81538729),
+        "lonper": (131.60246718, 0.00268329),
+        "node": (76.67984255, -0.27769418),
+    },
+    Earth: {
+        "a": (1.00000261, 5.62e-06),
+        "ecc": (0.01671123, -4.392e-05),
+        "inc": (-1.531e-05, -0.01294668),
+        "meanlon": (100.46457166, 35999.37244981),
+        "lonper": (102.93768193, 0.32327364),
+        "node": (0.0, 0.0),
+    },
+    Mars: {
+        "a": (1.52371034, 1.847e-05),
+        "ecc": (0.0933941, 7.882e-05),
+        "inc": (1.84969142, -0.00813131),
+        "meanlon": (-4.55343205, 19140.30268499),
+        "lonper": (-23.94362959, 0.44441088),
+        "node": (49.55953891, -0.29257343),
+    },
+    Jupiter: {
+        "a": (5.202887, -0.00011607),
+        "ecc": (0.04838624, -0.00013253),
+        "inc": (1.30439695, -0.00183714),
+        "meanlon": (34.39644051, 3034.74612775),
+        "lonper": (14.72847983, 0.21252668),
+        "node": (100.47390909, 0.20469106),
+    },
+    Saturn: {
+        "a": (9.53667594, -0.0012506),
+        "ecc": (0.05386179, -0.00050991),
+        "inc": (2.48599187, 0.00193609),
+        "meanlon": (49.95424423, 1222.49362201),
+        "lonper": (92.59887831, -0.41897216),
+        "node": (113.66242448, -0.28867794),
+    },
+    Uranus: {
+        "a": (19.18916464, -0.00196176),
+        "ecc": (0.04725744, -4.397e-05),
+        "inc": (0.77263783, -0.00242939),
+        "meanlon": (313.23810451, 428.48202785),
+        "lonper": (170.9542763, 0.40805281),
+        "node": (74.01692503, 0.04240589),
+    },
+    Neptune: {
+        "a": (30.06992276, 0.00026291),
+        "ecc": (0.00859048, 5.105e-05),
+        "inc": (1.77004347, 0.00035372),
+        "meanlon": (-55.12002969, 218.45945325),
+        "lonper": (44.96476227, -0.32241464),
+        "node": (131.78422574, -0.00508664),
+    },
+    Pluto: {
+        "a": (39.48211675, -0.00031596),
+        "ecc": (0.2488273, 5.17e-05),
+        "inc": (17.14001206, 4.818e-05),
+        "meanlon": (238.92903833, 145.20780515),
+        "lonper": (224.06891629, -0.04062942),
+        "node": (110.30393684, -0.01183482),
+    },
+}
+
+
+def _get_element(element_0, element_dot, epoch=J2000):
+    T_cent = (epoch.jd - J2000.jd) / 36525
+    return element_0 + element_dot * T_cent
+
+
+def _get_elements(body, epoch=J2000):
+    elements = MEAN_ELEMENTS_1800AD_2050AD[body]
+    return {
+        name: _get_element(elem[0], elem[1], epoch) for name, elem in elements.items()
+    }
+
+
+def get_mean_orbit(body, epoch=J2000):
+    elements = _get_elements(body, epoch)
+
+    a = elements["a"]
+    e = elements["ecc"]
+    inc = elements["inc"]
+    node = elements["node"]
+
+    if inc < 0:
+        inc = -inc
+        node = (node + 180) % 360
+
+    argp = elements["lonper"] - node
+    M = elements["meanlon"] - elements["lonper"]
+
+    return Orbit.from_classical(
+        body.parent,
+        a * u.au,
+        e * u.one,
+        inc * u.deg,
+        node * u.deg,
+        argp * u.deg,
+        M_to_nu(M * u.deg, e * u.one),
+        epoch,
+        plane=Planes.EARTH_ECLIPTIC,
+    )
+
 
 def build_ephem_interpolant(body, period, t_span, rtol=1e-5):
     """Interpolates ephemerides data

--- a/src/poliastro/plotting/misc.py
+++ b/src/poliastro/plotting/misc.py
@@ -10,7 +10,6 @@ from poliastro.bodies import (
     Uranus,
     Venus,
 )
-from poliastro.twobody import Orbit
 
 from .core import OrbitPlotter2D, OrbitPlotter3D
 from .static import StaticOrbitPlotter
@@ -22,12 +21,11 @@ def _plot_bodies(orbit_plotter, outer=True, epoch=None):
         bodies.extend([Jupiter, Saturn, Uranus, Neptune])
 
     for body in bodies:
-        orb = Orbit.from_body_ephem(body, epoch)
-        orbit_plotter.plot(orb, label=str(body))
+        orbit_plotter.plot(body.get_mean_orbit(epoch), label=str(body))
 
 
 def _plot_solar_system_2d(outer=True, epoch=None, interactive=False):
-    pqw = Orbit.from_body_ephem(Earth, epoch).pqw()
+    pqw = Earth.get_mean_orbit().pqw()
     if interactive:
         orbit_plotter = (
             OrbitPlotter2D()

--- a/src/poliastro/tests/tests_plotting/test_core.py
+++ b/src/poliastro/tests/tests_plotting/test_core.py
@@ -6,7 +6,6 @@ from astropy import units as u
 from poliastro.bodies import Earth, Mars, Sun
 from poliastro.examples import iss
 from poliastro.plotting import OrbitPlotter2D, OrbitPlotter3D
-from poliastro.twobody.orbit import Orbit
 
 
 @pytest.mark.parametrize("plotter_class", [OrbitPlotter2D, OrbitPlotter3D])
@@ -92,8 +91,7 @@ def test_plot_3d_trajectory_plots_a_trajectory():
     frame = OrbitPlotter3D()
     assert len(frame.trajectories) == 0
 
-    earth = Orbit.from_body_ephem(Earth)
-    trajectory = earth.sample()
+    trajectory = Earth.get_mean_orbit().sample()
     frame.set_attractor(Sun)
     frame.plot_trajectory(trajectory)
 
@@ -105,7 +103,7 @@ def test_plot_2d_trajectory_plots_a_trajectory():
     frame = OrbitPlotter2D()
     assert len(frame.trajectories) == 0
 
-    earth = Orbit.from_body_ephem(Earth)
+    earth = Earth.get_mean_orbit()
     trajectory = earth.sample()
     frame.set_attractor(Sun)
     frame.set_frame(*earth.pqw())
@@ -119,8 +117,7 @@ def test_plot_2d_trajectory_plots_a_trajectory():
 def test_show_calls_prepare_plot(plotter_class):
     with mock.patch.object(plotter_class, "_prepare_plot") as mock_prepare_plot:
         m = plotter_class()
-        earth = Orbit.from_body_ephem(Earth)
-        m.plot(orbit=earth, label="Object")
+        m.plot(orbit=Earth.get_mean_orbit(), label="Object")
         m.show()
 
         mock_prepare_plot.assert_called_with()

--- a/src/poliastro/tests/tests_plotting/test_static.py
+++ b/src/poliastro/tests/tests_plotting/test_static.py
@@ -5,7 +5,6 @@ import pytest
 from poliastro.bodies import Earth, Jupiter, Mars
 from poliastro.examples import iss
 from poliastro.plotting.static import StaticOrbitPlotter
-from poliastro.twobody.orbit import Orbit
 
 
 def test_orbitplotter_has_axes():
@@ -69,8 +68,8 @@ def test_color():
 
 def test_plot_trajectory_sets_label():
     op = StaticOrbitPlotter()
-    earth = Orbit.from_body_ephem(Earth)
-    mars = Orbit.from_body_ephem(Mars)
+    earth = Earth.get_mean_orbit()
+    mars = Mars.get_mean_orbit()
     trajectory = earth.sample()
     op.plot(mars, label="Mars")
     op.plot_trajectory(trajectory, label="Earth")
@@ -95,7 +94,7 @@ def test_redraw_makes_attractor_none():
 def test_set_frame_plots_same_colors():
     # TODO: Review
     op = StaticOrbitPlotter()
-    jupiter = Orbit.from_body_ephem(Jupiter)
+    jupiter = Jupiter.get_mean_orbit()
     op.plot(jupiter)
     colors1 = [orb[2] for orb in op.trajectories]
     op.set_frame(*jupiter.pqw())
@@ -106,8 +105,8 @@ def test_set_frame_plots_same_colors():
 def test_redraw_keeps_trajectories():
     # See https://github.com/poliastro/poliastro/issues/518
     op = StaticOrbitPlotter()
-    earth = Orbit.from_body_ephem(Earth)
-    mars = Orbit.from_body_ephem(Mars)
+    earth = Earth.get_mean_orbit()
+    mars = Mars.get_mean_orbit()
     trajectory = earth.sample()
     op.plot(mars, label="Mars")
     op.plot_trajectory(trajectory, label="Earth")

--- a/src/poliastro/tests/tests_threebody/test_soi.py
+++ b/src/poliastro/tests/tests_threebody/test_soi.py
@@ -3,7 +3,6 @@ from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose
 
 from poliastro.bodies import (
-    Body,
     Earth,
     Jupiter,
     Mars,
@@ -39,14 +38,6 @@ def test_laplace_radius(body, expected_r_SOI):
     assert_quantity_allclose(r_SOI, expected_r_SOI, rtol=1e-1)
 
 
-def test_laplace_radius_given_a():
-    parent = Body(None, 1 * u.km ** 3 / u.s ** 2, "Parent")
-    body = Body(parent, 1 * u.km ** 3 / u.s ** 2, "Body")
-    r_SOI = laplace_radius(body, 1 * u.km)
-
-    assert r_SOI == 1 * u.km
-
-
 @pytest.mark.parametrize(
     "body, expected_r_SOI",
     [
@@ -64,14 +55,6 @@ def test_hill_radius(body, expected_r_SOI):
     if expected_r_SOI is not None:
         expected_r_SOI = expected_r_SOI * u.m
 
-    r_SOI = hill_radius(body, e=0 * u.one)
+    r_SOI = hill_radius(body)
 
     assert_quantity_allclose(r_SOI, expected_r_SOI, rtol=1e-1)
-
-
-def test_hill_radius_given_a():
-    parent = Body(None, 1 * u.km ** 3 / u.s ** 2, "Parent")
-    body = Body(parent, 1 * u.km ** 3 / u.s ** 2, "Body")
-    r_SOI = hill_radius(body, 1 * u.km, 0.25 * u.one)
-    expected_r_SOI = 520.02096 * u.m
-    assert_quantity_allclose(r_SOI, expected_r_SOI, rtol=1e-8)

--- a/src/poliastro/tests/tests_twobody/test_orbit.py
+++ b/src/poliastro/tests/tests_twobody/test_orbit.py
@@ -33,7 +33,6 @@ from poliastro.examples import iss
 from poliastro.frames import (
     GCRS,
     HCRS,
-    ICRS,
     HeliocentricEclipticJ2000,
     JupiterICRS,
     MarsICRS,
@@ -46,12 +45,7 @@ from poliastro.frames import (
     VenusICRS,
     get_frame,
 )
-from poliastro.twobody.orbit import (
-    Orbit,
-    OrbitSamplingWarning,
-    PatchedConicsWarning,
-    TimeScaleWarning,
-)
+from poliastro.twobody.orbit import Orbit, OrbitSamplingWarning, PatchedConicsWarning
 
 
 @pytest.fixture()
@@ -146,31 +140,6 @@ def test_apply_maneuver_changes_epoch():
     dv = [0, 0, 0] * u.km / u.s
     orbit_new = ss.apply_maneuver([(dt, dv)])
     assert orbit_new.epoch == ss.epoch + dt
-
-
-def test_orbit_from_ephem_with_no_epoch_is_today():
-    # This is not that obvious http://stackoverflow.com/q/6407362/554319
-    body = Earth
-    ss = Orbit.from_body_ephem(body)
-    assert (Time.now() - ss.epoch).sec < 1
-
-
-def test_from_ephem_raises_warning_if_time_is_not_tdb_with_proper_time(recwarn):
-    body = Earth
-    epoch = Time("2017-09-29 07:31:26", scale="utc")
-    expected_epoch_string = "2017-09-29 07:32:35.182"  # epoch.tdb.value
-
-    Orbit.from_body_ephem(body, epoch)
-
-    w = recwarn.pop(TimeScaleWarning)
-    assert expected_epoch_string in str(w.message)
-
-
-@pytest.mark.parametrize("body", [Moon, Pluto])
-def test_from_ephem_raises_error_for_pluto_moon(body):
-    with pytest.raises(RuntimeError) as excinfo:
-        Orbit.from_body_ephem(body)
-    assert "To compute the position and velocity" in excinfo.exconly()
 
 
 def test_circular_has_proper_semimajor_axis():
@@ -525,15 +494,6 @@ def test_orbit_from_custom_body_raises_error_when_asked_frame():
         "Frames for orbits around custom bodies are not yet supported"
         in excinfo.exconly()
     )
-
-
-@pytest.mark.parametrize(
-    "body", [Sun, Mercury, Venus, Earth, Mars, Jupiter, Saturn, Uranus, Neptune]
-)
-def test_orbit_from_ephem_is_in_icrs_frame(body):
-    ss = Orbit.from_body_ephem(body)
-
-    assert ss.frame.is_equivalent_frame(ICRS())
 
 
 def test_orbit_accepts_ecliptic_plane():

--- a/src/poliastro/tests/tests_twobody/test_orbit.py
+++ b/src/poliastro/tests/tests_twobody/test_orbit.py
@@ -618,41 +618,31 @@ def test_plane_is_set_in_horizons():
 
 
 @pytest.mark.parametrize(
-    "attractor,angular_velocity,expected_a,expected_period",
+    "attractor,expected_a,expected_period",
     [
-        (
-            Earth,
-            (2 * np.pi / 23.9345) * u.rad / u.hour,
-            42_164_205 * u.m,
-            23.9345 * u.hour,
-        ),
-        (
-            Mars,
-            (2 * np.pi / 24.6228) * u.rad / u.hour,
-            20_427_595 * u.m,
-            24.6228 * u.hour,
-        ),
+        (Earth, 42_164_205 * u.m, 23.9345 * u.hour),
+        (Mars, 20_427_595 * u.m, 24.6228 * u.hour),
     ],
 )
 def test_geostationary_creation_from_angular_velocity(
-    attractor, angular_velocity, expected_a, expected_period
+    attractor, expected_a, expected_period
 ):
-    ss = Orbit.geostationary(attractor=attractor, angular_velocity=angular_velocity)
+    ss = Orbit.geostationary(attractor=attractor)
     assert_quantity_allclose(ss.a, expected_a, rtol=1.0e-7)
     assert_quantity_allclose(ss.period, expected_period, rtol=1.0e-7)
 
 
 @pytest.mark.parametrize(
-    "attractor,period,expected_a",
+    "attractor,expected_period,expected_a",
     [
         (Earth, 23.9345 * u.hour, 42_164_205 * u.m),
         (Mars, 24.6228 * u.hour, 20_427_595 * u.m),
     ],
 )
-def test_geostationary_creation_from_period(attractor, period, expected_a):
-    ss = Orbit.geostationary(attractor=attractor, period=period)
+def test_geostationary_creation_from_period(attractor, expected_period, expected_a):
+    ss = Orbit.geostationary(attractor=attractor)
     assert_quantity_allclose(ss.a, expected_a, rtol=1.0e-7)
-    assert_quantity_allclose(ss.period, period, rtol=1.0e-7)
+    assert_quantity_allclose(ss.period, expected_period, rtol=1.0e-7)
 
 
 @pytest.mark.parametrize(
@@ -665,30 +655,15 @@ def test_geostationary_creation_from_period(attractor, period, expected_a):
 def test_geostationary_creation_with_Hill_radius(
     attractor, period, hill_radius, expected_a
 ):
-    ss = Orbit.geostationary(
-        attractor=attractor, period=period, hill_radius=hill_radius
-    )
+    ss = Orbit.geostationary(attractor=attractor, hill_radius=hill_radius)
     assert_quantity_allclose(ss.a, expected_a, rtol=1.0e-7)
     assert_quantity_allclose(ss.period, period, rtol=1.0e-7)
 
 
-@pytest.mark.parametrize("attractor", [Earth, Mars])
-def test_geostationary_input(attractor):
+@pytest.mark.parametrize("attractor,hill_radius", [(Venus, 1_000_000 * u.km)])
+def test_geostationary_non_existence_condition(attractor, hill_radius):
     with pytest.raises(ValueError) as excinfo:
-        Orbit.geostationary(attractor=attractor)
-
-    assert (
-        "ValueError: At least one among angular_velocity or period must be passed"
-        in excinfo.exconly()
-    )
-
-
-@pytest.mark.parametrize(
-    "attractor,period,hill_radius", [(Venus, 243.025 * u.day, 1_000_000 * u.km)]
-)
-def test_geostationary_non_existence_condition(attractor, period, hill_radius):
-    with pytest.raises(ValueError) as excinfo:
-        Orbit.geostationary(attractor=attractor, period=period, hill_radius=hill_radius)
+        Orbit.geostationary(attractor=attractor, hill_radius=hill_radius)
 
     assert (
         "Geostationary orbit for the given parameters doesn't exist"
@@ -698,7 +673,7 @@ def test_geostationary_non_existence_condition(attractor, period, hill_radius):
 
 def test_heliosynchronous_orbit_enough_arguments():
     with pytest.raises(ValueError) as excinfo:
-        Orbit.heliosynchronous(a=None, ecc=None, inc=None)
+        Orbit.heliosynchronous(Earth, a=None, ecc=None, inc=None)
 
     assert (
         "At least two parameters of the set {a, ecc, inc} are required."
@@ -711,7 +686,7 @@ def test_heliosynchronous_orbit_inc():
     expected_ecc = 0 * u.one
     expected_a = 800 * u.km + Earth.R
     expected_inc = 98.6 * u.deg
-    ss0 = Orbit.heliosynchronous(a=expected_a, ecc=expected_ecc)
+    ss0 = Orbit.heliosynchronous(Earth, a=expected_a, ecc=expected_ecc)
 
     assert_quantity_allclose(ss0.inc, expected_inc, rtol=1e-4)
     assert_quantity_allclose(ss0.a, expected_a)
@@ -723,7 +698,7 @@ def test_heliosynchronous_orbit_a():
     expected_ecc = 0.2 * u.one
     expected_inc = 98.6 * u.deg
     expected_a = 7346.846 * u.km
-    ss0 = Orbit.heliosynchronous(ecc=expected_ecc, inc=expected_inc)
+    ss0 = Orbit.heliosynchronous(Earth, ecc=expected_ecc, inc=expected_inc)
 
     assert_quantity_allclose(ss0.inc, expected_inc, rtol=1e-4)
     assert_quantity_allclose(ss0.a, expected_a, rtol=1e-5)

--- a/src/poliastro/threebody/soi.py
+++ b/src/poliastro/threebody/soi.py
@@ -31,21 +31,15 @@ is:
     a\\left(\\frac{m}{3M}\\right)^{\\frac{1}{3}}
 
 """
-from astropy import units as u
-
-from poliastro.constants import J2000_TDB
 
 
-@u.quantity_input(a=u.m)
-def laplace_radius(body, a=None):
+def laplace_radius(body):
     """Approximated radius of the Laplace Sphere of Influence (SOI) for a body.
 
     Parameters
     ----------
     body : `~poliastro.bodies.Body`
            Astronomical body which the SOI's radius is computed for.
-    a : float, optional
-        Semimajor axis of the body's orbit, default to None (will be computed from ephemerides).
 
     Returns
     -------
@@ -53,31 +47,19 @@ def laplace_radius(body, a=None):
         Approximated radius of the Sphere of Influence (SOI) [m]
 
     """
-    # Compute semimajor axis at epoch J2000 for the body if it was not
-    # introduced by the user
-    if a is None:
-        # https://github.com/poliastro/poliastro/pull/679#issuecomment-503902597
-        from poliastro.twobody.orbit import Orbit
-
-        a = Orbit.from_body_ephem(body, J2000_TDB).a
-
+    a = body.get_mean_orbit().a
     r_SOI = a * (body.k / body.parent.k) ** (2 / 5)
 
     return r_SOI.decompose()
 
 
-@u.quantity_input(a=u.m, e=u.one)
-def hill_radius(body, a=None, e=None):
+def hill_radius(body):
     """Approximated radius of the Hill Sphere of Influence (SOI) for a body.
 
     Parameters
     ----------
     body : `~poliastro.bodies.Body`
            Astronomical body which the SOI's radius is computed for.
-    a : float, optional
-        Semimajor axis of the body's orbit, default to None (will be computed from ephemerides).
-    e : float, optional
-        Eccentricity of the body's orbit, default to 0 (will be computed from ephemerides).
 
     Returns
     -------
@@ -85,17 +67,11 @@ def hill_radius(body, a=None, e=None):
         Approximated radius of the Sphere of Influence (SOI) [m]
 
     """
-    # Compute semimajor and eccentricity axis at epoch J2000 for the body if it was not
-    # introduced by the user
-    if a is None or e is None:
-        # https://github.com/poliastro/poliastro/pull/679#issuecomment-503902597
-        from poliastro.twobody.orbit import Orbit
-
-        ss = Orbit.from_body_ephem(body, J2000_TDB)
-        a = a if a is not None else ss.a
-        e = e if e is not None else ss.ecc
+    mean_orbit = body.get_mean_orbit()
+    a = mean_orbit.a
+    ecc = mean_orbit.ecc
 
     mass_ratio = body.k / (3 * body.parent.k)
-    r_SOI = a * (1 - e) * (mass_ratio ** (1 / 3))
+    r_SOI = a * (1 - ecc) * (mass_ratio ** (1 / 3))
 
     return r_SOI.decompose()


### PR DESCRIPTION
Fix #790, address #445.

Notice that the title of #445 is "Offer an alternative to Orbit.propagate for the Moon and planets", but rather than offering an alternative, here we're saying "use something else". A user could still do `Earth.get_mean_orbit().propagate`, but it's more evident than before that the result of the propagation is approximate.

Besides, I'm still not 100 % happy with two things:

* `poliastro.ephem.get_mean_orbit` ended up being somewhat complex. However, I could not think of a simpler solution: if we just have `body.a`, `body.ecc`, `body.inc`... it's still not clear _with respect to what_ those elements are measured, and we are back to having implicit reference frames, which I don't like. By having the elements and the reference frame we ended up having an `Orbit`. This opens the door for having more low-precision ephemerides, but I chose the Standish JPL one because it's simple (linear regressions) and should be representative over a wide period of time.
* `body.get_mean_orbit` still introduces a circular dependency because of planetary frames.

There are a couple of tests that need fixing.