### PR TITLE
Mark few more tests as remote

### DIFF
--- a/tests/tests_plotting/test_static.py
+++ b/tests/tests_plotting/test_static.py
@@ -186,6 +186,7 @@ def test_body_plotting(earth_perihelion):
 
 
 @pytest.mark.mpl_image_compare
+@pytest.mark.remote_data
 def test_plot_ephem_epoch():
     epoch = Time("2020-02-14 00:00:00")
     ephem = Ephem.from_horizons(
@@ -205,6 +206,7 @@ def test_plot_ephem_epoch():
 
 
 @pytest.mark.mpl_image_compare
+@pytest.mark.remote_data
 def test_plot_ephem_no_epoch():
     epoch = Time("2020-02-14 00:00:00")
     ephem = Ephem.from_horizons(


### PR DESCRIPTION
The `test_plot_ephem_epoch()` and `test_plot_ephem_no_epoch()` actually cause a remote access to download the ephemerides. Without the mark, this causes a failure on systems that have no connection (like in Debian during build time).

This PR adds the required markers for these tests.