### PR TITLE
Better plotting API

### DIFF
--- a/src/poliastro/plotting/core.py
+++ b/src/poliastro/plotting/core.py
@@ -253,7 +253,7 @@ class OrbitPlotter2D(_PlotlyOrbitPlotter, Mixin2D):
         if self._frame is None:
             raise ValueError(
                 "A frame must be set up first, please use "
-                "set_frame(*orbit.pqw()) or plot(orbit)"
+                "set_orbit_frame(orbit) or plot(orbit)"
             )
 
         rr = positions.represent_as(CartesianRepresentation).xyz.transpose()
@@ -290,6 +290,6 @@ class OrbitPlotter2D(_PlotlyOrbitPlotter, Mixin2D):
             raise NotImplementedError("trail not supported yet")
 
         if not self._frame:
-            self.set_frame(*orbit.pqw())
+            self._set_frame(*orbit.pqw())
 
         return super().plot(orbit, label=label, color=color, trail=trail)

--- a/src/poliastro/plotting/misc.py
+++ b/src/poliastro/plotting/misc.py
@@ -12,7 +12,6 @@ from poliastro.bodies import (
     Uranus,
     Venus,
 )
-from poliastro.twobody import Orbit
 
 from .core import OrbitPlotter2D, OrbitPlotter3D
 from .static import StaticOrbitPlotter
@@ -24,12 +23,10 @@ def _plot_bodies(orbit_plotter, outer=True, epoch=None):
         bodies.extend([Jupiter, Saturn, Uranus, Neptune])
 
     for body in bodies:
-        orb = Orbit.from_body_ephem(body, epoch)
-        orbit_plotter.plot(orb, label=str(body))
+        orbit_plotter.plot_body_orbit(body, epoch)
 
 
 def _plot_solar_system_2d(epoch, outer=True, interactive=False):
