### PR TITLE
Add Github actions for triggering validation repo

### DIFF
--- a/.github/workflows/validation_trigger.yml
+++ b/.github/workflows/validation_trigger.yml
@@ -1,0 +1,30 @@
+# This workflow triggers poliastro/validation CI from poliastro/poliastro
+# everytime a new commit is introduced in poliastro:master branch
+name: Validation test cases
+
+on:
+  # A collection of events which trigger the validation action
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  release:
+
+  # Enable manually to execute the actions
+  workflow_dispatch:
+
+jobs:
+  
+  # Validate poliastro's new features
+  validation:
+    runs-on: ubuntu-latest
+    environment: validation-env
+
+    # Steps to be followed during validation job
+    steps:
+      - name: Trigger poliastro/validation
+        run: |
+          curl -XPOST -u "${{ secrets.PAT_VALIDATION}}:${{secrets.PAT_VALIDATION_TOKEN}}" \
+          -H "Accept: application/vnd.github.everest-preview+json" \
+          -H "Content-Type: application/json" https://api.github.com/repos/poliastro/validation/actions/workflows/build.yaml/dispatches \
+          --data '{"ref": "master"}'

--- a/.github/workflows/validation_trigger.yml
+++ b/.github/workflows/validation_trigger.yml
@@ -26,5 +26,5 @@ jobs:
         run: |
           curl -XPOST -u "${{ secrets.PAT_VALIDATION}}:${{secrets.PAT_VALIDATION_TOKEN}}" \
           -H "Accept: application/vnd.github.everest-preview+json" \
-          -H "Content-Type: application/json" https://api.github.com/repos/poliastro/validation/actions/workflows/build.yaml/dispatches \
+          -H "Content-Type: application/json" https://api.github.com/repos/poliastro/validation/actions/workflows/ci_actions.yml/dispatches \
           --data '{"ref": "master"}'


### PR DESCRIPTION
This is related with https://github.com/poliastro/validation/issues/5. It adds a GitHub actions file for triggering the [validation repository](https://github.com/poliastro/validation/) every time a new merge in main branch is done or a release is published.