### PR TITLE
Changed unit test to compare databases

### DIFF
--- a/src/poliastro/tests/tests_twobody/test_orbit.py
+++ b/src/poliastro/tests/tests_twobody/test_orbit.py
@@ -983,8 +983,7 @@ def test_from_sbdb():
 
         # Two DB are not exactly the same because orbits perturb slowly and
         # measurment taken at different epochs in Horizons and SBDB
-        max_err = [0.0005 * y for y in ss_classical] # Maximum error of 0.05%
-                                                     # Chosen arbitrarily 
+        max_err = [0.0005 * y for y in ss_classical] # Maximum error of 0.05% (chosen arbitarily)
 
         assert diff_bw_orbits < max_err
 

--- a/src/poliastro/tests/tests_twobody/test_orbit.py
+++ b/src/poliastro/tests/tests_twobody/test_orbit.py
@@ -975,15 +975,21 @@ def test_from_sbdb():
         ss_target = Orbit.from_sbdb(target_name)
         ss_classical = ss_target.classical()
 
-        ss_ref = Orbit.from_horizons(name=target_name, attractor=Sun, plane=Planes.EARTH_ECLIPTIC)
-        ss_ref = ss_ref.propagate_to_anomaly(ss_classical[5])  # Catch reference orbit to same epoch
+        ss_ref = Orbit.from_horizons(
+            name=target_name, attractor=Sun, plane=Planes.EARTH_ECLIPTIC
+        )
+        ss_ref = ss_ref.propagate_to_anomaly(
+            ss_classical[5]
+        )  # Catch reference orbit to same epoch
         ss_ref_class = ss_ref.classical()
 
         diff_bw_orbits = [abs(x[1] - x[0]) for x in zip(ss_classical, ss_ref_class)]
 
         # Two DB are not exactly the same because orbits perturb slowly and
         # measurment taken at different epochs in Horizons and SBDB
-        max_err = [0.0005 * y for y in ss_classical]  # Maximum error of 0.05% (chosen arbitarily)
+        max_err = [
+            0.0005 * y for y in ss_classical
+        ]  # Maximum error of 0.05% (chosen arbitarily)
 
         assert diff_bw_orbits < max_err
 

--- a/src/poliastro/tests/tests_twobody/test_orbit.py
+++ b/src/poliastro/tests/tests_twobody/test_orbit.py
@@ -967,8 +967,8 @@ def test_from_coord_if_coord_is_not_of_shape_zero():
 
 
 @pytest.mark.remote_data
-def test_from_sbdb():
-    targets = ["Ceres", "Vesta", "Eros"]  # Objects in both JPL SBDB and JPL Horizons
+@pytest.mark.parametrize("targets", ["Ceres", "Vesta", "Eros"])  # Objects in both JPL SBDB and JPL Horizons
+def test_from_sbdb_and_from_horizons_give_similar_results(targets):
 
     for target_name in targets:
 
@@ -983,15 +983,7 @@ def test_from_sbdb():
         )  # Catch reference orbit to same epoch
         ss_ref_class = ss_ref.classical()
 
-        diff_bw_orbits = [abs(x[1] - x[0]) for x in zip(ss_classical, ss_ref_class)]
-
-        # Two DB are not exactly the same because orbits perturb slowly and
-        # measurment taken at different epochs in Horizons and SBDB
-        max_err = [
-            0.0005 * y for y in ss_classical
-        ]  # Maximum error of 0.05% (chosen arbitarily)
-
-        assert diff_bw_orbits < max_err
+        assert_quantity_allclose(ss_classical, ss_ref_class, rtol=5.0e-4)  # Maximum error of 0.05% (chosen arbitarily)
 
 
 @pytest.mark.remote_data

--- a/src/poliastro/tests/tests_twobody/test_orbit.py
+++ b/src/poliastro/tests/tests_twobody/test_orbit.py
@@ -978,12 +978,12 @@ def test_from_sbdb_and_from_horizons_give_similar_results(target_name):
     ss_ref = Orbit.from_horizons(
         name=target_name, attractor=Sun, plane=Planes.EARTH_ECLIPTIC
     )
-    
+
     ss_ref = ss_ref.propagate_to_anomaly(
         ss_classical[5]
     )  # Catch reference orbit to same epoch
     ss_ref_class = ss_ref.classical()
