### PR TITLE
min and max function

### DIFF
--- a/src/poliastro/earth/sensors.py
+++ b/src/poliastro/earth/sensors.py
@@ -3,7 +3,7 @@ from astropy import units as u
 
 
 @u.quantity_input(h=u.km, η_fov=u.rad, η_center=u.rad, R=u.km)
-def max_and_min_ground_range(h, η_fov, η_center, R):
+def min_and_max_ground_range(h, η_fov, η_center, R):
     """
     Calculates the minimum and maximum values of ground-range angles
     Parameters
@@ -43,7 +43,7 @@ def max_and_min_ground_range(h, η_fov, η_center, R):
     Λ_max = np.arcsin(ρ_max * np.sin(η_max) / R)
     Λ_min = np.arcsin(ρ_min * np.sin(η_min) / R)
 
-    return Λ_max, Λ_min
+    return Λ_min, Λ_max
 
 
 @u.quantity_input(
@@ -104,7 +104,7 @@ def max_and_min_ground_range_with_specific_azimuth(
     )
     delta_Λ = np.arcsin(np.sin(β) * np.sin(Λ) / np.cos(φ_tgt))
     λ_tgt = λ_nadir + delta_Λ
-    Λ_max, Λ_min = max_and_min_ground_range(h, η_fov, η_center, R)
+    Λ_min, Λ_max = min_and_max_ground_range(h, η_fov, η_center, R)
     delta_λ = (Λ_max - Λ_min) / 2
 
     return delta_λ, φ_tgt, λ_tgt

--- a/tests/tests_earth/test_sensors.py
+++ b/tests/tests_earth/test_sensors.py
@@ -4,8 +4,8 @@ from astropy.tests.helper import assert_quantity_allclose
 
 from poliastro.bodies import Earth
 from poliastro.earth.sensors import (
-    max_and_min_ground_range,
     max_and_min_ground_range_with_specific_azimuth,
+    min_and_max_ground_range,
 )
 
 
@@ -32,7 +32,7 @@ from poliastro.earth.sensors import (
 def test_max_and_min_ground_range(h, n_fov, n_center, expected_Λ_max, expected_Λ_min):
 
     R = Earth.R.to(u.km)
-    Λ_max, Λ_min = max_and_min_ground_range(h, n_fov, n_center, R)
+    Λ_min, Λ_max = min_and_max_ground_range(h, n_fov, n_center, R)
     assert_quantity_allclose(Λ_max, expected_Λ_max)
     assert_quantity_allclose(Λ_min, expected_Λ_min)
 


### PR DESCRIPTION
 Linked to #1015 
closes #1014

Changed the name of the method from max_and_min_ground_range to min_and_max_ground_range in all relevant files.
Changed the order of the parameters in the return statement.