### PR TITLE
Fix near parabolic regimes

### DIFF
--- a/src/poliastro/core/angles.py
+++ b/src/poliastro/core/angles.py
@@ -282,6 +282,7 @@ def M_to_E(M, ecc):
     This uses a Newton iteration on the Kepler equation.
 
     """
+    assert -np.pi <= M <= np.pi
     if ecc < 0.8:
         E0 = M
     else:

--- a/src/poliastro/core/angles.py
+++ b/src/poliastro/core/angles.py
@@ -285,7 +285,7 @@ def M_to_E(M, ecc):
     if ecc < 0.8:
         E0 = M
     else:
-        E0 = np.pi
+        E0 = np.pi * np.sign(M)
     E = newton("elliptic", E0, args=(M, ecc))
     return E
 

--- a/src/poliastro/core/angles.py
+++ b/src/poliastro/core/angles.py
@@ -40,7 +40,7 @@ def newton(regime, x0, args=(), tol=1.48e-08, maxiter=50):
             return p
         p0 = p
 
-    return 1.0
+    return np.nan
 
 
 @jit
@@ -282,7 +282,10 @@ def M_to_E(M, ecc):
     This uses a Newton iteration on the Kepler equation.
 
     """
-    E0 = M
+    if ecc < 0.8:
+        E0 = M
+    else:
+        E0 = np.pi
     E = newton("elliptic", E0, args=(M, ecc))
     return E
 

--- a/src/poliastro/core/propagation/farnocchia.py
+++ b/src/poliastro/core/propagation/farnocchia.py
@@ -226,7 +226,9 @@ def nu_from_delta_t(delta_t, ecc, k=1.0, q=1.0, delta=1e-2):
         # Strong elliptic
         n = np.sqrt(k * (1 - ecc) ** 3 / q ** 3)
         M = n * delta_t
-        E = M_to_E(M, ecc)
+        # This might represent several revolutions,
+        # so we wrap the true anomaly
+        E = M_to_E((M + np.pi) % (2 * np.pi) - np.pi, ecc)
         nu = E_to_nu(E, ecc)
     elif 1 - delta <= ecc < 1:
         E_delta = np.arccos((1 - delta) / ecc)
@@ -237,7 +239,9 @@ def nu_from_delta_t(delta_t, ecc, k=1.0, q=1.0, delta=1e-2):
         # We check against abs(M) because E_delta could also be negative
         if E_to_M(E_delta, ecc) <= abs(M):
             # Strong elliptic, proceed
-            E = M_to_E(M, ecc)
+            # This might represent several revolutions,
+            # so we wrap the true anomaly
+            E = M_to_E((M + np.pi) % (2 * np.pi) - np.pi, ecc)
             nu = E_to_nu(E, ecc)
         else:
             # Near parabolic, recompute M

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -1226,9 +1226,11 @@ class Orbit:
             Resulting orbit after propagation.
 
         """
+        # Silently wrap anomaly
+        nu = (value + np.pi * u.rad) % (2 * np.pi * u.rad) - np.pi * u.rad
 
         # Compute time of flight for correct epoch
-        time_of_flight = self.time_to_anomaly(value)
+        time_of_flight = self.time_to_anomaly(nu)
 
         return self.from_classical(
             self.attractor,
@@ -1237,7 +1239,7 @@ class Orbit:
             self.inc,
             self.raan,
             self.argp,
-            value,
+            nu,
             epoch=self.epoch + time_of_flight,
             plane=self.plane,
         )

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -1238,6 +1238,14 @@ class Orbit:
         # Compute time of flight for correct epoch
         time_of_flight = self.time_to_anomaly(nu)
 
+        if time_of_flight < 0:
+            if self.ecc >= 1:
+                raise ValueError("True anomaly {:.2f} not reachable".format(value))
+            else:
+                # For a closed orbit, instead of moving backwards
+                # we need to do another revolution
+                time_of_flight = self.period - time_of_flight
+
         return self.from_classical(
             self.attractor,
             self.a,

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -16,18 +16,15 @@ from astroquery.jplhorizons import Horizons
 from astroquery.jplsbdb import SBDB
 
 from poliastro.constants import J2000
-from poliastro.core.propagation.farnocchia import (
-    M_to_nu as M_to_nu_fast,
-    nu_to_M as nu_to_M_fast,
-)
 from poliastro.frames import Planes
 from poliastro.frames.util import get_frame
 from poliastro.threebody.soi import laplace_radius
-from poliastro.twobody.angles import raan_from_ltan
 from poliastro.twobody.propagation import farnocchia, propagate
 
+from ..core.propagation.farnocchia import delta_t_from_nu as delta_t_from_nu_fast
 from ..util import find_closest_value, norm
 from ..warnings import OrbitSamplingWarning, PatchedConicsWarning, TimeScaleWarning
+from .angles import D_to_nu, E_to_nu, F_to_nu, M_to_D, M_to_E, M_to_F, raan_from_ltan
 from .elements import (
     get_eccentricity_critical_argp,
     get_eccentricity_critical_inc,
@@ -217,8 +214,15 @@ class Orbit:
     @cached_property
     def t_p(self):
         """Elapsed time since latest perifocal passage. """
-        M = nu_to_M_fast(self.nu.to_value(u.rad), self.ecc.value) * u.rad
-        t_p = self.period * M / (360 * u.deg)
+        t_p = (
+            delta_t_from_nu_fast(
+                self.nu.to_value(u.rad),
+                self.ecc.value,
+                self.attractor.k.to_value(u.km ** 3 / u.s ** 2),
+                self.r_p.to_value(u.km),
+            )
+            * u.s
+        )
         return t_p
 
     @classmethod
@@ -669,8 +673,16 @@ class Orbit:
         argp = obj["orbit"]["elements"]["w"].to(u.deg) * u.deg
 
         # Since JPL provides Mean Anomaly (M) we need to make
-        # the conversion to the true anomaly (\nu)
-        nu = M_to_nu_fast(obj["orbit"]["elements"]["ma"].to(u.rad), ecc.value) * u.rad
+        # the conversion to the true anomaly (nu)
+        M = obj["orbit"]["elements"]["ma"].to(u.rad) * u.rad
+        # NOTE: It is unclear how this conversion should happen,
+        # see https://ssd-api.jpl.nasa.gov/doc/sbdb.html
+        if ecc < 1:
+            nu = E_to_nu(M_to_E(M, ecc), ecc)
+        elif ecc == 1:
+            nu = D_to_nu(M_to_D(M))
+        else:
+            nu = F_to_nu(M_to_F(M, ecc), ecc)
 
         epoch = time.Time(obj["orbit"]["epoch"].to(u.d), format="jd")
 
@@ -1211,11 +1223,19 @@ class Orbit:
             Time of flight required.
 
         """
