### PR TITLE
Coe2rv vectorized

### DIFF
--- a/src/poliastro/core/elements.py
+++ b/src/poliastro/core/elements.py
@@ -85,8 +85,8 @@ def rv_pqw(k, p, ecc, nu):
     u_q = np.array([[0, 1, 0]]).T
     u_w = np.array([[0, 0, 1]]).T
 
-    r = ((u_p * cos(nu) + u_q * sin(nu) + u_w * 0.) * (p / (1 + ecc * cos(nu)))).T
-    v = ((u_p * -sin(nu) + u_q *(ecc + cos(nu))  + u_w * 0.) * sqrt(k / p)).T
+    r = ((u_p * cos(nu) + u_q * sin(nu) + u_w * 0.0) * (p / (1 + ecc * cos(nu)))).T
+    v = ((u_p * -sin(nu) + u_q * (ecc + cos(nu)) + u_w * 0.0) * sqrt(k / p)).T
 
     return r, v
 
@@ -156,6 +156,7 @@ def coe2rv(k, p, ecc, inc, raan, argp, nu):
         \end{bmatrix}
 
     """
+
     pqw = rv_pqw(k, p, ecc, nu)
     rm = coe_rotation_matrix(inc, raan, argp)
 

--- a/src/poliastro/core/elements.py
+++ b/src/poliastro/core/elements.py
@@ -68,11 +68,27 @@ def rv_pqw(k, p, ecc, nu):
     r = [-5312706.25105345  9201877.15251336    0] [m]
     v = [-5753.30180931 -1328.66813933  0] [m]/[s]
 
+    Also works on 1-N arrays:
+    >>> r, v = rv_pqw(np.full((4,1),k), np.full((4,1),p), np.full((4,1),ecc), np.full((4,1),nu))
+    r = [[-5312706.25105345  9201877.15251336    0]
+         [-5312706.25105345  9201877.15251336    0]
+         [-5312706.25105345  9201877.15251336    0]
+         [-5312706.25105345  9201877.15251336    0]] [m]
+    v = [[-5753.30180931 -1328.66813933  0]
+         [-5753.30180931 -1328.66813933  0]
+         [-5753.30180931 -1328.66813933  0]
+         [-5753.30180931 -1328.66813933  0]] [m]/[s]
     """
-    pqw = np.array([[cos(nu), sin(nu), 0], [-sin(nu), ecc + cos(nu), 0]]) * np.array(
-        [[p / (1 + ecc * cos(nu))], [sqrt(k / p)]]
-    )
-    return pqw
+
+    # Unit vectors in pqw (this is done to circumvent a numba issue: https://github.com/numba/numba/issues/4470)
+    u_p = np.array([1, 0, 0])
+    u_q = np.array([0, 1, 0])
+    u_w = np.array([0, 0, 1])
+
+    r = (cos(nu) * u_p + sin(nu) * u_q + 0 * u_w) * (p / (1 + ecc * cos(nu)))
+    v = (-sin(nu) * u_p + (ecc + cos(nu)) * u_q + 0 * u_w) * sqrt(k / p)
+
+    return r, v
 
 
 @jit

--- a/src/poliastro/core/elements.py
+++ b/src/poliastro/core/elements.py
@@ -2,7 +2,7 @@
     to convert between different elements that define the orbit
     of a body.
     """
-
+import numba
 import numpy as np
 from numpy import cross
 from numpy.core.umath import cos, sin, sqrt
@@ -65,11 +65,11 @@ def rv_pqw(k, p, ecc, nu):
     >>> p = h**2 / k  # Parameter of the orbit
     >>> r, v = rv_pqw(k, p, ecc, nu)
     >>> # Printing the results
-    r = [-5312706.25105345  9201877.15251336    0] [m]
-    v = [-5753.30180931 -1328.66813933  0] [m]/[s]
+    r = [[-5312706.25105345  9201877.15251336    0]] [m]
+    v = [[-5753.30180931 -1328.66813933  0]] [m]/[s]
 
-    Also works on 1-N arrays:
-    >>> r, v = rv_pqw(np.full((4,1),k), np.full((4,1),p), np.full((4,1),ecc), np.full((4,1),nu))
+    Also works on vector inputs:
+    >>> r, v = rv_pqw(np.full(4,k), np.full(4,p), np.full(4,ecc), np.full(4,nu))
     r = [[-5312706.25105345  9201877.15251336    0]
          [-5312706.25105345  9201877.15251336    0]
          [-5312706.25105345  9201877.15251336    0]
@@ -81,12 +81,12 @@ def rv_pqw(k, p, ecc, nu):
     """
 
     # Unit vectors in pqw (this is done to circumvent a numba issue: https://github.com/numba/numba/issues/4470)
-    u_p = np.array([1, 0, 0])
-    u_q = np.array([0, 1, 0])
-    u_w = np.array([0, 0, 1])
+    u_p = np.array([[1, 0, 0]]).T
+    u_q = np.array([[0, 1, 0]]).T
+    u_w = np.array([[0, 0, 1]]).T
 
