### PR TITLE
Reduce warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,10 @@ markers =
     remote_data
     filterwarnings
     mpl_image_compare
+filterwarnings =
+    # This Deprecation warning is not present in numba 0.53.0
+    # and should be removed when the dependency version is upgraded
+    ignore:`np\.long` is a deprecated alias for `np\.compat\.long`:DeprecationWarning
 
 [flake8]
 ignore = E203, E266, E501, W503

--- a/src/poliastro/czml/extract_czml.py
+++ b/src/poliastro/czml/extract_czml.py
@@ -77,7 +77,7 @@ class CZMLExtractor:
 
         if not self.attractor:
             self.attractor = Earth
-        elif not (self.attractor.R and self.attractor.R_polar):
+        elif self.attractor.R is None or self.attractor.R_polar is None:
             raise ValueError(
                 "Invalid ellipsoid of attractor.\n"
                 + "Make sure your body has valid 'R' and 'R_polar' parameters"

--- a/tests/test_czml.py
+++ b/tests/test_czml.py
@@ -70,7 +70,7 @@ def test_czml_custom_packet():
     )
 
     pckt = extractor.packets[-1]
-    # Test that custom packet parameters where set correctly
+    # Test that custom packet parameters were set correctly
     assert repr(pckt) == expected_packet
 
 

--- a/tests/tests_plotting/test_misc.py
+++ b/tests/tests_plotting/test_misc.py
@@ -5,11 +5,19 @@ from poliastro.plotting import OrbitPlotter2D, OrbitPlotter3D
 from poliastro.plotting.misc import plot_solar_system
 
 
+@pytest.mark.filterwarnings(
+    'ignore:ERFA function "epv00" yielded.*of "'
+    'warning. date outsidethe range 1900-2100 AD"'
+)
 @pytest.mark.parametrize("outer,expected", [(True, 8), (False, 4)])
 def test_plot_solar_system_has_expected_number_of_orbits(outer, expected):
     assert len(plot_solar_system(outer).trajectories) == expected
 
 
+@pytest.mark.filterwarnings(
+    'ignore:ERFA function "epv00" yielded.*of "'
+    'warning. date outsidethe range 1900-2100 AD"'
+)
 @pytest.mark.parametrize(
     "use_3d, plotter_class", [(True, OrbitPlotter3D), (False, OrbitPlotter2D)]
 )
@@ -24,6 +32,10 @@ def test_plot_inner_solar_system_static(earth_perihelion):
     return plt.gcf()
 
 
+@pytest.mark.filterwarnings(
+    'ignore:ERFA function "epv00" yielded.*of "'
+    'warning. date outsidethe range 1900-2100 AD"'
+)
 @pytest.mark.mpl_image_compare
 def test_plot_outer_solar_system_static(earth_perihelion):
     plot_solar_system(outer=True, epoch=earth_perihelion)

--- a/tests/tests_twobody/test_orbit.py
+++ b/tests/tests_twobody/test_orbit.py
@@ -231,17 +231,6 @@ def test_parabolic_has_zero_energy():
     assert_allclose(ss.energy.value, 0.0, atol=1e-16)
 
 
-def test_pqw_for_circular_equatorial_orbit():
-    ss = Orbit.circular(Earth, 600 * u.km)
-    expected_p = [1, 0, 0] * u.one
-    expected_q = [0, 1, 0] * u.one
-    expected_w = [0, 0, 1] * u.one
-    p, q, w = ss.pqw()
-    assert_allclose(p, expected_p)
-    assert_allclose(q, expected_q)
-    assert_allclose(w, expected_w)
-
-
 @pytest.mark.parametrize(
     "attractor,alt,argp,expected_argp,expected_inc",
     [
@@ -616,27 +605,6 @@ def test_from_horizons_raise_valueerror():
 
 
 @pytest.mark.remote_data
-def test_orbit_from_horizons_has_expected_elements():
-    epoch = Time("2018-07-23", scale="tdb")
-    # Orbit Parameters of Ceres
-    # Taken from https://ssd.jpl.nasa.gov/horizons.cgi
-    ss = Orbit.from_classical(
-        Sun,
-        2.76710759221651 * u.au,
-        0.07554803091400027 * u.one,
-        27.18502494739172 * u.deg,
-        23.36913218336299 * u.deg,
-        132.2919809219236 * u.deg,
-        21.28957916690369 * u.deg,
-        epoch,
-    )
-    ss1 = Orbit.from_horizons(name="Ceres", attractor=Sun, epoch=epoch)
-    assert ss.pqw()[0].value.all() == ss1.pqw()[0].value.all()
-    assert_quantity_allclose(ss.r_a, ss1.r_a, rtol=1.0e-4)
-    assert_quantity_allclose(ss.a, ss1.a, rtol=1.0e-4)
-
-
-@pytest.mark.remote_data
 def test_plane_is_set_in_horizons():
     plane = Planes.EARTH_ECLIPTIC
     ss = Orbit.from_horizons(name="Ceres", attractor=Sun, plane=plane)
@@ -931,32 +899,11 @@ def test_convert_from_coe_to_rv():
     assert_quantity_allclose(nu, expected_nu, rtol=1e-4)
 
 
-def test_perifocal_points_to_perigee():
-    _d = 1.0 * u.AU  # Unused distance
-    _ = 0.5 * u.one  # Unused dimensionless value
-    _a = 1.0 * u.deg  # Unused angle
-    ss = Orbit.from_classical(Sun, _d, _, _a, _a, _a, _a)
-    p, _, _ = ss.pqw()
-    assert_allclose(p, ss.e_vec / ss.ecc)
-
-
 def test_arglat_within_range():
     r = [3_539.08827417, 5_310.19903462, 3_066.31301457] * u.km
     v = [-6.49780849, 3.24910291, 1.87521413] * u.km / u.s
     ss = Orbit.from_vectors(Earth, r, v)
     assert 0 * u.deg <= ss.arglat <= 360 * u.deg
-
-
-def test_pqw_returns_dimensionless():
-    r_0 = ([1, 0, 0] * u.au).to(u.km)  # type: ignore
-    v_0 = ([0, 6, 0] * u.au / u.year).to(u.km / u.day)
-    ss = Orbit.from_vectors(Sun, r_0, v_0)
-
-    p, q, w = ss.pqw()
-
-    assert p.unit == u.one
-    assert q.unit == u.one
-    assert w.unit == u.one
 
 
 def test_from_coord_fails_if_no_time_differential():

--- a/tests/tests_twobody/test_propagation.py
+++ b/tests/tests_twobody/test_propagation.py
@@ -335,6 +335,12 @@ def test_propagate_to_date_has_proper_epoch():
     assert (ss1.epoch - final_epoch).sec == approx(0.0, abs=1e-6)
 
 
+@pytest.mark.filterwarnings(
+    'ignore:ERFA function "utctai" ' 'yielded . of "dubious year \\(Note .\\)'
+)
+@pytest.mark.filterwarnings(
+    'ignore:ERFA function "taiutc" ' 'yielded . of "dubious year \\(Note .\\)'
+)
 @pytest.mark.parametrize("propagator", [danby, markley, gooding])
 def test_propagate_long_times_keeps_geometry(propagator):
     # See https://github.com/poliastro/poliastro/issues/265


### PR DESCRIPTION
This handles all warnings, the coverage decreases for deprecated functions `Orbit.from_body_ephem()` and `Orbit.pqm()`