### PR TITLE
Fixing Binder Links to point towards Main Branch 

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ be read on the wonderful [Read the Docs](https://readthedocs.org/).
 
 # Examples
 
-[![mybinder](https://img.shields.io/badge/launch-binder-e66581.svg?style=flat-square)](https://beta.mybinder.org/v2/gh/poliastro/poliastro/master?filepath=index.ipynb)
+[![mybinder](https://img.shields.io/badge/launch-binder-e66581.svg?style=flat-square)](https://beta.mybinder.org/v2/gh/poliastro/poliastro/main?filepath=index.ipynb)
 
 In the examples directory you can find several Jupyter notebooks with
 specific applications of poliastro. You can launch a cloud Jupyter
 server using [binder](https://beta.mybinder.org/) to edit the notebooks
 without installing anything. Try it out!
 
-<https://beta.mybinder.org/v2/gh/poliastro/poliastro/master?filepath=index.ipynb>
+<https://beta.mybinder.org/v2/gh/poliastro/poliastro/main?filepath=index.ipynb>
 
 # Requirements
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -93,7 +93,7 @@ GitHub, and all contributions and feedback are more than welcome. You
 can test poliastro in your browser using binder, a cloud Jupyter
 notebook server:
 
-[![image](https://img.shields.io/badge/launch-binder-e66581.svg?style=flat-square)](https://mybinder.org/v2/gh/poliastro/poliastro/master?filepath=index.ipynb)
+[![image](https://img.shields.io/badge/launch-binder-e66581.svg?style=flat-square)](https://mybinder.org/v2/gh/poliastro/poliastro/main?filepath=index.ipynb)
 
 See [benchmarks](https://benchmarks.poliastro.space/) for the
 performance analysis of poliastro.

--- a/index.ipynb
+++ b/index.ipynb
@@ -12,6 +12,8 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## [Comparing Hohmann and bielliptic transfers](docs/source/examples/Comparing%20Hohmann%20and%20bielliptic%20transfers.mystnb)\n",
     "\n",
@@ -29,11 +31,11 @@
     "\n",
     "[![mars](docs/source/examples/trans_30_260.png)](docs/source/examples/Going%20to%20Mars%20with%20Python%20using%20poliastro.mystnb)\n",
     "\n",
-    "## [Propagation using Cowell's formulation](docs/source/examples/Propagation%20using%20Cowell's%20formulation.mystnb)\n",
+    "## [Propagation using Cowell's formulation](docs/source/examples/Propagation%20using%20Cowells%20formulation.mystnb)\n",
     "\n",
     "[![cowell](docs/source/examples/cowell.png)](docs/source/examples/Propagation%20using%20Cowells%20formulation.mystnb)\n",
     "\n",
-    "## [Revisiting Lambert's problem in Python](docs/source/examples/Revisiting%20Lambert's%20problem%20in%20Python.mystnb)\n",
+    "## [Revisiting Lambert's problem in Python](docs/source/examples/Revisiting%20Lamberts%20problem%20in%20Python.mystnb)\n",
     "\n",
     "[![cowell](docs/source/examples/lambert.png)](docs/source/examples/Revisiting%20Lamberts%20problem%20in%20Python.mystnb)\n",
     "\n",
@@ -56,11 +58,11 @@
     "## [Visualizing the SpaceX Tesla Roadster trip to Mars](docs/source/examples/Visualizing%20the%20SpaceX%20Tesla%20Roadster%20trip%20to%20Mars.mystnb)\n",
     "\n",
     "[![3DPlot](docs/source/examples/Tesla.png)](docs/source/examples/Visualizing%20the%20SpaceX%20Tesla%20Roadster%20trip%20to%20Mars.mystnb)"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Old notebooks\n",
     "\n",
@@ -68,9 +70,7 @@
     "\n",
     "* https://github.com/poliastro/poliastro/blob/c361af5/examples/Solving%20Lambert's%20problem%20in%20Python.ipynb\n",
     "* https://github.com/poliastro/poliastro/blob/9e71402/examples/Quickly%20solving%20Kepler's%20Problem%20in%20Python%20using%20numba.ipynb"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   }
  ],
  "metadata": {
@@ -89,7 +89,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hello, 
This PR aims to fix the binder repository that currently points to the `master`, changing to updated `main`
Implements #1119 
Thanks :)