### PR TITLE
Parallelized coe2rv_many

### DIFF
--- a/src/poliastro/core/_jit.py
+++ b/src/poliastro/core/_jit.py
@@ -24,6 +24,7 @@ try:
     import numba
 
     jit = numba.njit
+    prange = numba.prange
 except ImportError:
     warnings.warn(
         "Could not import numba package. All poliastro "
@@ -32,3 +33,4 @@ except ImportError:
         "boost performance."
     )
     jit = ijit
+    prange = range

--- a/src/poliastro/core/elements.py
+++ b/src/poliastro/core/elements.py
@@ -4,6 +4,7 @@
     """
 
 import numpy as np
+from numba import prange
 from numpy import cross
 from numpy.core.umath import cos, sin, sqrt
 from numpy.linalg import norm
@@ -432,3 +433,16 @@ def mee2coe(p, f, g, h, k, L):
     argp = (lonper - raan) % (2 * np.pi)
     nu = (L - lonper) % (2 * np.pi)
     return p, ecc, inc, raan, argp, nu
+
+
+@jit(parallel=True)
+def coe2rv_many(k, p, ecc, inc, raan, argp, nu):
+
+    n = nu.shape[0]
+    rr = np.zeros((n, 3))
+    vv = np.zeros((n, 3))
+
+    for i in prange(n):
+        rr[i, :], vv[i, :] = coe2rv(k[i], p[i], ecc[i], inc[i], raan[i], argp[i], nu[i])
+
+    return rr, vv

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -21,6 +21,7 @@ from poliastro.frames.util import get_frame
 from poliastro.threebody.soi import laplace_radius
 from poliastro.twobody.propagation import farnocchia, propagate
 
+from ..core.elements import coe2rv_many
 from ..core.propagation.farnocchia import delta_t_from_nu as delta_t_from_nu_fast
 from ..util import find_closest_value, norm
 from ..warnings import OrbitSamplingWarning, PatchedConicsWarning, TimeScaleWarning
@@ -1416,16 +1417,24 @@ class Orbit:
         else:
             nu_values = self._sample_open(values, min_anomaly, max_anomaly)
 
-        # FIXME: Refactor this insanity to remove a lot of back and forth
-        # 1. Convert to classical to extract nu values (either 1 or 3 are no ops)
-        # 2. Sample values of nu -> M -> times
-        # 3. Convert to cartesian to call the farnocchia propagator harcoded here (either 1 or 3 are no ops)
-        # 4. For each time, convert to classical to retain "slow" elements
-        # 5. For each time, compute nu0 -> M0 (same value always)
-        # 6. For each time, t -> M -> nu
-        # 7. For each time, convert classical to cartesian and assemble orbit
-        time_values = time.TimeDelta(self._generate_time_values(nu_values))
-        cartesian = propagate(self, time_values)
+        n = nu_values.shape[0]
+        rr, vv = coe2rv_many(
+            np.full(n, self.attractor.k.to(u.m ** 3 / u.s ** 2).value),
+            np.full(n, self.p.to(u.m).value),
+            np.full(n, self.ecc.value),
+            np.full(n, self.inc.to(u.rad).value),
+            np.full(n, self.raan.to(u.rad).value),
+            np.full(n, self.argp.to(u.rad).value),
+            nu_values.to(u.rad).value,
+        )
+
+        # Add units
+        rr = rr * u.m
+        vv = vv * u.m / u.s
+
+        cartesian = CartesianRepresentation(
+            rr, differentials=CartesianDifferential(vv, xyz_axis=1), xyz_axis=1
+        )
 
         return cartesian
 

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -1429,8 +1429,8 @@ class Orbit:
         )
 
         # Add units
-        rr = rr * u.m
-        vv = vv * u.m / u.s
+        rr = (rr << u.m).to(u.km)
+        vv = (vv << (u.m / u.s)).to(u.km / u.s)
 
         cartesian = CartesianRepresentation(
             rr, differentials=CartesianDifferential(vv, xyz_axis=1), xyz_axis=1


### PR DESCRIPTION
As discussed in #1046 here is the slick and clean implementation of a parallelized coev2rv_many.

`orbit.sample(...)` uses the new parallelized implemenation.