### PR TITLE
Changed frame of get_body_barycentric in change_attractor()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dev = [
     "pytest-mpl",
     "pytest-mypy",
     "pytest-remotedata",
-    "sphinx",
+    "sphinx<3", # Temporary, see https://github.com/readthedocs/sphinx-hoverxref/issues/45
     "sphinx_rtd_theme @ https://github.com/Juanlu001/sphinx_rtd_theme/archive/avoid-require-redefinition.zip",
     "sphinx-hoverxref @ https://github.com/readthedocs/sphinx-hoverxref/archive/master.zip",
     "sphinx-notfound-page",

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -486,9 +486,15 @@ class Orbit:
             return self
         elif self.attractor == new_attractor.parent:  # "Sun -> Earth"
             r_soi = laplace_radius(new_attractor)
-            distance = norm(
-                self.r - get_body_barycentric(new_attractor.name, self.epoch).xyz
+            barycentric_position = get_body_barycentric(new_attractor.name, self.epoch)
+            # transforming new_attractor's frame into frame of attractor
+            new_attractor_r = (
+                ICRS(barycentric_position)
+                .transform_to(self.get_frame())
+                .represent_as(CartesianRepresentation)
+                .xyz
             )
+            distance = norm(self.r - new_attractor_r)
         elif self.attractor.parent == new_attractor:  # "Earth -> Sun"
             r_soi = laplace_radius(self.attractor)
             distance = norm(self.r)

--- a/tests/tests_twobody/test_orbit.py
+++ b/tests/tests_twobody/test_orbit.py
@@ -1101,3 +1101,13 @@ def test_time_to_anomaly():
     tof = iss_180.time_to_anomaly(0 * u.deg)
 
     assert_quantity_allclose(tof, expected_tof)
+
+
+@pytest.mark.xfail
+def test_issue_798():
+    epoch = Time("2019-11-10 12:00:00")
+    iss = Orbit.from_horizons(
+        "International Space Station", Sun, epoch=epoch, id_type="majorbody"
+    )
+    iss = iss.change_attractor(Earth)
+    assert iss.attractor == Earth


### PR DESCRIPTION
Addresses #798 

Changing the frame fixed the problem mentioned in #798. But we still need to use force=True to change the attractor.
```
>>> epoch = Time("2019-11-10 12:00:00") 
>>> iss = Orbit.from_horizons("International Space Station", Sun, epoch=epoch, id_type="majorbody"); iss 
1 x 1 AU x 19.1 deg (HCRS) orbit around Sun (☉) at epoch 2019-11-10 12:01:09.183 (TDB)
>>> iss.ecc
<Quantity 0.25646986>
>>> iss.change_attractor(Earth) 
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/uchiha/Desktop/poliastro/abcenv/lib/python3.7/site-packages/poliastro/twobody/orbit.py", line 522, in change_attractor
    raise ValueError("Orbit will never leave the SOI of its current attractor")
ValueError: Orbit will never leave the SOI of its current attractor
```
ValueError is raised because `ecc < 1`