### PR TITLE
New documentation layout

### DIFF
--- a/docs/source/bibliography.rst
+++ b/docs/source/bibliography.rst
@@ -1,5 +1,5 @@
-References
-==========
+Bibliography
+============
 
   *Nanos gigantum humeris insidentes.*
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -1,5 +1,5 @@
-Contributing
-============
+Contribute
+==========
 
 poliastro is a community project, hence all contributions are more than
 welcome!

--- a/docs/source/gallery.rst
+++ b/docs/source/gallery.rst
@@ -1,5 +1,5 @@
-Jupyter notebooks
-=================
+Gallery
+=======
 
 The following page contains a collection of practical examples and problem
 solutions solved with **poliastro**. From interplanetary transfers, to asteroid

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -87,7 +87,7 @@ Contents
 
 .. toctree::
     :maxdepth: 2
-    :caption: Install, use and contribute
+    :caption: How to
 
     getting_started
     user_guide
@@ -97,20 +97,15 @@ Contents
     :maxdepth: 2
     :caption: Tutorials
 
-    jupyter
+    gallery
 
 .. toctree::
     :maxdepth: 2
-    :caption: API Docs
+    :caption: References
 
     api/safe/safe_index
     api/core/core_index
-
-.. toctree::
-    :maxdepth: 2
-    :caption: Bibliography
-
-    references
+    bibliography
 
 
 .. note::

--- a/src/poliastro/neos/dastcom5.py
+++ b/src/poliastro/neos/dastcom5.py
@@ -6,9 +6,9 @@ import re
 import urllib.request
 import zipfile
 
-import astropy.units as u
 import numpy as np
 import pandas as pd
+from astropy import units as u
 from astropy.time import Time
 
 from poliastro.bodies import Sun

--- a/src/poliastro/plotting/porkchop.py
+++ b/src/poliastro/plotting/porkchop.py
@@ -1,10 +1,9 @@
 """
 This is the script for porkchop plotting
 """
-
-import matplotlib.pyplot as plt
 import numpy as np
 from astropy import coordinates as coord, units as u
