### PR TITLE
Upgrade nbsphinx

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -363,8 +363,3 @@ exclude_patterns.append('_autoapi_templates/python/module.rst')
 suppress_warnings.append('ref.python')
 
 myst_update_mathjax = False
-
-# Sphinx 4.0 will change the default MathJax version to 3,
-# so we proactively set it to 2 until we decide to do a migration,
-# see https://www.sphinx-doc.org/en/master/usage/extensions/math.html#module-sphinx.ext.mathjax
-mathjax_path = "https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-AMS-MML_HTMLorMML"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ dev = [
     "jupytext",
     "mypy>=0.740",
     "myst-parser>=0.13.1",
-    "nbsphinx>=0.5.0",
+    "nbsphinx>=0.8.4",
     "nbconvert>=5.5",
     "pycodestyle",
     "pytest>=3.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ cesium = ["czml3 ~=0.5.3"]
 dev = [
     "black==20.8b1",
     "coverage",
-    "docutils<0.17",
+    "docutils",
     "hypothesis",
     "ipykernel",
     "ipython>=5.0",


### PR DESCRIPTION
Well! It turns out that the MathJax configuration error I observed was due to a bad interaction between nbsphinx and Sphinx 4, as explained in https://github.com/sphinx-doc/sphinx/issues/9148. So I am reverting #1187, and unpinning docutils as well to see how it goes.