### PR TITLE
Fix LaTeX equation on docs index page

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -43,8 +43,8 @@ and `chat`_.
    :alt: Molniya orbit
 
    Plot of a `Molniya orbit`_ around the Earth
-   (\\(a = 26600\\,\\mathrm{km}, e = 0.75,
-   i = 63.4 \\mathrm{{}^{\\circ}} \\)).
+   (:math:`a = 26600\mathrm{km}, e = 0.75,
+   i = 63.4\mathrm{^\circ}`).
 
 The `source code`_, `issue tracker`_ and `wiki`_ are hosted on GitHub, and all
 contributions and feedback are more than welcome. You can test poliastro in your


### PR DESCRIPTION
LaTex equation on image description formatting errors. 
With this change it gets from this:
![](https://i.imgur.com/Jw2pGbR.png)
to this:
![](https://i.imgur.com/6y3eyoe.png)