### PR TITLE
Fixed RTD build Failure with `Docutils==0.16`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ cesium = ["czml3 ~=0.5.3"]
 dev = [
     "black==20.8b1",
     "coverage",
+    "docutils<0.17",
     "hypothesis",
     "ipykernel",
     "ipython>=5.0",


### PR DESCRIPTION
Hello, 
This PR aims to fix the failing docs due to the updated Docutils version #1155 
Thanks :)