### PR TITLE
Add option to skip compiling of jupyter notebooks on documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -140,12 +140,12 @@ intersphinx_mapping = {
     'matplotlib': ('https://matplotlib.org', None)
 }
 
-"""
-if os.environ.get('READTHEDOCS') == 'True':
+if os.environ.get('POLIASTRO_SKIP_NOTEBOOKS') == 'True':
     nbsphinx_execute = 'never'
 else:
     nbsphinx_execute = 'always'
 
+"""
     # Controls when a cell will time out (defaults to 30; use -1 for no timeout):
     nbsphinx_timeout = 60
 """

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -145,11 +145,6 @@ if os.environ.get('POLIASTRO_SKIP_NOTEBOOKS') == 'True':
 else:
     nbsphinx_execute = 'always'
 
-"""
-    # Controls when a cell will time out (defaults to 30; use -1 for no timeout):
-    nbsphinx_timeout = 60
-"""
-
 # -- Options for HTML output ----------------------------------------------
 
 html_theme = "sphinx_rtd_theme"


### PR DESCRIPTION
Jupyter notebooks take a long time to compile. This change adds the option for the contributor to set the following environment variable to skip them while generatting docs:

POLIASTRO_SKIP_NOTEBOOKS=True

Discussion about it on #365