### PR TITLE
Fixed Duplicated Sphinx Extension

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,7 +38,6 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
     'sphinx.ext.todo',
-    'sphinx.ext.mathjax',
     'sphinx.ext.intersphinx',
     'nbsphinx',
     'IPython.sphinxext.ipython_console_highlighting',

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -327,7 +327,7 @@ easily visualize in two dimensions:
 
 .. code-block:: python
 
-    from poliastro.plotting import OrbitPlotter
+    from poliastro.plotting import OrbitPlotter2D
     
     op = OrbitPlotter2D()
     ss_a, ss_f = ss_i.apply_maneuver(hoh, intermediate=True)


### PR DESCRIPTION
Fixes #850 

- Removed Duplicated Sphinx Extension

```
>>> from poliastro.plotting import OrbitPlotter
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'OrbitPlotter' from 'poliastro.plotting' 
```
Changed `from poliastro.plotting import OrbitPlotter` to ` from poliastro.plotting import OrbitPlotter2D`




