### PR TITLE
Improve naming of ground range diff function

### DIFF
--- a/src/poliastro/earth/sensors.py
+++ b/src/poliastro/earth/sensors.py
@@ -51,9 +51,7 @@ def min_and_max_ground_range(h, η_fov, η_center, R):
 @u.quantity_input(
     h=u.km, η_fov=u.rad, η_center=u.rad, β=u.rad, φ_nadir=u.rad, λ_nadir=u.rad, R=u.km
 )
-def max_and_min_ground_range_with_specific_azimuth(
-    h, η_fov, η_center, β, φ_nadir, λ_nadir, R
-):
+def ground_range_diff_at_azimuth(h, η_fov, η_center, β, φ_nadir, λ_nadir, R):
     """Calculates the difference in ground-range angles from the η_center angle and the latitude and longitude of the target
     for a desired phase angle, β, used to specify where the sensor is looking.
 
@@ -66,7 +64,7 @@ def max_and_min_ground_range_with_specific_azimuth(
     η_center: ~astropy.units.Quantity
         Center boresight angle.
     β: ~astropy.units.Quantity
-        Phase angle, used to specify where the sensor is looking.
+        Azimuth angle, used to specify where the sensor is looking.
     φ_nadir: ~astropy.units.Quantity
         Latitude angle of nadir point.
     λ_nadir: ~astropy.units.Quantity

--- a/tests/tests_earth/test_sensors.py
+++ b/tests/tests_earth/test_sensors.py
@@ -4,7 +4,7 @@ from astropy.tests.helper import assert_quantity_allclose
 
 from poliastro.bodies import Earth
 from poliastro.earth.sensors import (
-    max_and_min_ground_range_with_specific_azimuth,
+    ground_range_diff_at_azimuth,
     min_and_max_ground_range,
 )
 
@@ -54,7 +54,7 @@ def test_max_and_min_ground_range(h, n_fov, n_center, expected_Λ_max, expected_
         ),
     ],
 )
-def test_max_and_min_ground_range_with_specific_azimuth(
+def test_ground_range_diff_at_azimuth(
     h,
     n_fov,
     n_center,
@@ -67,7 +67,7 @@ def test_max_and_min_ground_range_with_specific_azimuth(
 ):
 
     R = Earth.R.to(u.km)
-    delta_Λ, φ_tgt, λ_tgt = max_and_min_ground_range_with_specific_azimuth(
+    delta_Λ, φ_tgt, λ_tgt = ground_range_diff_at_azimuth(
         h, n_center, n_fov, β, φ_nadir, λ_nadir, R
     )
     assert_quantity_allclose(delta_Λ, expected_delta_Λ)
@@ -92,7 +92,7 @@ def test_max_and_min_ground_range_with_specific_azimuth(
         ),
     ],
 )
-def test_exception_max_and_min_ground_range_with_specific_azimuth(
+def test_exception_ground_range_diff_at_azimuth(
     h,
     n_fov,
     n_center,
@@ -106,7 +106,5 @@ def test_exception_max_and_min_ground_range_with_specific_azimuth(
 
     R = Earth.R.to(u.km)
     with pytest.raises(ValueError) as excinfo:
-        max_and_min_ground_range_with_specific_azimuth(
-            h, n_center, n_fov, β, φ_nadir, λ_nadir, R
-        )
+        ground_range_diff_at_azimuth(h, n_center, n_fov, β, φ_nadir, λ_nadir, R)
     assert "β must be between 0º and 180º" in excinfo.exconly()


### PR DESCRIPTION
Found this while writing the release notes for 0.15.0. I think this name is shorter and more clear.