### PR TITLE
fix units in test to match doc example

### DIFF
--- a/tests/tests_twobody/test_perturbations.py
+++ b/tests/tests_twobody/test_perturbations.py
@@ -193,12 +193,12 @@ def test_atmospheric_drag():
     B = C_D * A / m
 
     # parameters of the atmosphere
-    rho0 = rho0_earth.value  # kg/km^3
-    H0 = H0_earth.value
+    rho0 = rho0_earth.to(u.kg / u.km**3).value  # kg/km^3
+    H0 = H0_earth.to(u.km).value  # km
     tof = 100000  # s
 
     dr_expected = (
-        -B * rho0_earth * np.exp(-(norm(r0) - R) / H0) * np.sqrt(k * norm(r0)) * tof
+        -B * rho0 * np.exp(-(norm(r0) - R) / H0) * np.sqrt(k * norm(r0)) * tof
     )
     # assuming the atmospheric decay during tof is small,
     # dr_expected = F_r * tof (Newton's integration formula), where
@@ -219,7 +219,7 @@ def test_atmospheric_drag():
     )
 
     assert_quantity_allclose(
-        norm(rr[0].to(u.km).value) - norm(r0), dr_expected.value, rtol=1e-2
+        norm(rr[0].to(u.km).value) - norm(r0), dr_expected, rtol=1e-2
     )
 
 

--- a/tests/tests_twobody/test_perturbations.py
+++ b/tests/tests_twobody/test_perturbations.py
@@ -193,13 +193,11 @@ def test_atmospheric_drag():
     B = C_D * A / m
 
     # parameters of the atmosphere
-    rho0 = rho0_earth.to(u.kg / u.km**3).value  # kg/km^3
+    rho0 = rho0_earth.to(u.kg / u.km ** 3).value  # kg/km^3
     H0 = H0_earth.to(u.km).value  # km
     tof = 100000  # s
 
-    dr_expected = (
-        -B * rho0 * np.exp(-(norm(r0) - R) / H0) * np.sqrt(k * norm(r0)) * tof
-    )
+    dr_expected = -B * rho0 * np.exp(-(norm(r0) - R) / H0) * np.sqrt(k * norm(r0)) * tof
     # assuming the atmospheric decay during tof is small,
     # dr_expected = F_r * tof (Newton's integration formula), where
     # F_r = -B rho(r) |r|^2 sqrt(k / |r|^3) = -B rho(r) sqrt(k |r|)


### PR DESCRIPTION
While developing a thing to estimate satellite decay times, I noticed that the units in this test did not match the units in the very similar example in the documentation. This PR makes the test match the example.

https://docs.poliastro.space/en/stable/examples/Natural%20and%20artificial%20perturbations.html#Atmospheric-drag