### PR TITLE
Deleted text in doc string  of src/poliastro/__init__.py

### DIFF
--- a/src/poliastro/__init__.py
+++ b/src/poliastro/__init__.py
@@ -1,10 +1,5 @@
 """
-=========
-poliastro
-=========
-
 Utilities and Python wrappers for Orbital Mechanics
-
 """
 
 __version__ = "0.15.dev0"


### PR DESCRIPTION
This fixes the issue https://github.com/poliastro/poliastro/issues/957

Fixed by deleting the first 3 lines of the doc string in `src/poliastro/__init__.py`
