### PR TITLE
Fixing Non Functional Azure Pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ resources:
     type: github
     endpoint: poliastro
     name: OpenAstronomy/azure-pipelines-templates
-    ref: main
+    ref: master             # Referenced to the "Master" branch in the Open Astronomy Repository 
 
 trigger:
   branches:


### PR DESCRIPTION
Hello,
This PR aims to fix the current non-functional `Azure` Pipelines ... The Pipeline is redirected to non-existent `main` branch on upstream Repository `OpenAstronomy/azure-pipelines-templates`
Fixes #1168 
Thanks :)