### PR TITLE
stop integrating when we impact the planet

### DIFF
--- a/src/poliastro/twobody/events.py
+++ b/src/poliastro/twobody/events.py
@@ -1,0 +1,23 @@
+from astropy import units as u
+from numpy.linalg import norm
+
+
+class LithobrakeEvent:
+    def __init__(self, R):
+        self._R = R
+        self._last_t = None
+
+    @property
+    def terminal(self):
+        # tell scipy to stop the integration at H = R (impact)
+        return True
+
+    @property
+    def last_t(self):
+        return self._last_t * u.s
+
+    def __call__(self, t, u):
+        self._last_t = t
+        H = norm(u[:3])
+        # scipy will search for H - R = 0
+        return H - self._R

--- a/tests/tests_twobody/test_perturbations.py
+++ b/tests/tests_twobody/test_perturbations.py
@@ -21,6 +21,7 @@ from poliastro.core.perturbations import (
 from poliastro.ephem import build_ephem_interpolant
 from poliastro.twobody import Orbit
 from poliastro.twobody.propagation import cowell
+from poliastro.twobody.events import LithobrakeEvent
 
 
 @pytest.mark.slow
@@ -238,26 +239,6 @@ def test_atmospheric_demise():
     H0 = H0_earth.to(u.km).value  # km
 
     tofs = [365] * u.d  # actually hits the ground a bit after day 48
-
-    class LithobrakeEvent:
-        def __init__(self, R):
-            self._R = R
-            self._last_t = None
-
-        @property
-        def terminal(self):
-            # tell scipy to stop the integration at H = R (impact)
-            return True
-
-        @property
-        def last_t(self):
-            return self._last_t * u.s
-
-        def __call__(self, t, u):
-            self._last_t = t
-            H = norm(u[:3])
-            # scipy will search for H - R = 0
-            return H - self._R
 
     lithobrake_event = LithobrakeEvent(R)
     events = [lithobrake_event]


### PR DESCRIPTION
The current code doesn't deal well with atmospheric decay when the satellite reaches the surface of the planet. As-is the code overshoots and if you integrate for too long after the surface is reached the code appears to start consuming infinite cpu.

![230km-decay-overshoot](https://user-images.githubusercontent.com/2142266/80288145-ce4f6380-86ea-11ea-9982-451d97c88ff0.png)

This checkin uses a scikit integration "event" to stop integration when the satellite hits the planet. Since the existing API doesn't let the propagation routine change anything about the times passed in, I have chosen to return the final value for all subsequent times. This graphs OK, but it will leave users sad if they want to know the time of impact. I'm not sure how to solve this interface issue better.

cc @iamabhishek0 