### PR TITLE
Action for triggering validation repository

### DIFF
--- a/.github/workflows/validation_trigger.yml
+++ b/.github/workflows/validation_trigger.yml
@@ -1,0 +1,26 @@
+# This workflow triggers poliastro/validation CI from poliastro/poliastro
+# everytime a new commit is introduced in poliastro:master branch
+name: Validation test cases
+
+on:
+  # A collection of events which trigger the validation action
+  push:
+    branches: [master]
+  release:
+
+jobs:
+  
+  # Validate poliastro's new features
+  validation:
+    runs-on: ubuntu-latest
+
+    # Steps to be followed during validation job
+    steps:
+      - name: Trigger poliastro/validation
+        run: |
+          curl -X POST https://api.github.com/repos/poliastro/validation/dispatches \
+          -H 'Accept: application/vnd.github.everest-preview+json' \
+          -u ${{ secrets.ACCESS_TOKEN }} \
+          --data '{"event_type": "ping-validation", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'" }}'
+
+


### PR DESCRIPTION
This is related with https://github.com/poliastro/validation/issues/5. It adds a github actions file for triggering the [validation repository](https://github.com/poliastro/validation/) every time a new merge in main branch is done or a release is published.