### PR TITLE
Allow propagation to use classical orbital elements

### DIFF
--- a/src/poliastro/core/propagation/__init__.py
+++ b/src/poliastro/core/propagation/__init__.py
@@ -271,7 +271,7 @@ def mikkola_coe(k, p, ecc, inc, raan, argp, nu, tof):
             # Hyperbolic
             nu = F_to_nu(E, ecc)
 
-    return nu
+    return coe2rv(k, p, ecc, inc, raan, argp, nu)
 
 
 @jit
@@ -304,9 +304,9 @@ def mikkola(k, r0, v0, tof, rtol=None):
 
     # Solving for the classical elements
     p, ecc, inc, raan, argp, nu = rv2coe(k, r0, v0)
-    nu = mikkola_coe(k, p, ecc, inc, raan, argp, nu, tof)
+    coe2rv_ = mikkola_coe(k, p, ecc, inc, raan, argp, nu, tof)
 
-    return coe2rv(k, p, ecc, inc, raan, argp, nu)
+    return coe2rv_
 
 
 @jit
@@ -355,7 +355,7 @@ def markley_coe(k, p, ecc, inc, raan, argp, nu, tof):
     E += delta5
     nu = E_to_nu(E, ecc)
 
-    return nu
+    return coe2rv(k, p, ecc, inc, raan, argp, nu)
 
 
 @jit
