### PR TITLE
Avoid lambda usage in conf.py

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -323,8 +323,7 @@ nbsphinx_thumbnails = {
 }
 
 # Custom nbsphinx format for Jupytext markdown notebooks
-import jupytext
 
 nbsphinx_custom_formats = {
-   '.md': lambda s: jupytext.reads(s, '.md'),
+    '.md': ['jupytext.reads', {'fmt': 'md'}],
 }


### PR DESCRIPTION
As advised by @mgeier in https://github.com/mwouts/jupytext/issues/119, lambda function should not be used with `nbsphinx_custom_formats`. This pull request removes its usage in `conf.py` file.