### PR TITLE
Fix reading of Halley's comet from DASTCOM5

### DIFF
--- a/src/poliastro/neos/dastcom5.py
+++ b/src/poliastro/neos/dastcom5.py
@@ -392,7 +392,7 @@ def record_from_name(name):
     records = []
     lines = string_record_from_name(name)
     for line in lines:
-        records.append(int(line[:6].lstrip()))
+        records.append(int(line[:8].lstrip()))
     return records
 
 

--- a/tests/tests_neos/test_dastcom5.py
+++ b/tests/tests_neos/test_dastcom5.py
@@ -33,17 +33,6 @@ def test_orbit_from_name(mock_record_from_name, mock_orbit_from_record):
     mock_record_from_name.assert_called_with(name)
 
 
-@mock.patch("poliastro.neos.dastcom5.orbit_from_record")
-@mock.patch("poliastro.neos.dastcom5.record_from_name")
-def test_record_from_name(mock_record_from_name, mock_orbit_from_record):
-    name = "example_name"
-    mock_orbit_from_record.return_value = iss
-    mock_record_from_name.return_value = [1]
-
-    assert dastcom5.orbit_from_name(name) == [iss]
-    mock_record_from_name.assert_called_with(name)
-
-
 @mock.patch("poliastro.neos.dastcom5.np.fromfile")
 @mock.patch("poliastro.neos.dastcom5.open")
 def test_read_headers(mock_open, mock_np_fromfile):
@@ -126,9 +115,14 @@ def test_download_dastcom5_downloads_file(mock_request, mock_isdir, mock_zipfile
     )
 
 
-def test_issue_902():
-    try:
-        dastcom5.orbit_from_name("1P")
-        dastcom5.orbit_from_name("europa")
-    except (OSError, ValueError):
-        pytest.fail()
+@mock.patch("poliastro.neos.dastcom5.string_record_from_name")
+def test_issue_902(mock_string_record_from_name):
+    name = "1P"
+    mock_string_record_from_name.return_value = [
+        "90000001 Halley",
+        "90000002 Halley",
+    ]
+    assert dastcom5.record_from_name(name) == [
+        90000001,
+        90000002,
+    ]

--- a/tests/tests_neos/test_dastcom5.py
+++ b/tests/tests_neos/test_dastcom5.py
@@ -124,3 +124,11 @@ def test_download_dastcom5_downloads_file(mock_request, mock_isdir, mock_zipfile
         os.path.join(dastcom5.POLIASTRO_LOCAL_PATH, "dastcom5.zip"),
         dastcom5._show_download_progress,
     )
+
+
+def test_issue_902():
+    try:
+        dastcom5.orbit_from_name("1P")
+        dastcom5.orbit_from_name("europa")
+    except (OSError, ValueError):
+        pytest.fail()


### PR DESCRIPTION
Address #902 

Record of `1P` is 90000001 but due to this line record was returned as 900000 which was reason for the exception
https://github.com/poliastro/poliastro/blob/70eb54d710442a153b1280cd28428f737cd5f6a0/src/poliastro/neos/dastcom5.py#L395