### PR TITLE
Minor change removing if-statement allows for the markley_coe propagator to be called using 1-N arrays.

### DIFF
--- a/src/poliastro/core/propagation/__init__.py
+++ b/src/poliastro/core/propagation/__init__.py
@@ -324,9 +324,7 @@ def markley_coe(k, p, ecc, inc, raan, argp, nu, tof):
     M = M0 + n * tof
 
     # Range between -pi and pi
-    M = M % (2 * np.pi)
-    if M > np.pi:
-        M = -(2 * np.pi - M)
+    M = (M + np.pi) % (2 * np.pi) - np.pi
 
     # Equation (20)
     alpha = (3 * np.pi ** 2 + 1.6 * (np.pi - np.abs(M)) / (1 + ecc)) / (np.pi ** 2 - 6)


### PR DESCRIPTION
The if-statement in the markley_coe function is the only line that doesn't allow the function to be properly vectorized.

I've changed these lines to be solely arithmetic, therefore working on 1-N arrays.

With this changes the variables k, p, ecc, nu and tof may be single values (original capability), all equal length 1-N arrays, or a mix of single values & equal length 1-N arrays.