-    r = (cos(nu) * u_p + sin(nu) * u_q + 0 * u_w) * (p / (1 + ecc * cos(nu)))
-    v = (-sin(nu) * u_p + (ecc + cos(nu)) * u_q + 0 * u_w) * sqrt(k / p)
+    r = ((u_p * cos(nu) + u_q * sin(nu) + u_w * 0.) * (p / (1 + ecc * cos(nu)))).T
+    v = ((u_p * -sin(nu) + u_q *(ecc + cos(nu))  + u_w * 0.) * sqrt(k / p)).T
 
     return r, v
 

--- a/src/poliastro/core/elements.py
+++ b/src/poliastro/core/elements.py
@@ -2,7 +2,6 @@
     to convert between different elements that define the orbit
     of a body.
     """
-import numba
 import numpy as np
 from numpy import cross
 from numpy.core.umath import cos, sin, sqrt
@@ -99,6 +98,7 @@ def coe_rotation_matrix(inc, raan, argp):
     r = r @ rotation_matrix(argp, 2)
     return r
 
+
 @jit
 def pqw2ijk_vectors(inc, raan, argp):
     r"""
@@ -133,17 +133,22 @@ def pqw2ijk_vectors(inc, raan, argp):
     u_j = np.array([[0, 1, 0]]).T
     u_k = np.array([[0, 0, 1]]).T
 
-    p_ijk = (u_i * (cos(raan)*cos(argp) - sin(raan)*sin(argp)*cos(inc))
-             + u_j * (sin(raan)*cos(argp) + cos(raan)*sin(argp)*cos(inc))
-             + u_k * sin(argp)*sin(inc)).T
-    q_ijk = (u_i * (-cos(raan) * sin(argp) - sin(raan) * cos(argp) * cos(inc))
-             + u_j * (-sin(raan) * sin(argp) + cos(raan) * cos(argp) * cos(inc))
-             + u_k * cos(argp) * sin(inc)).T
-    w_ijk = (u_i * sin(raan) * sin(inc)
-             + u_j * -cos(raan) * sin(inc)
-             + u_k * cos(inc)).T
+    p_ijk = (
+        u_i * (cos(raan) * cos(argp) - sin(raan) * sin(argp) * cos(inc))
+        + u_j * (sin(raan) * cos(argp) + cos(raan) * sin(argp) * cos(inc))
+        + u_k * sin(argp) * sin(inc)
+    ).T
+    q_ijk = (
+        u_i * (-cos(raan) * sin(argp) - sin(raan) * cos(argp) * cos(inc))
+        + u_j * (-sin(raan) * sin(argp) + cos(raan) * cos(argp) * cos(inc))
+        + u_k * cos(argp) * sin(inc)
+    ).T
+    w_ijk = (
+        u_i * sin(raan) * sin(inc) + u_j * -cos(raan) * sin(inc) + u_k * cos(inc)
+    ).T
 
     return p_ijk, q_ijk, w_ijk
+
 
 @jit
 def coe2rv(k, p, ecc, inc, raan, argp, nu):
@@ -213,19 +218,19 @@ def coe2rv(k, p, ecc, inc, raan, argp, nu):
     >>> argp = np.deg2rad(5) # Argument of perigee (rad)
     >>> r, v = coe2rv(k, p, ecc, inc, raan, argp, nu)
     >>> # Printing the results
-    r = [[-5312706.25105345  9201877.15251336    0]] [m]
-    v = [[-5753.30180931 -1328.66813933  0]] [m]/[s]
+    r = [[-7479732.8022355   4367456.2250807   6154536.06448901]] [m]
+    v = [[-5090.25400955 -2699.95544546 -1290.50201252]] [m]/[s]
 
     Also works on vector inputs:
     >>> r, v = coe2rv(np.full(4,k), np.full(4,p), np.full(4,ecc), np.full(4,inc), np.full(4,raan), np.full(4,argp), np.full(4,nu))
