### PR TITLE
Drop Python 3.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,7 @@ poliastro requires the following Python packages:
 * SciPy, for root finding and numerical propagation
 
 poliastro is tested on Linux, OS X and Windows on Python
-3.6, 3.7 and 3.8 against latest NumPy.
+3.7 and 3.8 against latest NumPy.
 
 |azure_pipelines|
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ variables:
   CI_NAME: Azure Pipelines
   CI_BUILD_ID: $(Build.BuildId)
   CI_BUILD_URL: "https://dev.azure.com/poliastro/poliastro/_build/results?buildId=$(Build.BuildId)"
-  CIBW_BUILD: cp36-* cp37-* cp38-*
+  CIBW_BUILD: cp37-* cp38-*
   CIBW_SKIP: "*-win32 *-manylinux1_i686"
   CODECOV_TOKEN: "0d87eeea-9528-4c59-b23f-0aedb3cc76a3"
 
@@ -45,10 +45,6 @@ jobs:
     envs:
       - linux: check
         name : quality
-        libraries: {}
-
-      - linux: py36
-        name: py36_test
         libraries: {}
 
       - linux: py37

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -15,7 +15,7 @@ poliastro requires a number of Python packages, notably:
 * SciPy, for root finding and numerical propagation
 
 poliastro is usually tested on Linux and Windows on Python
-3.6, 3.7 and 3.8 against latest NumPy.
+3.7 and 3.8 against latest NumPy.
 It should work on OS X without problems.
 
 Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ requires = [
     "cached_property ; python_version<'3.8'",
     "jplephem",
     "matplotlib >=2.0,!=3.0.1",
-    "numba >=0.46,!=0.49.0 ; implementation_name=='cpython'",
+    "numba >=0.46 ; implementation_name=='cpython'",
     "numpy",
     "pandas",
     "plotly ~=4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
     "Topic :: Scientific/Engineering :: Astronomy",
 ]
-requires-python = ">=3.6,<3.9"
+requires-python = ">=3.7,<3.9"
 requires = [
     "astropy >=3.2,<5",
     "astroquery >=0.3.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ requires = [
     "cached_property ; python_version<'3.8'",
     "jplephem",
     "matplotlib >=2.0,!=3.0.1",
-    "numba >=0.46 ; implementation_name=='cpython'",
+    "numba >=0.46,!=0.49.0 ; implementation_name=='cpython'",  # https://github.com/numba/numba/issues/5661
     "numpy",
     "pandas",
     "plotly ~=4.0",

--- a/tests/tests_twobody/test_sampling.py
+++ b/tests/tests_twobody/test_sampling.py
@@ -53,6 +53,7 @@ def test_sample_closed_starts_at_min_anomaly_if_in_range(min_nu, ecc, max_nu):
     ),
     ecc=eccentricities_q(),
 )
+@example(1e-16 * u.rad, 0 * u.one)
 @example(0 * u.rad, 0 * u.one)
 @example(0 * u.rad, 0.88680956 * u.one)
 def test_sample_closed_starts_and_ends_at_min_anomaly_if_in_range_and_no_max_given(
@@ -60,5 +61,5 @@ def test_sample_closed_starts_and_ends_at_min_anomaly_if_in_range_and_no_max_giv
 ):
     result = sample_closed(min_nu, ecc)
 
-    assert_quantity_allclose(result[0], min_nu)
+    assert_quantity_allclose(result[0], min_nu, atol=1e-14 * u.rad)
     assert_quantity_allclose(result[-1], min_nu, atol=1e-14 * u.rad)

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ description = list of environments againts tox runs the tests
 envlist =
     check
     docs
-    {py36,py37,py38,pypy3}{,-fast,-online,-slow,-images,-coverage}
+    {py37,py38,pypy3}{,-fast,-online,-slow,-images,-coverage}
 # See https://tox.readthedocs.io/en/latest/example/package.html#flit
 isolated_build = True
 isolated_build_env = build
@@ -14,7 +14,6 @@ whitelist_externals=
     /usr/bin/bash
 basepython =
     pypy3: pypy3
-    py36: python3.6
     py37: python3.7
     py38: python3.8
     # See https://github.com/tox-dev/tox/issues/1548


### PR DESCRIPTION
https://docs.python.org/3.7/whatsnew/3.7.html

Interesting for us:

* PEP 563, postponed evaluation of type annotations.
* "the insertion-order preservation nature of dict objects has been declared to be an official part of the Python language spec"
* PEP 565, improved DeprecationWarning handling

Nothing really groundbreaking.