-        # Compute time of flight for correct epoch
-        M = nu_to_M_fast(self.nu.to_value(u.rad), self.ecc.value) * u.rad
-        new_M = nu_to_M_fast(value.to_value(u.rad), self.ecc.value) * u.rad
-        tof = Angle(new_M - M).wrap_at(360 * u.deg) / self.n
+        # Silently wrap anomaly
+        nu = (value + np.pi * u.rad) % (2 * np.pi * u.rad) - np.pi * u.rad
 
+        delta_t = (
+            delta_t_from_nu_fast(
+                nu.to_value(u.rad),
+                self.ecc.value,
+                self.attractor.k.to_value(u.km ** 3 / u.s ** 2),
+                self.r_p.to_value(u.km),
+            )
+            * u.s
+        )
+        tof = delta_t - self.t_p
         return tof
 
     @u.quantity_input(value=u.rad)
@@ -1345,14 +1365,13 @@ class Orbit:
     def _generate_time_values(self, nu_vals):
         # Subtract current anomaly to start from the desired point
         ecc = self.ecc.value
-        nu = self.nu.to(u.rad).value
+        k = self.attractor.k.to_value(u.km ** 3 / u.s ** 2)
+        q = self.r_p.to_value(u.km)
 
-        M_vals = [
-            nu_to_M_fast(nu_val, ecc) - nu_to_M_fast(nu, ecc)
+        time_values = [
+            delta_t_from_nu_fast(nu_val, ecc, k, q)
             for nu_val in nu_vals.to(u.rad).value
-        ] * u.rad
-
-        time_values = (M_vals / self.n).decompose()
+        ] * u.s - self.t_p
         return time_values
 
     def apply_maneuver(self, maneuver, intermediate=False):

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -678,6 +678,7 @@ class Orbit:
         # NOTE: It is unclear how this conversion should happen,
         # see https://ssd-api.jpl.nasa.gov/doc/sbdb.html
         if ecc < 1:
+            M = (M + np.pi * u.rad) % (2 * np.pi * u.rad) - np.pi * u.rad
             nu = E_to_nu(M_to_E(M, ecc), ecc)
         elif ecc == 1:
             nu = D_to_nu(M_to_D(M))

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -351,6 +351,12 @@ class Orbit:
         if ecc > 1 and a > 0:
             raise ValueError("Hyperbolic orbits have negative semimajor axis")
 
+        if not -np.pi * u.rad <= nu < np.pi * u.rad:
+            warn("Wrapping true anomaly to -π <= nu < π", stacklevel=2)
+            nu = ((nu + np.pi * u.rad) % (2 * np.pi * u.rad) - np.pi * u.rad).to(
+                nu.unit
+            )
+
         ss = ClassicalState(
             attractor, a * (1 - ecc ** 2), ecc, inc, raan, argp, nu, plane
         )

--- a/tests/test_maneuver.py
+++ b/tests/test_maneuver.py
@@ -44,7 +44,7 @@ def test_maneuver_impulse():
     assert man.impulses[0] == (0 * u.s, dv)
 
 
-@pytest.mark.parametrize("nu", [0, 180] * u.deg)
+@pytest.mark.parametrize("nu", [0, -180] * u.deg)
 def test_hohmann_maneuver(nu):
     # Data from Vallado, example 6.1
     alt_i = 191.34411 * u.km
