### PR TITLE
Prepare for Sphinx 4

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -363,3 +363,8 @@ exclude_patterns.append('_autoapi_templates/python/module.rst')
 suppress_warnings.append('ref.python')
 
 myst_update_mathjax = False
+
+# Sphinx 4.0 will change the default MathJax version to 3,
+# so we proactively set it to 2 until we decide to do a migration,
+# see https://www.sphinx-doc.org/en/master/usage/extensions/math.html#module-sphinx.ext.mathjax
+mathjax_path = "https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-AMS-MML_HTMLorMML"


### PR DESCRIPTION
For the moment, I just had to set the MathJax version to 2, so the configuration doesn't break. In any case, several of our dependencies pin `sphinx<4`, so we won't immediately be affected by the new version.