### PR TITLE
fix units in this test to match example in docs

### DIFF
--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -41,7 +41,7 @@ from poliastro.core.propagation import (
 )
 
 
-def cowell(k, r, v, tofs, rtol=1e-11, *, ad=None, **ad_kwargs):
+def cowell(k, r, v, tofs, rtol=1e-11, *, events=None, ad=None, **ad_kwargs):
     """Propagates orbit using Cowell's formulation.
 
     Parameters
@@ -56,6 +56,9 @@ def cowell(k, r, v, tofs, rtol=1e-11, *, ad=None, **ad_kwargs):
         Array of times to propagate.
     rtol : float, optional
         Maximum relative error permitted, default to 1e-10.
+    events : function(t, u(t)), optional
+        passed to solve_ivp: integration stops when this function
+        returns <= 0., assuming you set events.terminal=True
     ad : function(t0, u, k), optional
          Non Keplerian acceleration (km/s2), default to None.
 
@@ -102,13 +105,18 @@ def cowell(k, r, v, tofs, rtol=1e-11, *, ad=None, **ad_kwargs):
         atol=1e-12,
         method=DOP853,
         dense_output=True,
+        events=events,
     )
     if not result.success:
         raise RuntimeError("Integration failed")
 
+    t_end = min(result.t_events[0]) if result.t_events else None
+
     rrs = []
     vvs = []
     for i in range(len(tofs)):
+        if t_end is not None and tofs[i] > t_end:
+            break
         y = result.sol(tofs[i])
         rrs.append(y[:3])
         vvs.append(y[3:])

--- a/tests/tests_twobody/test_perturbations.py
+++ b/tests/tests_twobody/test_perturbations.py
@@ -193,12 +193,12 @@ def test_atmospheric_drag():
     B = C_D * A / m
 
     # parameters of the atmosphere
-    rho0 = rho0_earth.value  # kg/km^3
-    H0 = H0_earth.value
+    rho0 = rho0_earth.to(u.kg / u.km**3).value  # kg/km^3
+    H0 = H0_earth.to(u.km).value  # km
     tof = 100000  # s
 
     dr_expected = (
-        -B * rho0_earth * np.exp(-(norm(r0) - R) / H0) * np.sqrt(k * norm(r0)) * tof
+        -B * rho0 * np.exp(-(norm(r0) - R) / H0) * np.sqrt(k * norm(r0)) * tof
     )
     # assuming the atmospheric decay during tof is small,
     # dr_expected = F_r * tof (Newton's integration formula), where

--- a/tests/tests_twobody/test_perturbations.py
+++ b/tests/tests_twobody/test_perturbations.py
@@ -219,8 +219,55 @@ def test_atmospheric_drag():
     )
 
     assert_quantity_allclose(
-        norm(rr[0].to(u.km).value) - norm(r0), dr_expected.value, rtol=1e-2
+        norm(rr[0].to(u.km).value) - norm(r0), dr_expected, rtol=1e-2
     )
+
+
+@pytest.mark.slow
+def test_atmospheric_demise():
+    # Test an orbital decay that hits Earth. No analytic solution.
+    R = Earth.R.to(u.km).value
+
+    orbit = Orbit.circular(Earth, 230 * u.km)
+
+    # parameters of a body
+    C_D = 2.2  # dimentionless (any value would do)
+    A = ((np.pi / 4.0) * (u.m ** 2)).to(u.km ** 2).value  # km^2
+    m = 100  # kg
+
+    # parameters of the atmosphere
+    rho0 = rho0_earth.to(u.kg / u.km**3).value  # kg/km^3
+    H0 = H0_earth.to(u.km).value  # km
+
+    #tofs = [365 * 86400] * u.s  # currently gets results of length 0 due to tofs[0] < t_end
+    from astropy.time import TimeDelta
+    tofs = TimeDelta(np.linspace(0 * u.h, 365 * 86400 * u.s, num=365 * 24))
+
+    def event_lithobrake(R, t, u):
+        # search for where H - R crosses zero, and then terminate
+        H = norm(u[:3])
+        return H - R
+
+    event_lithobrake_r = functools.partial(event_lithobrake, R)
+    event_lithobrake_r.terminal = True
+    events = [event_lithobrake_r]
+
+    rr, _ = cowell(
+        Earth.k,
+        orbit.r,
+        orbit.v,
+        tofs,
+        ad=atmospheric_drag,
+        R=R,
+        C_D=C_D,
+        A=A,
+        m=m,
+        H0=H0,
+        rho0=rho0,
+        events=events,
+    )
+
+    assert_quantity_allclose(norm(rr[-1]), R, atol=50)  # below 50km by the end
 
 
 @pytest.mark.slow


### PR DESCRIPTION
While developing a thing to estimate satellite decay times, I noticed that the units in this test did not match the units in the very similar example in the documentation.

https://docs.poliastro.space/en/stable/examples/Natural%20and%20artificial%20perturbations.html#Atmospheric-drag