@@ -388,9 +388,9 @@ def markley(k, r0, v0, tof):
     """
     # Solve first for eccentricity and mean anomaly
     p, ecc, inc, raan, argp, nu = rv2coe(k, r0, v0)
-    nu = markley_coe(k, p, ecc, inc, raan, argp, nu, tof)
+    coe2rv_ = markley_coe(k, p, ecc, inc, raan, argp, nu, tof)
 
-    return coe2rv(k, p, ecc, inc, raan, argp, nu)
+    return coe2rv_
 
 
 @jit
@@ -722,7 +722,8 @@ def pimienta_coe(k, p, ecc, inc, raan, argp, nu, tof):
         + 15 * w
     )
 
-    return E_to_nu(E, ecc)
+    nu = E_to_nu(E, ecc)
+    return coe2rv(k, p, ecc, inc, raan, argp, nu)
 
 
 @jit
@@ -757,9 +758,9 @@ def pimienta(k, r0, v0, tof):
 
     # Solve first for eccentricity and mean anomaly
     p, ecc, inc, raan, argp, nu = rv2coe(k, r0, v0)
-    nu = pimienta_coe(k, p, ecc, inc, raan, argp, nu, tof)
+    coe2rv_ = pimienta_coe(k, p, ecc, inc, raan, argp, nu, tof)
 
-    return coe2rv(k, p, ecc, inc, raan, argp, nu)
+    return coe2rv_
 
 
 @jit
@@ -791,7 +792,9 @@ def gooding_coe(k, p, ecc, inc, raan, argp, nu, tof, numiter=150, rtol=1e-8):
         n += 1
 
     E = M + psi
-    return E_to_nu(E, ecc)
+
+    nu = E_to_nu(E, ecc)
+    return coe2rv(k, p, ecc, inc, raan, argp, nu)
 
 
 @jit
@@ -826,9 +829,9 @@ def gooding(k, r0, v0, tof, numiter=150, rtol=1e-8):
 
     # Solve first for eccentricity and mean anomaly
     p, ecc, inc, raan, argp, nu = rv2coe(k, r0, v0)
-    nu = gooding_coe(k, p, ecc, inc, raan, argp, nu, tof, numiter, rtol)
+    coe2rv_ = gooding_coe(k, p, ecc, inc, raan, argp, nu, tof, numiter, rtol)
 
-    return coe2rv(k, p, ecc, inc, raan, argp, nu)
+    return coe2rv_
 
 
 @jit
@@ -842,7 +845,7 @@ def danby_coe(k, p, ecc, inc, raan, argp, nu, tof, numiter=20, rtol=1e-8):
         M0 = E_to_M(nu_to_E(nu, ecc), ecc)
         M = M0 + n * tof
         nu = M - 2 * np.pi * np.floor(M / 2 / np.pi)
-        return nu
+        return coe2rv(k, p, ecc, inc, raan, argp, nu)
 
     elif ecc < 1.0:
         # For elliptical orbit
@@ -897,7 +900,7 @@ def danby_coe(k, p, ecc, inc, raan, argp, nu, tof, numiter=20, rtol=1e-8):
     else:
         raise ValueError("Maximum number of iterations has been reached.")
 
-    return nu
+    return coe2rv(k, p, ecc, inc, raan, argp, nu)
 
 
 @jit
@@ -932,6 +935,6 @@ def danby(k, r0, v0, tof, numiter=20, rtol=1e-8):
 
     # Solve first for eccentricity and mean anomaly
     p, ecc, inc, raan, argp, nu = rv2coe(k, r0, v0)
-    nu = danby_coe(k, p, ecc, inc, raan, argp, nu, tof, numiter, rtol)
+    coe2rv_ = danby_coe(k, p, ecc, inc, raan, argp, nu, tof, numiter, rtol)
 
-    return coe2rv(k, p, ecc, inc, raan, argp, nu)
+    return coe2rv_

--- a/src/poliastro/core/propagation/farnocchia.py
+++ b/src/poliastro/core/propagation/farnocchia.py
@@ -291,7 +291,8 @@ def farnocchia_coe(k, p, ecc, inc, raan, argp, nu, tof):
     delta_t0 = delta_t_from_nu(nu, ecc, k, q)
     delta_t = delta_t0 + tof
 
-    return nu_from_delta_t(delta_t, ecc, k, q)
+    nu = nu_from_delta_t(delta_t, ecc, k, q)
+    return coe2rv(k, p, ecc, inc, raan, argp, nu)
 
 
 @jit
@@ -328,6 +329,6 @@ def farnocchia(k, r0, v0, tof):
 
     # get the initial true anomaly and orbit parameters that are constant over time
     p, ecc, inc, raan, argp, nu0 = rv2coe(k, r0, v0)
-    nu = farnocchia_coe(k, p, ecc, inc, raan, argp, nu0, tof)
+    coe2rv_ = farnocchia_coe(k, p, ecc, inc, raan, argp, nu0, tof)
 
-    return coe2rv(k, p, ecc, inc, raan, argp, nu)
+    return coe2rv_

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -29,12 +29,18 @@ from scipy.integrate import DOP853, solve_ivp
 
 from poliastro.core.propagation import (
     danby as danby_fast,
+    danby_coe as danby_coe_fast,
     farnocchia as farnocchia_fast,
+    farnocchia_coe as farnocchia_coe_fast,
     func_twobody,
     gooding as gooding_fast,
+    gooding_coe as gooding_coe_fast,
     markley as markley_fast,
+    markley_coe as markley_coe_fast,
     mikkola as mikkola_fast,
+    mikkola_coe as mikkola_coe_fast,
     pimienta as pimienta_fast,
+    pimienta_coe as pimienta_coe_fast,
     vallado as vallado_fast,
 )
 
@@ -153,6 +159,52 @@ def farnocchia(k, r, v, tofs, **kwargs):
     )
 
 
+def farnocchia_classical(k, p, ecc, inc, raan, argp, nu, tofs, **kwargs):
+    """Propagates orbit.
+
+    Parameters
+    ----------
+    k : ~astropy.units.Quantity
+            Standard gravitational parameter of the attractor.
+    p: float
+        Semi-latus rectum of parameter (km)
+    ecc: float
+        Eccentricity
+    inc:
+        Inclination (rad)
+    raan: float
+        Right ascension of the ascending node (rad)
+    argp: float
+        Argument of Perigee (rad)
+    nu: float
+        True anomaly
+    tofs: float
+        Time of flight (s).
+
+    Returns
+    -------
+    rr : ~astropy.units.Quantity
+        Propagated position vectors.
+    vv : ~astropy.units.Quantity
+        Propagated velocity vectors.
+
+    """
+    p = p.to(u.km).value
+    inc = inc.to(u.rad).value
+    raan = raan.to(u.rad).value
+    argp = argp.to(u.rad).value
+    nu = nu.to(u.rad).value
+    ecc = ecc.value
+    k = k.to(u.km ** 3 / u.s ** 2).value
+    tofs = tofs.to(u.s).value
+    results = [farnocchia_coe_fast(k, p, ecc, inc, raan, argp, nu, tof) for tof in tofs]
+
+    return (
+        [result[0] for result in results] * u.km,
+        [result[1] for result in results] * u.km / u.s,
+    )
+
+
 def vallado(k, r, v, tofs, numiter=350, **kwargs):
     """Propagates Keplerian orbit.
 
