### PR TITLE
Removed Redundant `precommit.sh` in `bin/` directory

### DIFF
--- a/bin/pre_commit.sh
+++ b/bin/pre_commit.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/bash
-
-pep8 .
-pytest --cov-report term-missing --cov . src/
-pylint poliastro --disable=no-member,no-name-in-module,invalid-name --reports=n


### PR DESCRIPTION
Hello, 
This PR aims to remove the redundant `precommit.sh` script from the `bin/` directory.
The functionality is already present in the current `tox` automation :)
Thanks :)