### PR TITLE
Fix issue 960

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -76,7 +76,7 @@ is within the scope of the library so you don't waste your time -
 `the mailing list`_ or `the chat`_ are good places to ask.
 
 .. _`the mailing list`: https://groups.io/g/poliastro-dev
-.. _`the chat`: https://riot.im/app/#/room/#poliastro:matrix.org
+.. _`the chat`: #poliastro:matrix.or
 
 If the feature you suggest happens to be useful and within scope, you will
 probably be advised to create a new `wiki`_ page with some information

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -76,7 +76,7 @@ is within the scope of the library so you don't waste your time -
 `the mailing list`_ or `the chat`_ are good places to ask.
 
 .. _`the mailing list`: https://groups.io/g/poliastro-dev
-.. _`the chat`: #poliastro:matrix.or
+.. _`the chat`: http://chat.poliastro.space/
 
 If the feature you suggest happens to be useful and within scope, you will
 probably be advised to create a new `wiki`_ page with some information

--- a/README.rst
+++ b/README.rst
@@ -39,8 +39,8 @@
    :target: https://groups.io/g/poliastro-dev
 
 .. |matrix| image:: https://img.shields.io/matrix/poliastro:matrix.org.svg?style=flat-square
-   :alt: Join the chat at https://chat.openastronomy.org/#/room/#poliastro:matrix.org
-   :target: https://chat.openastronomy.org/#/room/#poliastro:matrix.org
+   :alt: Join the chat at http://chat.poliastro.space/
+   :target: http://chat.poliastro.space/
 
 |azure_pipelines| |codecov| |codeclimate|
 
@@ -146,7 +146,7 @@ Release announcements and general discussion take place on our `Mailing List`_ .
 
 For further clarifications and discussions, feel free to join Poliastro `Chat Room`_.
 
-.. _`Chat Room`: https://chat.openastronomy.org/#/room/#poliastro:matrix.org
+.. _`Chat Room`: http://chat.poliastro.space/
 .. _`Mailing List`: https://groups.io/g/poliastro-dev
 
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -77,7 +77,7 @@ is within the scope of the library so you don't waste your time -
 `the mailing list`_ or `the chat`_ are good places to ask.
 
 .. _`the mailing list`: https://groups.io/g/poliastro-dev
-.. _`the chat`: https://riot.im/app/#/room/#poliastro:matrix.org
+.. _`the chat`: http://chat.poliastro.space/
 
 If the feature you suggest happens to be useful and within scope, you will
 probably be advised to create a new `wiki`_ page with some information

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -33,7 +33,7 @@ announcements and general discussion take place on our `mailing list`_
 and `chat`_.
 
 .. _`mailing list`: https://groups.io/g/poliastro-dev
-.. _`chat`: https://riot.im/app/#/room/#poliastro:matrix.org
+.. _`chat`: http://chat.poliastro.space/
 
 .. include:: form.rst
 


### PR DESCRIPTION
Close #960 by changing all the old riot link to --> http://chat.poliastro.space/