@@ -256,6 +308,57 @@ def mikkola(k, r, v, tofs, rtol=None):
     )
 
 
+def mikkola_classical(k, p, ecc, inc, raan, argp, nu, tofs, rtol=None):
+    """Solves Kepler Equation by a cubic approximation. This method is valid
+    no mater the orbit's nature.
+
+    Parameters
+    ----------
+    k : ~astropy.units.Quantity
+        Standard gravitational parameter of the attractor.
+    p: float
+        Semi-latus rectum of parameter (km)
+    ecc: float
+        Eccentricity
+    inc:
+        Inclination (rad)
+    raan: float
+        Right ascension of the ascending node (rad)
+    argp: float
+        Argument of Perigee (rad)
+    nu: float
+        True anomaly
+    tofs: float
+        Time of flight (s).
+
+    Returns
+    -------
+    rr : ~astropy.units.Quantity
+        Propagated position vectors.
+    vv : ~astropy.units.Quantity
+
+    Note
+    ----
+    This method was derived by Seppo Mikola in his paper *A Cubic Approximation
+    For Kepler's Equation* with DOI: https://doi.org/10.1007/BF01235850
+    """
+
+    p = p.to(u.m).value
+    inc = inc.to(u.rad).value
+    raan = raan.to(u.rad).value
+    argp = argp.to(u.rad).value
+    nu = nu.to(u.rad).value
+    ecc = ecc.value
+    k = k.to(u.m ** 3 / u.s ** 2).value
+    tofs = tofs.to(u.s).value
+    results = [mikkola_coe_fast(k, p, ecc, inc, raan, argp, nu, tof) for tof in tofs]
+
+    return (
+        [result[0] for result in results] * u.m,
+        [result[1] for result in results] * u.m / u.s,
+    )
+
+
 def markley(k, r, v, tofs, rtol=None):
     """Elliptical Kepler Equation solver based on a fifth-order
     refinement of the solution of a cubic equation.
@@ -290,8 +393,60 @@ def markley(k, r, v, tofs, rtol=None):
     r0 = r.to(u.m).value
     v0 = v.to(u.m / u.s).value
     tofs = tofs.to(u.s).value
-
     results = [markley_fast(k, r0, v0, tof) for tof in tofs]
+
+    return (
+        [result[0] for result in results] * u.m,
+        [result[1] for result in results] * u.m / u.s,
+    )
+
+
+def markley_classical(k, p, ecc, inc, raan, argp, nu, tofs, rtol=None):
+    """Elliptical Kepler Equation solver based on a fifth-order
+    refinement of the solution of a cubic equation.
+
+    Parameters
+    ----------
+    k : ~astropy.units.Quantity
+        Standard gravitational parameter of the attractor.
+    p: float
+        Semi-latus rectum of parameter (km)
+    ecc: float
+        Eccentricity
+    inc:
+        Inclination (rad)
+    raan: float
+        Right ascension of the ascending node (rad)
+    argp: float
+        Argument of Perigee (rad)
+    nu: float
+        True anomaly
+    tofs: float
+        Time of flight (s).
+
+    Returns
+    -------
+    rr : ~astropy.units.Quantity
+        Propagated position vectors.
+    vv : ~astropy.units.Quantity
+        Propagated velocity vectors.
+
+    Note
+    ----
+    This method was originally presented by Markley in his paper *Kepler Equation Solver*
+    with DOI: https://doi.org/10.1007/BF00691917
+    """
+
+    p = p.to(u.m).value
+    inc = inc.to(u.rad).value
+    raan = raan.to(u.rad).value
+    argp = argp.to(u.rad).value
+    nu = nu.to(u.rad).value
+    ecc = ecc.value
+    k = k.to(u.m ** 3 / u.s ** 2).value
+    tofs = tofs.to(u.s).value
+    results = [markley_coe_fast(k, p, ecc, inc, raan, argp, nu, tof) for tof in tofs]
+
     return (
         [result[0] for result in results] * u.m,
         [result[1] for result in results] * u.m / u.s,
@@ -342,6 +497,60 @@ def pimienta(k, r, v, tofs, rtol=None):
     )
 
 
+def pimienta_classical(k, p, ecc, inc, raan, argp, nu, tofs, rtol=None):
+    """Kepler solver for both elliptic and parabolic orbits based on a 15th
+    order polynomial with accuracies around 10e-5 for elliptic case and 10e-13
+    in the hyperbolic regime.
+
+    Parameters
+    ----------
+    k : ~astropy.units.Quantity
+        Standard gravitational parameter of the attractor.
+    p: float
+        Semi-latus rectum of parameter (km)
+    ecc: float
+        Eccentricity
+    inc:
+        Inclination (rad)
+    raan: float
+        Right ascension of the ascending node (rad)
+    argp: float
+        Argument of Perigee (rad)
+    nu: float
+        True anomaly
+    tofs: float
+        Time of flight (s).
+
+    Returns
+    -------
+    rr : ~astropy.units.Quantity
+        Propagated position vectors.
+    vv : ~astropy.units.Quantity
+        Propagated velocity vectors.
+
+    Note
+    ----
+    This algorithm was developed by Pimienta-Peñalver and John L. Crassidis in
+    their paper *Accurate Kepler Equation solver without trascendental function
+    evaluations*. Original paper is on Buffalo's UBIR repository: http://hdl.handle.net/10477/50522
+    """
+
+    p = p.to(u.m).value
+    inc = inc.to(u.rad).value
+    raan = raan.to(u.rad).value
+    argp = argp.to(u.rad).value
+    nu = nu.to(u.rad).value
+    ecc = ecc.value
+    k = k.to(u.m ** 3 / u.s ** 2).value
+    tofs = tofs.to(u.s).value
+    results = [pimienta_coe_fast(k, p, ecc, inc, raan, argp, nu, tof) for tof in tofs]
+
+    return (
+        [result[0] for result in results] * u.m,
+        [result[1] for result in results] * u.m / u.s,
+    )
+
+
 def gooding(k, r, v, tofs, numiter=150, rtol=1e-8):
     """Solves the Elliptic Kepler Equation with a cubic convergence and
     accuracy better than 10e-12 rad is normally achieved. It is not valid for
