### PR TITLE
Docs captions

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -80,15 +80,36 @@ Contents
 
 .. toctree::
     :maxdepth: 2
+    :caption: Welcome to poliastro
 
     about
+    changelog
+
+.. toctree::
+    :maxdepth: 2
+    :caption: Install, use and contribute
+
     getting_started
     user_guide
+    contributing
+
+.. toctree::
+    :maxdepth: 2
+    :caption: Tutorials
+
     jupyter
+
+.. toctree::
+    :maxdepth: 2
+    :caption: API Docs
+
     api/safe/safe_index
     api/core/core_index
-    changelog
-    contributing
+
+.. toctree::
+    :maxdepth: 2
+    :caption: Bibliography
+
     references
 
 


### PR DESCRIPTION
This pull requests add some captions to the documentation so it becomes visually easier to differentiate between sections. Although this feature is not linked to any open issue, I see it as a first step for other documentation related tasks.

I thought this could be an interesting simple feature. **Caption names were selected without previous discussion, so let me know if some change is required.**

With captions (PR)             |  Without captions (Current)
:-------------------------:|:-------------------------:
![ex_1](https://user-images.githubusercontent.com/28702884/84496352-1b909000-acad-11ea-9ed5-47bd40ec276a.png) |  ![ex_2](https://user-images.githubusercontent.com/28702884/84496411-36630480-acad-11ea-8616-ba02ddca6ad1.png)
