### PR TITLE
Exclude docs/ from sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,3 +90,6 @@ include = [
     "src/poliastro/atmosphere/data/coesa76_rho.dat",
     "setup.cfg"
 ]
+exclude = [
+    "docs/"
+]


### PR DESCRIPTION
Solves for issue #951 by excluding documentation from `sdist` distribution.