### PR TITLE
Fix deprecation warning from Astropy in Ephem

### DIFF
--- a/src/poliastro/ephem.py
+++ b/src/poliastro/ephem.py
@@ -140,7 +140,7 @@ def _get_destination_frame(attractor, plane, epochs):
     if attractor is not None:
         destination_frame = get_frame(attractor, plane, epochs)
     elif plane is Planes.EARTH_ECLIPTIC:
-        destination_frame = BarycentricMeanEcliptic
+        destination_frame = BarycentricMeanEcliptic()
     else:
         destination_frame = None
 


### PR DESCRIPTION
When the attractor for the Earth ecliptic frame is not specified,
Astropy 4.2 gives a deprecation warning about replacing a frame instance
with a frame class. This change instantiates the class before returning
it, similar to the get_frame function.

The full deprecation warning is:

> WARNING: AstropyDeprecationWarning: Transforming a frame instance to a frame class (as opposed to another frame instance) will not be supported in the future.  Either explicitly instantiate the target frame, or first convert the source frame instance to a `astropy.coordinates.SkyCoord` and use its `transform_to()` method. [astropy.coordinates.baseframe]
