### PR TITLE
corrected doc: jupyter installation

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -105,7 +105,7 @@ These are some succinct steps to set up a development environment:
 3. `Fork poliastro <https://help.github.com/articles/fork-a-repo/>`_.
 4. `Clone your fork <https://help.github.com/articles/cloning-a-repository/>`_.
 5. Install `flit`_ using
-   :code:`python -m pip install flit`
+   :code:`python -m pip install flit wheel`
 6. Change into the local checkout of your repository and install it in development mode using
    :code:`flit install --symlink` (:code:`--symlink` means that the
    installed code will change as soon as you change it in the download
@@ -114,10 +114,6 @@ These are some succinct steps to set up a development environment:
 8. Make changes and commit.
 9. `Push to your fork <https://help.github.com/articles/pushing-to-a-remote/>`_.
 10. `Open a pull request! <https://help.github.com/articles/creating-a-pull-request/>`_
-
-If you experience errors complaining about `invalid command 'bdist_wheel'` during `flit install --symlink`,
-install the `wheel` package using :code:`python -m pip install wheel` and try the installation
-again.
 
 For more detailed explanations, please check out the `Astropy development docs`__.
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -115,6 +115,10 @@ These are some succinct steps to set up a development environment:
 9. `Push to your fork <https://help.github.com/articles/pushing-to-a-remote/>`_.
 10. `Open a pull request! <https://help.github.com/articles/creating-a-pull-request/>`_
 
+If you experience errors complaining about `invalid command 'bdist_wheel'` during `flit install --symlink`,
+install the `wheel` package using :code:`python -m pip install wheel` and try the installation
+again.
+
 For more detailed explanations, please check out the `Astropy development docs`__.
 
 .. _`flit`: https://github.com/takluyver/flit

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -43,7 +43,7 @@ If you don't want to use conda you can `install poliastro from PyPI`_
 using pip::
 
   $ pip install numpy  # Run this one first for pip 9 and older!
-  $ pip install poliastro[jupyter] pytest
+  $ pip install poliastro [jupyter] pytest
 
 Finally, you can also install the latest development version of poliastro
 `directly from GitHub`_::
@@ -79,11 +79,14 @@ Using poliastro on JupyterLab
 
 After the release of Plotly 3.0, plotting orbits using poliastro is easier than ever.
 
-You have to install three extensions of JupyterLab to make your experience smooth::
+You need to install the jupyter-lab, which will install the necessary dependencies.
+You can do this using pip::
 
-  $ jupyter labextension install @jupyter-widgets/jupyterlab-manager@0.38
-  $ jupyter labextension install plotlywidget@0.7.0
-  $ jupyter labextension install @jupyterlab/plotly-extension@0.18.1
+  $ pip install jupyter-lab
+
+And then start the jupyter-lab with::
+
+  $ jupyter-lab
 
 And as the documentation of JupyterLab Extensions states:
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -79,10 +79,10 @@ Using poliastro on JupyterLab
 
 After the release of Plotly 3.0, plotting orbits using poliastro is easier than ever.
 
-You need to install the jupyter-lab, which will install the necessary dependencies.
+You need to install the jupyterlab, which will install the necessary dependencies, including plotly.
 You can do this using pip::
 
-  $ pip install jupyter-lab
+  $ pip install jupyterlab
 
 And then start the jupyter-lab with::
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -86,7 +86,7 @@ You can do this using pip::
 
 And then start the jupyter-lab with::
 
-  $ jupyter-lab
+  $ jupyter lab
 
 And as the documentation of JupyterLab Extensions states:
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -43,7 +43,7 @@ If you don't want to use conda you can `install poliastro from PyPI`_
 using pip::
 
   $ pip install numpy  # Run this one first for pip 9 and older!
-  $ pip install poliastro [jupyter] pytest
+  $ pip install poliastro[jupyter] pytest
 
 Finally, you can also install the latest development version of poliastro
 `directly from GitHub`_::


### PR DESCRIPTION
This PR corrects outdated section about Jupyter-lab installation and adds a small note in contributing section regarding how to solve the bdist_wheel missing error. This partially addresses #682.