### PR TITLE
Fix Jinja2 version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ dev = [
     "ipython>=5.0",
     "ipywidgets>=7.0",
     "isort",
+    "Jinja2<3.0.0",
     "jupyter-client",
     "jupytext",
     "mypy>=0.740",


### PR DESCRIPTION
Solves for #1218 by imposing temporarily `Jinja2<3.0.0`, which was release just a few hours ago. This will help us to keep merging contributions while we find a solution 👍🏽