### PR TITLE
Moving computations of `spheroid_location` to core

### DIFF
--- a/src/poliastro/core/spheroid_location.py
+++ b/src/poliastro/core/spheroid_location.py
@@ -1,4 +1,4 @@
-""" Low level calculations for spheroid locations """
+""" Low level calculations for oblate spheroid locations """
 
 import numpy as np
 from numba import njit as jit

--- a/src/poliastro/core/spheroid_location.py
+++ b/src/poliastro/core/spheroid_location.py
@@ -1,0 +1,185 @@
+""" Low level calculations for spheroid locations """
+
+import numpy as np
+from numba import njit as jit
+
+
+def cartesian_cords(_a, _c, _lon, _lat, _h):
+    """Calculates cartesian coordinates.
+
+    Parameters
+    ----------
+    _a: ~astropy.units.quantity.Quantity
+        Semi-major axis
+    _c: ~astropy.units.quantity.Quantity
+        Semi-minor axis
+    _lon: ~astropy.units.quantity.Quantity
+        geodetic longitude
+    _lat: ~astropy.units.quantity.Quantity
+        geodetic latitude
+    _h: ~astropy.units.quantity.Quantity
+        geodetic height
+
+    """
+    e2 = 1 - (_c / _a) ** 2
+    N = _a / np.sqrt(1 - e2 * np.sin(_lon) ** 2)
+
+    x = (N + _h) * np.cos(_lon) * np.cos(_lat)
+    y = (N + _h) * np.cos(_lon) * np.sin(_lat)
+    z = ((1 - e2) * N + _h) * np.sin(_lon)
+    return x, y, z
+
+
+@jit
+def f(_a, _c):
+    """Get first flattening.
+
+    Parameters
+    ----------
+    _a: float
+        Semi-major axis
+    _c: float
+        Semi-minor axis
+
+    """
+    return 1 - _c / _a
+
+
+@jit
+def N(a, b, c, cartesian_cords):
+    """Normal vector of the ellipsoid at the given location.
+
+    Parameters
+    ----------
+    a: float
+        Semi-major axis
+    b: float
+        Equitorial radius
+    c: float
+        Semi-minor axis
+    cartesian_cords: ~np.array
+        Cartesian coordinates
+
+    """
+    x, y, z = cartesian_cords
+    N = np.array([2 * x / a ** 2, 2 * y / b ** 2, 2 * z / c ** 2])
+    N /= np.linalg.norm(N)
+    return N
+
+
+@jit
+def tangential_vecs(N):
+    """Returns orthonormal vectors tangential to the ellipsoid at the given location.
+
+    Parameters
+    ----------
+    N: ~np.array
+        Normal vector of the ellipsoid
+
+    """
+    u = np.array([1.0, 0, 0])
+    u -= u.dot(N) * N
+    u /= np.linalg.norm(u)
+    v = np.cross(N, u)
+
+    return u, v
+
+
+def radius_of_curvature(_a, _c, _lat):
+    """Radius of curvature of the meridian at the latitude of the given location.
+
+    Parameters
+    ----------
+    _a: ~astropy.units.quantity.Quantity
+        Semi-major axis
+    _c: ~astropy.units.quantity.Quantity
+        Semi-minor axis
+    _lat: ~astropy.units.quantity.Quantity
+        geodetic latitude
+
+    """
+    e2 = 1 - (_c / _a) ** 2
+    rc = _a * (1 - e2) / (1 - e2 * np.sin(_lat) ** 2) ** 1.5
+    return rc
+
+
+@jit
+def distance(cartesian_cords, px, py, pz):
+    """Calculates the distance from an arbitrary point to the given location (Cartesian coordinates).
+
+    Parameters
+    ----------
+    cartesian_cords: ~np.array
+        Cartesian coordinates
+    px: float
+        x-coordinate of the point
+    py: float
+        y-coordinate of the point
+    pz: float
+        z-coordinate of the point
+
+    """
+    c = cartesian_cords
+    u = np.array([px, py, pz])
+    d = np.linalg.norm(c - u)
+    return d
+
+
+@jit
+def is_visible(cartesian_cords, px, py, pz, N):
+    """Determines whether an object located at a given point is visible from the given location.
+    Returns true if true, false otherwise.
+
+    Parameters
+    ----------
+    cartesian_cords: list
+        Cartesian coordinates
+    px: float
+        x-coordinate of the point
+    py: float
+        y-coordinate of the point
+    pz: float
+        z-coordinate of the point
+
+    """
+    c = cartesian_cords
+    u = np.array([px, py, pz])
+
+    d = -N.dot(c)
+    p = N.dot(u) + d
+    return p >= 0
+
+
+@jit
+def cartesian_to_ellipsoidal(_a, _c, x, y, z):
+    """
+    Converts ellipsoidal coordinates to the Cartesian coordinate system for the given ellipsoid.
+    Instead of the iterative formula, the function uses the approximation introduced in
+    Bowring, B. R. (1976). TRANSFORMATION FROM SPATIAL TO GEOGRAPHICAL COORDINATES
+
+    Parameters
+    ----------
+    _a: float
+        Semi-major axis
+    _c: float
+        Semi-minor axis
+    x: float
+        x coordinate
+    y: float
+        y coordinate
+    z: float
+        z coordinate
+
+    """
+    e2 = 1 - (_c / _a) ** 2
+    e2_ = e2 / (1 - e2)
+    p = np.sqrt(x ** 2 + y ** 2)
+    th = np.arctan(z * _a / (p * _c))
+    lon = np.arctan(y / x)
+    lat = np.arctan((z + e2_ * _c * np.sin(th) ** 3) / (p - e2 * _a * np.cos(th) ** 3))
+
+    v = _a / np.sqrt(1 - e2 * np.sin(lat) ** 2)
+    h = p / np.cos(lat) - v
+    h = z / np.sin(lat) - (1 - e2) * v
+
+    return lat, lon, h

