### PR TITLE
Fix unit for gas constant in COESA models

### DIFF
--- a/src/poliastro/earth/atmosphere/coesa62.py
+++ b/src/poliastro/earth/atmosphere/coesa62.py
@@ -181,8 +181,7 @@ class COESA62(COESA):
             # Putting g = (g0*(r0/(r0 +z))**2) in (g * dz / z - zb + Tb/Lb)
             # and integrating it.
             integrand = quad(
-                lambda x: (g0_v * (r0_v / (r0_v + x)) ** 2)
-                / (x - zb_v + Tb_v / Lb_v),
+                lambda x: (g0_v * (r0_v / (r0_v + x)) ** 2) / (x - zb_v + Tb_v / Lb_v),
                 zb_v,
                 z_v,
             )

--- a/src/poliastro/earth/atmosphere/coesa62.py
+++ b/src/poliastro/earth/atmosphere/coesa62.py
@@ -73,7 +73,7 @@ beta = 1.458e-6 * u.kg / u.s / u.m / u.K ** (0.5)
 _gamma = 1.4
 sigma = 3.65e-10 * u.m
 N = 6.02257e26 * (u.kg * u.mol) ** -1
-R = 8314.32 * u.J / u.kg / u.K
+R = 8314.32 * u.J / u.kmol / u.K
 R_air = 287.053 * u.J / u.kg / u.K
 alpha = 34.1632 * u.K / u.km
 
@@ -181,7 +181,8 @@ class COESA62(COESA):
             # Putting g = (g0*(r0/(r0 +z))**2) in (g * dz / z - zb + Tb/Lb)
             # and integrating it.
             integrand = quad(
-                lambda x: (g0_v * (r0_v / (r0_v + x)) ** 2) / (x - zb_v + Tb_v / Lb_v),
+                lambda x: (g0_v * (r0_v / (r0_v + x)) ** 2)
+                / (x - zb_v + Tb_v / Lb_v),
                 zb_v,
                 z_v,
             )

--- a/src/poliastro/earth/atmosphere/coesa76.py
+++ b/src/poliastro/earth/atmosphere/coesa76.py
@@ -52,7 +52,7 @@ from poliastro.earth.atmosphere.base import COESA
 
 # Following constants come from original U.S Atmosphere 1962 paper so a pure
 # model of this atmosphere can be implemented
-R = 8314.32 * u.J / u.kg / u.K
+R = 8314.32 * u.J / u.kmol / u.K
 R_air = 287.053 * u.J / u.kg / u.K
 k = 1.380622e-23 * u.J / u.K
 Na = 6.022169e-26 / u.kmol


### PR DESCRIPTION
Fixes #992 

COESA atmospheric models 62 and 76 had wrong units for R gas constant (J/kg/K instead of J/kmol/K).