-    
+
     for test_elm, ref_elm in zip(ss_classical, ss_ref_class):
         assert_quantity_allclose(
             test_elm, ref_elm, rtol=1e-2

--- a/src/poliastro/tests/tests_twobody/test_orbit.py
+++ b/src/poliastro/tests/tests_twobody/test_orbit.py
@@ -968,22 +968,22 @@ def test_from_coord_if_coord_is_not_of_shape_zero():
 
 @pytest.mark.remote_data
 def test_from_sbdb():
-    targets = ["Ceres", "Vesta", "Eros"] # Objects in both JPL SBDB and JPL Horizons
+    targets = ["Ceres", "Vesta", "Eros"]  # Objects in both JPL SBDB and JPL Horizons
 
     for target_name in targets:
 
         ss_target = Orbit.from_sbdb(target_name)
         ss_classical = ss_target.classical()
 
-        ss_ref = Orbit.from_horizons(name=target_name, attractor=Sun,plane=Planes.EARTH_ECLIPTIC)
-        ss_ref = ss_ref.propagate_to_anomaly(ss_classical[5]) # Catch reference orbit to same epoch
+        ss_ref = Orbit.from_horizons(name=target_name, attractor=Sun, plane=Planes.EARTH_ECLIPTIC)
+        ss_ref = ss_ref.propagate_to_anomaly(ss_classical[5])  # Catch reference orbit to same epoch
         ss_ref_class = ss_ref.classical()
 
         diff_bw_orbits = [abs(x[1] - x[0]) for x in zip(ss_classical, ss_ref_class)]
 
         # Two DB are not exactly the same because orbits perturb slowly and
         # measurment taken at different epochs in Horizons and SBDB
-        max_err = [0.0005 * y for y in ss_classical] # Maximum error of 0.05% (chosen arbitarily)
+        max_err = [0.0005 * y for y in ss_classical]  # Maximum error of 0.05% (chosen arbitarily)
 
         assert diff_bw_orbits < max_err
 

--- a/src/poliastro/tests/tests_twobody/test_orbit.py
+++ b/src/poliastro/tests/tests_twobody/test_orbit.py
@@ -967,7 +967,9 @@ def test_from_coord_if_coord_is_not_of_shape_zero():
 
 
 @pytest.mark.remote_data
-@pytest.mark.parametrize("targets", ["Ceres", "Vesta", "Eros"])  # Objects in both JPL SBDB and JPL Horizons
+@pytest.mark.parametrize(
+    "targets", ["Ceres", "Vesta", "Eros"]
+)  # Objects in both JPL SBDB and JPL Horizons
 def test_from_sbdb_and_from_horizons_give_similar_results(targets):
 
     for target_name in targets:
@@ -983,7 +985,9 @@ def test_from_sbdb_and_from_horizons_give_similar_results(targets):
         )  # Catch reference orbit to same epoch
         ss_ref_class = ss_ref.classical()
 
-        assert_quantity_allclose(ss_classical, ss_ref_class, rtol=5.0e-4)  # Maximum error of 0.05% (chosen arbitarily)
+        assert_quantity_allclose(
+            ss_classical, ss_ref_class, rtol=5.0e-4
+        )  # Maximum error of 0.05% (chosen arbitarily)
 
 
 @pytest.mark.remote_data

--- a/src/poliastro/tests/tests_twobody/test_orbit.py
+++ b/src/poliastro/tests/tests_twobody/test_orbit.py
@@ -968,26 +968,26 @@ def test_from_coord_if_coord_is_not_of_shape_zero():
 
 @pytest.mark.remote_data
 @pytest.mark.parametrize(
-    "targets", ["Ceres", "Vesta", "Eros"]
+    "target_name", ["Ceres", "Vesta", "Eros"]
 )  # Objects in both JPL SBDB and JPL Horizons
-def test_from_sbdb_and_from_horizons_give_similar_results(targets):
+def test_from_sbdb_and_from_horizons_give_similar_results(target_name):
 
-    for target_name in targets:
+    ss_target = Orbit.from_sbdb(target_name)
+    ss_classical = ss_target.classical()
 
-        ss_target = Orbit.from_sbdb(target_name)
-        ss_classical = ss_target.classical()
-
-        ss_ref = Orbit.from_horizons(
-            name=target_name, attractor=Sun, plane=Planes.EARTH_ECLIPTIC
-        )
-        ss_ref = ss_ref.propagate_to_anomaly(
-            ss_classical[5]
-        )  # Catch reference orbit to same epoch
-        ss_ref_class = ss_ref.classical()
-
+    ss_ref = Orbit.from_horizons(
+        name=target_name, attractor=Sun, plane=Planes.EARTH_ECLIPTIC
+    )
+    
+    ss_ref = ss_ref.propagate_to_anomaly(
+        ss_classical[5]
+    )  # Catch reference orbit to same epoch
+    ss_ref_class = ss_ref.classical()
+    
+    for test_elm, ref_elm in zip(ss_classical, ss_ref_class):
         assert_quantity_allclose(
-            ss_classical, ss_ref_class, rtol=5.0e-4
-        )  # Maximum error of 0.05% (chosen arbitarily)
+            test_elm, ref_elm, rtol=1e-2
+        )  # Maximum error of 1% (chosen arbitrarily)
 
 
 @pytest.mark.remote_data


### PR DESCRIPTION
Mostly explained in issue #861 

Changes unit test to cross reference JPL databases instead of use hard-coded value, which will change over time.