@@ -69,7 +69,7 @@ def test_hohmann_maneuver(nu):
     )
 
 
-@pytest.mark.parametrize("nu", [0, 180] * u.deg)
+@pytest.mark.parametrize("nu", [0, -180] * u.deg)
 def test_bielliptic_maneuver(nu):
     # Data from Vallado, example 6.2
     alt_i = 191.34411 * u.km

--- a/tests/tests_twobody/test_orbit.py
+++ b/tests/tests_twobody/test_orbit.py
@@ -92,6 +92,15 @@ def test_state_raises_unitserror_if_elements_units_are_wrong():
     )
 
 
+def test_orbit_from_classical_wraps_out_of_range_anomaly_and_warns():
+    _d = 1.0 * u.AU  # Unused distance
+    _ = 0.5 * u.one  # Unused dimensionless value
+    _a = 1.0 * u.deg  # Unused angle
+    out_angle = np.pi * u.rad
+    with pytest.warns(UserWarning, match="Wrapping true anomaly to -π <= nu < π"):
+        Orbit.from_classical(Sun, _d, _, _a, _a, _a, out_angle)
+
+
 def test_state_raises_unitserror_if_rv_units_are_wrong():
     _d = [1.0, 0.0, 0.0] * u.AU
     wrong_v = [0.0, 1.0e-6, 0.0] * u.AU

--- a/tests/tests_twobody/test_propagation.py
+++ b/tests/tests_twobody/test_propagation.py
@@ -55,14 +55,6 @@ def test_hyperbolic_near_parabolic(ecc, propagator):
     # Still not implemented. Refer to issue #714.
     if propagator in [pimienta, gooding]:
         pytest.skip()
-    elif propagator is farnocchia and ecc == 1.01:
-        pytest.xfail(
-            "This belongs to the strong hyperbolic region "
-            "which gives nu_to_M(1.0, 1.0100000000000002) = 0.0008482321477948918 "
-            "but it is entering the near parabolic code path "
-            "which gives nu_to_M(1.0, 1.01) = 0.5997907037261884, "
-            "therefore the function is not smooth!"
-        )
 
     _a = 0.0 * u.rad
     tof = 1.0 * u.min
@@ -131,8 +123,8 @@ def test_propagating_to_certain_nu_is_correct():
     assert elliptic_at_aphelion.epoch > elliptic.epoch
 
     # test 10 random true anomaly values
-    for _ in range(10):
-        nu = np.random.uniform(low=0.0, high=2 * np.pi)
+    # TODO: Rework this test
+    for nu in np.random.uniform(low=-np.pi, high=np.pi, size=10):
         elliptic = elliptic.propagate_to_anomaly(nu * u.rad)
         r, _ = elliptic.rv()
         assert_quantity_allclose(norm(r), a * (1.0 - ecc ** 2) / (1 + ecc * np.cos(nu)))

--- a/tests/tests_twobody/test_propagation.py
+++ b/tests/tests_twobody/test_propagation.py
@@ -130,6 +130,15 @@ def test_propagating_to_certain_nu_is_correct():
         assert_quantity_allclose(norm(r), a * (1.0 - ecc ** 2) / (1 + ecc * np.cos(nu)))
 
 
+def test_propagate_to_anomaly_in_the_past_fails_for_open_orbits():
+    r0 = [Earth.R.to(u.km).value + 300, 0, 0] * u.km
+    v0 = [0, 15, 0] * u.km / u.s
+    orb = Orbit.from_vectors(Earth, r0, v0)
+
+    with pytest.raises(ValueError, match="True anomaly -0.02 rad not reachable"):
+        orb.propagate_to_anomaly(orb.nu - 1 * u.deg)
+
+
 def test_propagate_accepts_timedelta():
     # Data from Vallado, example 2.4
     r0 = [1131.340, -2282.343, 6672.423] * u.km

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ envlist =
     check
     docs
     {py36,py37,py38,pypy3}{,-fast,-online,-slow,-images,-coverage}
-    coverage
 # See https://tox.readthedocs.io/en/latest/example/package.html#flit
 isolated_build = True
 isolated_build_env = build


### PR DESCRIPTION
Regions of `(nu, ecc)` from Farnocchia at al., 2013:

![Screenshot from 2020-04-13 04-40-44](https://user-images.githubusercontent.com/316517/79087869-034dd480-7d41-11ea-8782-5cebefe00362.png)

Previously our logic was wrong: we were incorrectly using the near parabolic solution where we should have been using the strong elliptic solution, and therefore it failed "in the vicinity of `nu = pi`, `0.985 < ecc < 1.0` (for `delta=1e-2`)" [as I correctly identified two years ago](https://github.com/poliastro/poliastro/issues/475#issuecomment-439002103).

* [x] Fix `nu_to_M` ([which causes `orbit.M` to hang](https://github.com/poliastro/poliastro/issues/907#issuecomment-612694540))
* [x] Fix `M_to_nu` ([which causes the `mean_motion` propagator to hang](https://github.com/poliastro/poliastro/issues/475))

Fix #475 (finally!), fix #907.