-    pqw = Orbit.from_body_ephem(Earth, epoch).pqw()
     if interactive:
         orbit_plotter = (
             OrbitPlotter2D()
@@ -37,7 +34,7 @@ def _plot_solar_system_2d(epoch, outer=True, interactive=False):
     else:
         orbit_plotter = StaticOrbitPlotter()
 
-    orbit_plotter.set_frame(*pqw)
+    orbit_plotter.set_body_frame(Earth, epoch)
 
     _plot_bodies(orbit_plotter, outer, epoch)
 

--- a/src/poliastro/plotting/static.py
+++ b/src/poliastro/plotting/static.py
@@ -188,7 +188,7 @@ class StaticOrbitPlotter(BaseOrbitPlotter, Mixin2D):
         if self._frame is None:
             raise ValueError(
                 "A frame must be set up first, please use "
-                "set_frame(*orbit.pqw()) or plot(orbit)"
+                "set_orbit_frame(orbit) or plot(orbit)"
             )
 
         self._redraw_attractor()
@@ -224,7 +224,7 @@ class StaticOrbitPlotter(BaseOrbitPlotter, Mixin2D):
 
         """
         if not self._frame:
-            self.set_frame(*orbit.pqw())
+            self._set_frame(*orbit.pqw())
 
         colors = self._get_colors(color, trail)
 

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -406,6 +406,7 @@ class Orbit:
             "Orbit.from_body_ephem is deprecated and will be removed in a future release, "
             "see https://github.com/poliastro/poliastro/issues/445 for discussion.",
             DeprecationWarning,
+            stacklevel=2,
         )
 
         if not epoch:
@@ -416,6 +417,7 @@ class Orbit:
                 "Input time was converted to scale='tdb' with value "
                 f"{epoch.tdb.value}. Use Time(..., scale='tdb') instead.",
                 TimeScaleWarning,
+                stacklevel=2,
             )
         try:
             r, v = get_body_barycentric_posvel(body.name, epoch)
@@ -500,7 +502,11 @@ class Orbit:
         elif self.ecc < 1.0 and not force:
             raise ValueError("Orbit will never leave the SOI of its current attractor")
         else:
-            warn("Leaving the SOI of the current attractor", PatchedConicsWarning)
+            warn(
+                "Leaving the SOI of the current attractor",
+                PatchedConicsWarning,
+                stacklevel=2,
+            )
 
         new_frame = get_frame(new_attractor, self.plane, obstime=self.epoch)
         coords = self.get_frame().realize_frame(
@@ -1236,7 +1242,7 @@ class Orbit:
         # is outside of the hyperbolic range
         nu_max = hyp_nu_limit(self.ecc) - 1e-3 * u.rad  # Arbitrary delta
         if not Angle(limits).is_within_bounds(-nu_max, nu_max):
-            warn("anomaly outside range, clipping", OrbitSamplingWarning)
+            warn("anomaly outside range, clipping", OrbitSamplingWarning, stacklevel=2)
             limits = limits.clip(-nu_max, nu_max)
 
         nu_values = np.linspace(*limits, values)

--- a/tests/tests_plotting/test_core.py
+++ b/tests/tests_plotting/test_core.py
@@ -2,7 +2,7 @@ import pytest
 from astropy import units as u
 
 from poliastro.bodies import Earth, Mars, Sun
-from poliastro.examples import iss
+from poliastro.examples import churi, iss
 from poliastro.plotting import OrbitPlotter2D, OrbitPlotter3D
 from poliastro.twobody.orbit import Orbit
 
@@ -82,7 +82,7 @@ def test_plot_2d_trajectory_without_frame_raises_error():
         frame.plot_trajectory({})
     assert (
         "A frame must be set up first, please use "
-        "set_frame(*orbit.pqw()) or plot(orbit)" in excinfo.exconly()
+        "set_orbit_frame(orbit) or plot(orbit)" in excinfo.exconly()
     )
 
 
@@ -90,8 +90,7 @@ def test_plot_3d_trajectory_plots_a_trajectory():
     frame = OrbitPlotter3D()
     assert len(frame.trajectories) == 0
 
-    earth = Orbit.from_body_ephem(Earth)
-    trajectory = earth.sample()
+    trajectory = churi.sample()
     frame.set_attractor(Sun)
     frame.plot_trajectory(trajectory)
 
@@ -103,10 +102,9 @@ def test_plot_2d_trajectory_plots_a_trajectory():
     frame = OrbitPlotter2D()
     assert len(frame.trajectories) == 0
 
-    earth = Orbit.from_body_ephem(Earth)
-    trajectory = earth.sample()
+    trajectory = churi.sample()
     frame.set_attractor(Sun)
-    frame.set_frame(*earth.pqw())
+    frame.set_orbit_frame(churi)
     frame.plot_trajectory(trajectory)
 
     assert len(frame.trajectories) == 1

--- a/tests/tests_plotting/test_static.py
+++ b/tests/tests_plotting/test_static.py
@@ -1,21 +1,10 @@
-import astropy.units as u
 import matplotlib.pyplot as plt
 import pytest
 
 from poliastro.bodies import Earth, Jupiter, Mars
-from poliastro.examples import iss
+from poliastro.examples import churi, iss
 from poliastro.plotting.static import StaticOrbitPlotter
 from poliastro.twobody.orbit import Orbit
-
-
-def test_set_frame():
-    op = StaticOrbitPlotter()
-    p = [1, 0, 0] * u.one
-    q = [0, 1, 0] * u.one
-    w = [0, 0, 1] * u.one
-    op.set_frame(p, q, w)
-
-    assert op._frame == (p, q, w)
 
 
 def test_axes_labels_and_title():
@@ -62,14 +51,16 @@ def test_color():
 
 
 def test_plot_trajectory_sets_label():
+    expected_label = "67P"
+
     op = StaticOrbitPlotter()
-    earth = Orbit.from_body_ephem(Earth)
-    mars = Orbit.from_body_ephem(Mars)
-    trajectory = earth.sample()
-    op.plot(mars, label="Mars")
-    op.plot_trajectory(trajectory, label="Earth")
+    trajectory = churi.sample()
+    op.plot_body_orbit(Mars, label="Mars")
+
+    op.plot_trajectory(trajectory, label=expected_label)
+
     legend = plt.gca().get_legend()
-    assert legend.get_texts()[1].get_text() == "Earth"
+    assert legend.get_texts()[1].get_text() == expected_label
 
 
 @pytest.mark.parametrize(
@@ -90,10 +81,9 @@ def test_redraw_makes_attractor_none():
 def test_set_frame_plots_same_colors():
     # TODO: Review
     op = StaticOrbitPlotter()
-    jupiter = Orbit.from_body_ephem(Jupiter)
-    op.plot(jupiter)
+    op.plot_body_orbit(Jupiter)
     colors1 = [orb[2] for orb in op.trajectories]
-    op.set_frame(*jupiter.pqw())
+    op.set_body_frame(Jupiter)
     colors2 = [orb[2] for orb in op.trajectories]
     assert colors1 == colors2
 
@@ -101,15 +91,13 @@ def test_set_frame_plots_same_colors():
 def test_redraw_keeps_trajectories():
     # See https://github.com/poliastro/poliastro/issues/518
     op = StaticOrbitPlotter()
-    earth = Orbit.from_body_ephem(Earth)
-    mars = Orbit.from_body_ephem(Mars)
-    trajectory = earth.sample()
-    op.plot(mars, label="Mars")
-    op.plot_trajectory(trajectory, label="Earth")
+    trajectory = churi.sample()
+    op.plot_body_orbit(Mars, label="Mars")
+    op.plot_trajectory(trajectory, label="67P")
 
     assert len(op.trajectories) == 2
 
-    op.set_frame(*mars.pqw())
+    op.set_body_frame(Mars)
 
     assert len(op.trajectories) == 2
 


### PR DESCRIPTION
This adds a new method to all orbit plotters, `plot_body_orbit`, that "Plots complete revolution of body and current position if given", and another two for 2D orbit plotters, `set_orbit_frame` and `set_body_frame`. The former avoids calling `Orbit.from_body_ephem` (about to be removed), and the latter avoid the need to call `set_frame(*orbit.pqw())`, which is ugly, impossible to understand, and in general shouldn't be there.

We can maintain these APIs in the future, but refactor them internally so they work they way we want. Isn't it nice? :smile: 