### PR TITLE
Boosting vallado izzo

### DIFF
--- a/src/poliastro/iod/izzo.py
+++ b/src/poliastro/iod/izzo.py
@@ -5,6 +5,8 @@ from astropy import units as u
 
 from poliastro.core.iod import izzo as izzo_fast
 
+kms = u.km / u.s
+
 
 def lambert(k, r0, r, tof, M=0, numiter=35, rtol=1e-8):
     """Solves the Lambert problem using the Izzo algorithm.
@@ -42,4 +44,4 @@ def lambert(k, r0, r, tof, M=0, numiter=35, rtol=1e-8):
     sols = izzo_fast(k_, r0_, r_, tof_, M, numiter, rtol)
 
     for v0, v in sols:
-        yield v0 * u.km / u.s, v * u.km / u.s
+        yield v0 << kms, v << kms

--- a/src/poliastro/iod/vallado.py
+++ b/src/poliastro/iod/vallado.py
@@ -5,6 +5,8 @@ from astropy import units as u
 
 from poliastro.core.iod import vallado as vallado_fast
 
+kms = u.km / u.s
+
 
 def lambert(k, r0, r, tof, short=True, numiter=35, rtol=1e-8):
     """Solves the Lambert problem.
@@ -47,4 +49,4 @@ def lambert(k, r0, r, tof, short=True, numiter=35, rtol=1e-8):
 
     v0, v = vallado_fast(k_, r0_, r_, tof_, short, numiter, rtol)
 
-    yield v0 * u.km / u.s, v * u.km / u.s
+    yield v0 << kms, v << kms


### PR DESCRIPTION
Accounting for this [issue](https://github.com/poliastro/poliastro/issues/856).

I've noticed that the gain in time hasn't been too significant as was promised in [astropy](https://astropy.readthedocs.io/en/latest/units/index.html#performance-tips).

I applied this change in vallado.py and izzo.py. 

**Observations** :clipboard:
          

- **Vallado**
               - Original :  ``` 218 us +- 77.4 us ```
               - Modified:  ``` 182 us +- 79.8 us ```
- **Izzo**
               - Original :  ``` 245 us +- 251 us ```
               - Modified:  ``` 272 us +- 271 us ```  :exclamation: 

Somehow modified Izzo is **slower** than the original? I'm attaching screenshots for reference


![WITHOUT_UNITS_VALLADO](https://user-images.githubusercontent.com/45007169/76111712-c3d7ee00-6006-11ea-9d7e-3d6b92456555.png)
![WITH_UNITS_IZZO](https://user-images.githubusercontent.com/45007169/76111715-c63a4800-6006-11ea-800d-c25e2ef04859.png)
![WITHOUT_UNITS_IZZO](https://user-images.githubusercontent.com/45007169/76111720-c9353880-6006-11ea-8704-97c31fac29a9.png)
![USING_UNITS_VALLADO](https://user-images.githubusercontent.com/45007169/76111724-ca666580-6006-11ea-99cc-4abc83580550.png)

I'd like to know your opinion @jorgepiloto  :thinking: 

