### PR TITLE
Pin docutils

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ commands =
 description = this environments checks for flake8, black, isort and poliastro code style
 deps =
     black==20.8b1
-    docutils
+    docutils==0.16
     isort
     flake8
     build


### PR DESCRIPTION
From #1155 Pinning `docutils<0.17` for CI builds to pass till Sphinx develops a solution..

Thanks!!