--- a/src/poliastro/core/spheroid_location.py
+++ b/src/poliastro/core/spheroid_location.py
@@ -132,7 +132,7 @@ def is_visible(cartesian_cords, px, py, pz, N):
 
     Parameters
     ----------
-    cartesian_cords: list
+    cartesian_cords: ~np.array
         Cartesian coordinates
     px: float
         x-coordinate of the point

--- a/src/poliastro/core/spheroid_location.py
+++ b/src/poliastro/core/spheroid_location.py
@@ -4,20 +4,21 @@ import numpy as np
 from numba import njit as jit
 
 
+@jit
 def cartesian_cords(_a, _c, _lon, _lat, _h):
     """Calculates cartesian coordinates.
 
     Parameters
     ----------
-    _a: ~astropy.units.quantity.Quantity
+    _a: float
         Semi-major axis
-    _c: ~astropy.units.quantity.Quantity
+    _c: float
         Semi-minor axis
-    _lon: ~astropy.units.quantity.Quantity
+    _lon: float
         geodetic longitude
-    _lat: ~astropy.units.quantity.Quantity
+    _lat: float
         geodetic latitude
-    _h: ~astropy.units.quantity.Quantity
+    _h: float
         geodetic height
 
     """
@@ -85,16 +86,17 @@ def tangential_vecs(N):
     return u, v
 
 
+@jit
 def radius_of_curvature(_a, _c, _lat):
     """Radius of curvature of the meridian at the latitude of the given location.
 
     Parameters
     ----------
-    _a: ~astropy.units.quantity.Quantity
+    _a: float
         Semi-major axis
-    _c: ~astropy.units.quantity.Quantity
+    _c: float
         Semi-minor axis
-    _lat: ~astropy.units.quantity.Quantity
+    _lat: float
         geodetic latitude
 
     """

--- a/src/poliastro/spheroid_location.py
+++ b/src/poliastro/spheroid_location.py
@@ -44,14 +44,23 @@ class SpheroidLocation:
     @property
     def cartesian_cords(self):
         """Convert to the Cartesian Coordinate system."""
