### PR TITLE
Issue 840

### DIFF
--- a/src/poliastro/core/iod.py
+++ b/src/poliastro/core/iod.py
@@ -88,7 +88,7 @@ def vallado(k, r0, r, tof, short, numiter, rtol):
     >>> v1 = v1*u.km / u.s
     >>> v2 = v2*u.km / u.s
     >>> print(v1, v2)
-    [-5.99249499  1.92536673  3.24563805] km / s [-3.31245847 -4.196619   -0.38528907] km / s
+    [-5.99249503  1.92536671  3.24563805] km / s [-3.31245851 -4.19661901 -0.38528906] km / s
 
     Note
     ----
@@ -115,8 +115,8 @@ def vallado(k, r0, r, tof, short, numiter, rtol):
         raise RuntimeError("Cannot compute orbit, phase angle is 180 degrees")
 
     psi = 0.0
-    psi_low = -4 * np.pi
-    psi_up = 4 * np.pi
+    psi_low = -4 * np.pi ** 2
+    psi_up = 4 * np.pi ** 2
 
     count = 0
 

--- a/src/poliastro/tests/test_iod.py
+++ b/src/poliastro/tests/test_iod.py
@@ -1,5 +1,5 @@
 import pytest
-from astropy import units as u
+from astropy import constants as c, units as u
 from astropy.tests.helper import assert_quantity_allclose
 
 from poliastro.bodies import Earth
@@ -43,11 +43,12 @@ def test_curtis53(lambert):
     r0 = [273378.0, 0.0, 0.0] * u.km
     r = [145820.0, 12758.0, 0.0] * u.km
     tof = 13.5 * u.h
+    numiter = 100
 
     # ERRATA: j component is positive
     expected_va = [-2.4356, 0.26741, 0.0] * u.km / u.s
 
-    va, vb = next(lambert(k, r0, r, tof))
+    va, vb = next(lambert(k, r0, r, tof, numiter=numiter))
     assert_quantity_allclose(va, expected_va, rtol=1e-4)
 
 
@@ -121,3 +122,24 @@ def test_minimum_time_of_flight_convergence(M):
     y = iod._compute_y(x_T_min_expected, ll)
     T_min = iod._tof_equation_y(x_T_min_expected, y, 0.0, ll, M)
     assert T_min_expected == T_min
+
+
+@pytest.mark.parametrize(
+    "lambert_vallado,lambert_izzo", [(vallado.lambert, izzo.lambert)]
+)
+def test_issue840(lambert_vallado, lambert_izzo):
+    k = c.GM_earth.to(u.km ** 3 / u.s ** 2)
+    r0 = [10000.0, 0, 0] * u.km
+    rf = [8000.0, -5000, 0] * u.km
+    tof = 2 * u.hour
+
+    expected_va = [0.36591277, 5.8228806, 0.0] * u.km / u.s
+    expected_vb = [3.99397599, 4.78236576, 0.0] * u.km / u.s
+
+    va_v, vb_v = next(lambert_vallado(k, r0, rf, tof, short=False))
+    va_i, vb_i = next(lambert_izzo(k, r0, rf, tof))
+
+    assert_quantity_allclose(va_v, expected_va, rtol=1e-6)
+    assert_quantity_allclose(vb_v, expected_vb, rtol=1e-6)
+    assert_quantity_allclose(va_i, expected_va, rtol=1e-6)
+    assert_quantity_allclose(vb_i, expected_vb, rtol=1e-6)


### PR DESCRIPTION

- It highlights after which iterations tof stops changing
- It returns the velocity vectors of the boundary value tof when tof_input exceeds the limit. So if the user give tof > tof_max, then v_tof_max would be returned, similarly for tof < tof_min


[Link to discussion](https://github.com/poliastro/poliastro/issues/840)