-    r = [[-5312706.25105345  9201877.15251336    0]
-         [-5312706.25105345  9201877.15251336    0]
-         [-5312706.25105345  9201877.15251336    0]
-         [-5312706.25105345  9201877.15251336    0]] [m]
-    v = [[-5753.30180931 -1328.66813933  0]
-         [-5753.30180931 -1328.66813933  0]
-         [-5753.30180931 -1328.66813933  0]
-         [-5753.30180931 -1328.66813933  0]] [m]/[s]
+    r = [[-7479732.8022355   4367456.2250807   6154536.06448901]
+         [-7479732.8022355   4367456.2250807   6154536.06448901]
+         [-7479732.8022355   4367456.2250807   6154536.06448901]
+         [-7479732.8022355   4367456.2250807   6154536.06448901]] [m]
+    v = [[-5090.25400955 -2699.95544546 -1290.50201252]
+         [-5090.25400955 -2699.95544546 -1290.50201252]
+         [-5090.25400955 -2699.95544546 -1290.50201252]
+         [-5090.25400955 -2699.95544546 -1290.50201252]] [m]/[s]
 
     """
 
@@ -234,12 +239,16 @@ def coe2rv(k, p, ecc, inc, raan, argp, nu):
 
     r_ijk = r_pqw[:, 0] * p_ijk.T
     r_ijk = r_ijk + r_pqw[:, 1] * q_ijk.T
-    r_ijk = r_ijk + r_pqw[:, 2] * w_ijk.T    # This line does nothing because w is always 0 in the perifocal frame
+    r_ijk = (
+        r_ijk + r_pqw[:, 2] * w_ijk.T
+    )  # This line does nothing because w is always 0 in the perifocal frame
     r_ijk = r_ijk.T
 
     v_ijk = v_pqw[:, 0] * p_ijk.T
     v_ijk = v_ijk + v_pqw[:, 1] * q_ijk.T
-    v_ijk = v_ijk + v_pqw[:, 2] * w_ijk.T   # This line does nothing because w is always 0 in the perifocal frame
+    v_ijk = (
+        v_ijk + v_pqw[:, 2] * w_ijk.T
+    )  # This line does nothing because w is always 0 in the perifocal frame
     v_ijk = v_ijk.T
 
     return r_ijk, v_ijk

--- a/src/poliastro/core/propagation/__init__.py
+++ b/src/poliastro/core/propagation/__init__.py
@@ -324,9 +324,7 @@ def markley_coe(k, p, ecc, inc, raan, argp, nu, tof):
     M = M0 + n * tof
 
     # Range between -pi and pi
-    M = M % (2 * np.pi)
-    if M > np.pi:
-        M = -(2 * np.pi - M)
+    M = (M + np.pi) % (2 * np.pi) - np.pi
 
     # Equation (20)
     alpha = (3 * np.pi ** 2 + 1.6 * (np.pi - np.abs(M)) / (1 + ecc)) / (np.pi ** 2 - 6)

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -1417,9 +1417,20 @@ class Orbit:
         else:
             nu_values = self._sample_open(values, min_anomaly, max_anomaly)
 
+        # Convert coe's to cartesian
         rr, vv = coe2rv(
-            self.k, self.p, self.ecc, self.inc, self.raan, self.argp, nu_values
+            self.attractor.k.to(u.m ** 3 / u.s ** 2).value,
+            self.p.to(u.m).value,
+            self.ecc.value,
+            self.inc.to(u.rad).value,
+            self.raan.to(u.rad).value,
+            self.argp.to(u.rad).value,
+            nu_values.to(u.rad).value
         )
+
+        # Add units
+        rr = rr * u.m
+        vv = vv * u.m / u.s
 
         cartesian = CartesianRepresentation(
             rr, differentials=CartesianDifferential(vv, xyz_axis=1), xyz_axis=1

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -1425,7 +1425,7 @@ class Orbit:
             self.inc.to(u.rad).value,
             self.raan.to(u.rad).value,
             self.argp.to(u.rad).value,
-            nu_values.to(u.rad).value
+            nu_values.to(u.rad).value,
         )
 
         # Add units

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -300,11 +300,8 @@ def markley(k, r, v, tofs, rtol=None):
     v0 = v.to(u.m / u.s).value
     tofs = tofs.to(u.s).value
 
-    results = [markley_fast(k, r0, v0, tof) for tof in tofs]
-    return (
-        [result[0] for result in results] * u.m,
-        [result[1] for result in results] * u.m / u.s,
-    )
+    rr, vv = markley_fast(k, r0, v0, tofs)
+    return (rr * u.m, vv * u.m / u.s)
 
 
 def pimienta(k, r, v, tofs, rtol=None):
@@ -481,6 +478,9 @@ def propagate(orbit, time_of_flight, *, method=farnocchia, rtol=1e-10, **kwargs)
         rtol=rtol,
         **kwargs
     )
+
+    rr = rr.reshape(-1, 3)
+    vv = vv.reshape(-1, 3)
 
     # TODO: Turn these into unit tests
     assert rr.ndim == 2

--- a/src/poliastro/twobody/states.py
+++ b/src/poliastro/twobody/states.py
@@ -131,6 +131,10 @@ class ClassicalState(BaseState):
             self.nu.to(u.rad).value,
         )
 
+        # squeeze to 1d arrays
+        r = r[0, :]
+        v = v[0, :]
+
         return RVState(self.attractor, r * u.km, v * u.km / u.s, self.plane)
 
     def to_classical(self):


### PR DESCRIPTION
This PR contains a couple of things:
- the vectorized version of the markley propagator (as in #1044)
- removal in the for loops in `propagation.markley(...)`
- vectorized versions of `elements.rv_pqw(...)` and `elements.coe2rv(...)` 
- removed unnecessary (I think) conversions in `Orbit.sample(...)` and use vectorized computation
- some catches in other functions as `elements.coe2rv(...)` now always returns a 2d array (caveat)