@@ -379,6 +588,61 @@ def gooding(k, r, v, tofs, numiter=150, rtol=1e-8):
     tofs = tofs.to(u.s).value
 
     results = [gooding_fast(k, r0, v0, tof, numiter=numiter, rtol=rtol) for tof in tofs]
+    return (
+        [result[0] for result in results] * u.m,
+        [result[1] for result in results] * u.m / u.s,
+    )
+
+
+def gooding_classical(k, p, ecc, inc, raan, argp, nu, tofs, numiter=150, rtol=1e-8):
+    """Solves the Elliptic Kepler Equation with a cubic convergence and
+    accuracy better than 10e-12 rad is normally achieved. It is not valid for
+    eccentricities equal or greater than 1.0.
+
+    Parameters
+    ----------
+    k : ~astropy.units.Quantity
+        Standard gravitational parameter of the attractor.
+    p: float
+        Semi-latus rectum of parameter (km)
+    ecc: float
+        Eccentricity
+    inc:
+        Inclination (rad)
+    raan: float
+        Right ascension of the ascending node (rad)
+    argp: float
+        Argument of Perigee (rad)
+    nu: float
+        True anomaly
+    tofs: float
+        Time of flight (s).
+    Returns
+    -------
+    rr : ~astropy.units.Quantity
+        Propagated position vectors.
+    vv : ~astropy.units.Quantity
+
+    Note
+    ----
+    This method was developed by Gooding and Odell in their paper *The
+    hyperbolic Kepler equation (and the elliptic equation revisited)* with
+    DOI: https://doi.org/10.1007/BF01235540
+    """
+
+    p = p.to(u.m).value
+    inc = inc.to(u.rad).value
+    raan = raan.to(u.rad).value
+    argp = argp.to(u.rad).value
+    nu = nu.to(u.rad).value
+    ecc = ecc.value
+    k = k.to(u.m ** 3 / u.s ** 2).value
+    tofs = tofs.to(u.s).value
+    results = [
+        gooding_coe_fast(k, p, ecc, inc, raan, argp, nu, tof, numiter, rtol)
+        for tof in tofs
+    ]
+
     return (
         [result[0] for result in results] * u.m,
         [result[1] for result in results] * u.m / u.s,
@@ -427,6 +691,61 @@ def danby(k, r, v, tofs, rtol=1e-8):
     )
 
 