+from matplotlib import pyplot as plt
 
 from poliastro.bodies import (
     Earth,

--- a/src/poliastro/plotting/tisserand.py
+++ b/src/poliastro/plotting/tisserand.py
@@ -1,10 +1,9 @@
 """ Generates Tisserand plots """
-
 from enum import Enum
 
-import matplotlib.pyplot as plt
 import numpy as np
 from astropy import units as u
+from matplotlib import pyplot as plt
 
 from poliastro.plotting._base import BODY_COLORS
 from poliastro.twobody.mean_elements import get_mean_elements

--- a/src/poliastro/twobody/thrust/change_ecc_quasioptimal.py
+++ b/src/poliastro/twobody/thrust/change_ecc_quasioptimal.py
@@ -6,8 +6,8 @@ References
   Elliptical Orbit Transfers", 1997.
 
 """
-import astropy.units as u
 import numpy as np
+from astropy import units as u
 from numpy import cross
 from numpy.linalg import norm
 

--- a/tests/test_czml.py
+++ b/tests/test_czml.py
@@ -10,8 +10,9 @@ from poliastro.bodies import Mars
 from poliastro.examples import iss, molniya
 
 try:
-    from poliastro.czml.extract_czml import CZMLExtractor
     from czml3.core import Document
+
+    from poliastro.czml.extract_czml import CZMLExtractor
 except ImportError:
     pass
 

--- a/tests/tests_core/test_core_util.py
+++ b/tests/tests_core/test_core_util.py
@@ -1,9 +1,8 @@
 from functools import partial
 
-import hypothesis.strategies as st
 import numpy as np
 import pytest
-from hypothesis import given, settings
+from hypothesis import given, settings, strategies as st
 
 from poliastro.core.util import alinspace, rotation_matrix
 

--- a/tests/tests_plotting/test_misc.py
+++ b/tests/tests_plotting/test_misc.py
@@ -1,5 +1,5 @@
-import matplotlib.pyplot as plt
 import pytest
+from matplotlib import pyplot as plt
 
 from poliastro.plotting import OrbitPlotter2D, OrbitPlotter3D
 from poliastro.plotting.misc import plot_solar_system

--- a/tests/tests_plotting/test_porkchop.py
+++ b/tests/tests_plotting/test_porkchop.py
@@ -1,5 +1,5 @@
-import matplotlib.pyplot as plt
 import pytest
+from matplotlib import pyplot as plt
 
 from poliastro.bodies import Earth, Mars
 from poliastro.plotting.porkchop import porkchop

--- a/tests/tests_plotting/test_static.py
+++ b/tests/tests_plotting/test_static.py
@@ -1,8 +1,8 @@
-import matplotlib.pyplot as plt
 import pytest
 from astropy import units as u
 from astropy.coordinates import CartesianDifferential, CartesianRepresentation
 from astropy.time import Time
+from matplotlib import pyplot as plt
 
 from poliastro.bodies import Earth, Jupiter, Mars, Sun
 from poliastro.constants import J2000

--- a/tests/tests_plotting/test_tisserand.py
+++ b/tests/tests_plotting/test_tisserand.py
@@ -1,6 +1,6 @@
-import astropy.units as u
-import matplotlib.pyplot as plt
 import pytest
+from astropy import units as u
+from matplotlib import pyplot as plt
 
 from poliastro.bodies import Earth, Mars, Venus
 from poliastro.plotting._base import BODY_COLORS

--- a/tests/tests_twobody/test_orbit.py
+++ b/tests/tests_twobody/test_orbit.py
@@ -3,7 +3,6 @@ from collections import OrderedDict
 from functools import partial
 from unittest import mock
 
-import hypothesis.strategies as st
 import matplotlib
 import numpy as np
 import pytest
@@ -16,7 +15,7 @@ from astropy.coordinates import (
 )
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.time import Time
-from hypothesis import example, given, settings
+from hypothesis import example, given, settings, strategies as st
 from numpy.testing import assert_allclose, assert_array_equal
 
 from poliastro.bodies import (

--- a/tests/tests_twobody/test_propagation.py
+++ b/tests/tests_twobody/test_propagation.py
@@ -1,10 +1,9 @@
-import hypothesis.strategies as st
 import numpy as np
 import pytest
 from astropy import time, units as u
 from astropy.coordinates import CartesianRepresentation
 from astropy.tests.helper import assert_quantity_allclose
-from hypothesis import given, settings
+from hypothesis import given, settings, strategies as st
 from numpy.testing import assert_allclose
 from pytest import approx
 

--- a/tests/tests_twobody/test_sampling.py
+++ b/tests/tests_twobody/test_sampling.py
@@ -1,10 +1,9 @@
 from functools import partial
 
-import hypothesis.strategies as st
 import numpy as np
 from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose
-from hypothesis import example, given, settings
+from hypothesis import example, given, settings, strategies as st
 
 from poliastro.twobody.sampling import sample_closed
 

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ deps =
 skip_install = true
 commands =
     flake8 src tests
-    isort --check-only --diff --recursive --project poliastro --section-default THIRDPARTY src tests
+    isort --check-only --diff --project poliastro --section-default THIRDPARTY src tests
     black --check src tests
     mypy --ignore-missing-imports --check-untyped-defs --no-strict-optional src tests
 
@@ -66,7 +66,7 @@ deps =
     isort
 skip_install = true
 commands =
-    isort --recursive --project poliastro --section-default THIRDPARTY src tests
+    isort --project poliastro --section-default THIRDPARTY src tests
     black src tests
 
 


### PR DESCRIPTION
Solves for #975 by adding a new documentation layout.

**Old layout**            |  **New layout** 
:-------------------------:|:-------------------------:
![old_layout](https://user-images.githubusercontent.com/28702884/86466028-27fb8c00-bd33-11ea-9ca3-d58661131d28.png)  |  ![new_layout](https://user-images.githubusercontent.com/28702884/86466043-33e74e00-bd33-11ea-9c63-b472753a30cf.png)

Notice that some filenames were changed together with their heading sections just to match desired documentation structure :relaxed: 