-        cart_coords = cartesian_cords_fast(
-            self._a,
-            self._c,
-            self._lon,
-            self._lat,
-            self._h,
+        _a, _c, _lon, _lat, _h = (
+            self._a.to(u.m).value,
+            self._c.to(u.m).value,
+            self._lon.to(u.rad).value,
+            self._lat.to(u.rad).value,
+            self._h.to(u.m).value,
         )
-        return cart_coords
+        return (
+            cartesian_cords_fast(
+                _a,
+                _c,
+                _lon,
+                _lat,
+                _h,
+            )
+            * u.m
+        )
 
     @property
     def f(self):
@@ -75,9 +84,14 @@ class SpheroidLocation:
     @property
     def radius_of_curvature(self):
         """Radius of curvature of the meridian at the latitude of the given location."""
-        return radius_of_curvature_fast(
-            self._a, self._c, self._lat
-        )  # body.R and body.R_polar has u.m as units
+        _a, _c, _lat = (
+            self._a.to(u.m).value,
+            self._c.to(u.m).value,
+            self._lat.to(u.rad).value,
+        )
+        return (
+            radius_of_curvature_fast(_a, _c, _lat) * u.m
+        )  # Need to convert units to u.rad and then take value because numpy expects angles in radians if unit is not given.
 
     def distance(self, px, py, pz):
         """

--- a/src/poliastro/spheroid_location.py
+++ b/src/poliastro/spheroid_location.py
@@ -1,5 +1,5 @@
-import numpy as np
 import astropy.units as u
+import numpy as np
 
 from poliastro.core.spheroid_location import (
     N as N_fast,
@@ -45,20 +45,24 @@ class SpheroidLocation:
     def cartesian_cords(self):
         """Convert to the Cartesian Coordinate system."""
         cart_coords = cartesian_cords_fast(
-            self._a, self._c, self._lon, self._lat, self._h,
+            self._a,
+            self._c,
+            self._lon,
+            self._lat,
+            self._h,
         )
         return cart_coords
 
     @property
     def f(self):
         """Get first flattening."""
-        _a, _c = self._a.value, self._c.value
+        _a, _c = self._a.to(u.m).value, self._c.to(u.m).value
         return f_fast(_a, _c)
 
     @property
     def N(self):
         """Normal vector of the ellipsoid at the given location."""
-        a, b, c = self._a.value, self._b.value, self._c.value
+        a, b, c = self._a.to(u.m).value, self._b.to(u.m).value, self._c.to(u.m).value
         cartesian_cords = np.array([coord.value for coord in self.cartesian_cords])
         return N_fast(a, b, c, cartesian_cords)
 
@@ -71,8 +75,8 @@ class SpheroidLocation:
     @property
     def radius_of_curvature(self):
         """Radius of curvature of the meridian at the latitude of the given location."""
-        return (
-            radius_of_curvature_fast(self._a, self._c, self._lat)
+        return radius_of_curvature_fast(
+            self._a, self._c, self._lat
         )  # body.R and body.R_polar has u.m as units
 
     def distance(self, px, py, pz):
@@ -89,7 +93,7 @@ class SpheroidLocation:
             z-coordinate of the point
 
         """
-        px, py, pz = px.value, py.value, pz.value
+        px, py, pz = px.to(u.m).value, py.to(u.m).value, pz.to(u.m).value
         cartesian_cords = np.array([coord.value for coord in self.cartesian_cords])
         return (
             distance_fast(cartesian_cords, px, py, pz) * u.m
@@ -110,7 +114,7 @@ class SpheroidLocation:
             z-coordinate of the point
 
         """
-        px, py, pz = px.value, py.value, pz.value
+        px, py, pz = px.to(u.m).value, py.to(u.m).value, pz.to(u.m).value
         cartesian_cords = np.array([coord.value for coord in self.cartesian_cords])
 
         return is_visible_fast(cartesian_cords, px, py, pz, self.N)
@@ -131,7 +135,7 @@ class SpheroidLocation:
             z coordinate
 
         """
-        _a, _c = self._a.value, self._c.value
-        x, y, z = x.value, y.value, z.value
+        _a, _c = self._a.to(u.m).value, self._c.to(u.m).value
+        x, y, z = x.to(u.m).value, y.to(u.m).value, z.to(u.m).value
         lat, lon, h = cartesian_to_ellipsoidal_fast(_a, _c, x, y, z)
         return lat * u.rad, lon * u.rad, h * u.m

--- a/src/poliastro/spheroid_location.py
+++ b/src/poliastro/spheroid_location.py
@@ -14,7 +14,7 @@ from poliastro.core.spheroid_location import (
 
 
 class SpheroidLocation:
-    """Class representing a ground station on an arbitrary ellipsoid."""
+    """Class representing a ground station on an oblate ellipsoid."""
 
     def __init__(self, lon, lat, h, body):
         """

--- a/tests/test_spheroid_location.py
+++ b/tests/test_spheroid_location.py
@@ -46,6 +46,42 @@ def test_visible():
     assert not p.is_visible(*p2)
 
 
+def test_f():
+    expected_f = 0.0033528131
+
+    el_cords = (38.43 * u.deg, 41.2 * u.deg, 0 * u.m)
+
+    p = SpheroidLocation(*el_cords, Earth)
+
+    f = p.f
+
+    assert_quantity_allclose(f, expected_f)
+
+
+def test_radius_of_curvature():
+    expected_roc = 6363141.421601379 * u.m
+
+    el_cords = (38.43 * u.deg, 41.2 * u.deg, 0 * u.m)
+
+    p = SpheroidLocation(*el_cords, Earth)
+
+    roc = p.radius_of_curvature
+
+    assert_quantity_allclose(roc, expected_roc)
+
+
+def test_distance():
+    expected_distance = 6369864.745418392 * u.m
+    el_cords = (38.43 * u.deg, 41.2 * u.deg, 0 * u.m)
+    point_cords = (10.5 * u.m, 35.5 * u.m, 45.5 * u.m)
+
+    p = SpheroidLocation(*el_cords, Earth)
+
+    distance = p.distance(*point_cords)
+
+    assert_quantity_allclose(distance, expected_distance)
+
+
 def test_cartesian_conversion_approximate():
     el_cords = (0.670680 * u.rad, 0.7190227 * u.rad, 0 * u.m)
 


### PR DESCRIPTION
This implementation attempts to move computations in `spheroid_location.py`.

**Points**

1. Earlier, the `distance` function only returned the value without units even if the inputs are astropy quantities. Since it would be better to get the units as well, the current implementation returns them with units.
2. Tests for checking the execution of `f`, `radius_of_curvature`, and `distance` are added.
3. Two methods are not jitted since they give slight numerical inaccuracies while testing. Probably could be an investigation point. As a result, they are kept unjitted.

Thanks!!