+def danby_classical(k, p, ecc, inc, raan, argp, nu, tofs, numiter=20, rtol=1e-8):
+    """Kepler solver for both elliptic and parabolic orbits based on Danby's
+    algorithm.
+
+    Parameters
+    ----------
+    k: float
+        Standard Gravitational parameter.
+    p: float
+        Semi-latus rectum of parameter (km)
+    ecc: float
+        Eccentricity
+    inc:
+        Inclination (rad)
+    raan: float
+        Right ascension of the ascending node (rad)
+    argp: float
+        Argument of Perigee (rad)
+    nu: float
+        True anomaly
+    tofs: float
+        Time of flight (s).
+
+    Returns
+    -------
+    rr : ~astropy.units.Quantity
+        Propagated position vectors.
+    vv : ~astropy.units.Quantity
+        Propagated velocity vectors.
+
+    Note
+    ----
+    This algorithm was developed by Danby in his paper *The solution of Kepler
+    Equation* with DOI: https://doi.org/10.1007/BF01686811
+    """
+
+    k = k.to(u.m ** 3 / u.s ** 2).value
+    p = p.to(u.m).value
+    inc = inc.to(u.rad).value
+    raan = raan.to(u.rad).value
+    argp = argp.to(u.rad).value
+    nu = nu.to(u.rad).value
+    ecc = ecc.value
+    tofs = tofs.to(u.s).value
+    results = [
+        danby_coe_fast(k, p, ecc, inc, raan, argp, nu, tof, numiter, rtol)
+        for tof in tofs
+    ]
+
+    return (
+        [result[0] for result in results] * u.m,
+        [result[1] for result in results] * u.m / u.s,
+    )
+
+
 def propagate(orbit, time_of_flight, *, method=farnocchia, rtol=1e-10, **kwargs):
     """Propagate an orbit some time and return the result.
 
@@ -464,14 +783,29 @@ def propagate(orbit, time_of_flight, *, method=farnocchia, rtol=1e-10, **kwargs)
     else:
         pass
 
-    rr, vv = method(
-        orbit.attractor.k,
-        orbit.r,
-        orbit.v,
-        time_of_flight.reshape(-1).to(u.s),
-        rtol=rtol,
-        **kwargs
-    )
+    if method.__name__.endswith("_classical"):
+        _, ecc, inc, raan, argp, nu = orbit.classical()
+        rr, vv = method(
+            orbit.attractor.k,
+            orbit.p,
+            ecc,
+            inc,
+            raan,
+            argp,
+            nu,
+            time_of_flight.reshape(-1).to(u.s),
+            rtol=rtol,
+            **kwargs,
+        )
+    else:
+        rr, vv = method(
+            orbit.attractor.k,
+            orbit.r,
+            orbit.v,
+            time_of_flight.reshape(-1).to(u.s),
+            rtol=rtol,
+            **kwargs,
+        )
 
     # TODO: Turn these into unit tests
     assert rr.ndim == 2
@@ -486,12 +820,18 @@ def propagate(orbit, time_of_flight, *, method=farnocchia, rtol=1e-10, **kwargs)
 
 ELLIPTIC_PROPAGATORS = [
     farnocchia,
+    farnocchia_classical,
     vallado,
     mikkola,
+    mikkola_classical,
     markley,
+    markley_classical,
     pimienta,
+    pimienta_classical,
     gooding,
+    gooding_classical,
     danby,
+    danby_classical,
     cowell,
 ]
 PARABOLIC_PROPAGATORS = [farnocchia, vallado, mikkola, pimienta, gooding, cowell]

--- a/tests/tests_twobody/test_propagation.py
+++ b/tests/tests_twobody/test_propagation.py
@@ -29,11 +29,17 @@ from poliastro.twobody.propagation import (
     PARABOLIC_PROPAGATORS,
     cowell,
     danby,
+    danby_classical,
     farnocchia,
+    farnocchia_classical,
     gooding,
+    gooding_classical,
     markley,
+    markley_classical,
     mikkola,
+    mikkola_classical,
     pimienta,
+    pimienta_classical,
     vallado,
 )
 from poliastro.util import norm
@@ -72,7 +78,7 @@ def test_elliptic_near_parabolic(ecc, propagator):
 @pytest.mark.parametrize("propagator", HYPERBOLIC_PROPAGATORS)
 def test_hyperbolic_near_parabolic(ecc, propagator):
     # Still not implemented. Refer to issue #714.
-    if propagator in [pimienta, gooding]:
+    if propagator in [pimienta, gooding, gooding_classical]:
         pytest.skip()
 
     _a = 0.0 * u.rad
@@ -118,6 +124,34 @@ def test_propagation(propagator):
 
     assert_quantity_allclose(r, expected_r, rtol=1e-5)
     assert_quantity_allclose(v, expected_v, rtol=1e-4)
+
+
+def test_propagation_cartesian_and_classical_matches():
+    propagators = [farnocchia, mikkola, markley, pimienta, gooding, danby]
+    propagators_classical = [
+        farnocchia_classical,
+        mikkola_classical,
+        markley_classical,
+        pimienta_classical,
+        gooding_classical,
+        danby_classical,
+    ]
+    # Data from Vallado, example 2.4
+    r0 = [1131.340, -2282.343, 6672.423] * u.km
+    v0 = [-5.64305, 4.30333, 2.42879] * u.km / u.s
+
+    ss0 = Orbit.from_vectors(Earth, r0, v0)
+    tof = 40 * u.min
+
+    for propagator_pair in zip(propagators, propagators_classical):
+        ss1 = ss0.propagate(tof, method=propagator_pair[0])
+        ss2 = ss0.propagate(tof, method=propagator_pair[1])
+
+        r1, v1 = ss1.rv()
+        r2, v2 = ss2.rv()
+
+        assert_quantity_allclose(r1, r2, rtol=1e-2)
+        assert_quantity_allclose(v1, v2, rtol=1e-2)
 
 
 def test_propagating_to_certain_nu_is_correct():
@@ -195,7 +229,7 @@ def test_propagation_hyperbolic():
 def test_propagation_parabolic(propagator):
     # Example from Howard Curtis (3rd edition), section 3.5, problem 3.15
     # TODO: add parabolic solver in some parabolic propagators, refer to #417
-    if propagator in [mikkola, gooding]:
+    if propagator in [mikkola, gooding, gooding_classical]:
         pytest.skip()
 
     p = 2.0 * 6600 * u.km
@@ -444,6 +478,7 @@ def test_propagate_with_coe(propagator_coe):
     nu = nu.to_value(u.rad)
     k = iss.attractor.k.to_value(u.km ** 3 / u.s ** 2)
 
-    nu_final = propagator_coe(k, p, ecc, inc, raan, argp, nu, period)
+    r0, v0 = propagator_coe(k, p, ecc, inc, raan, argp, nu, period)
+    _, _, _, _, _, nu_final = rv2coe(k, r0, v0)
 
     assert_quantity_allclose(nu_final, nu)


### PR DESCRIPTION
In reference to #921, this implementation attempts to allow propagators to use classical orbital elements for propagation:

- Implemented on `farnocchia,mikkola,markley,pimienta,gooding,danby` propagators.
- `Orbit.propagate` has been given a keyword argument `classical` (default to `False`) which when set to `True` uses `classical` orbital elements for propagation.

In the test added, the position and velocity vectors returned in both cases (`classical=True` and `classical=False`) do not seem to be in agreement with each other currently. That would certainly need more investigation.

Thanks!!