### PR TITLE
Test dev version of sphinx-hoverxref

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ dev = [
     "sphinx-autoapi",
     "sphinx-gallery",
     "sphinx_rtd_theme~=0.5.0",
-    "sphinx-hoverxref==0.5b1",
+    "sphinx-hoverxref @ https://github.com/readthedocs/sphinx-hoverxref/archive/humitos/support-intersphinx.zip",
     "sphinx-notfound-page",
 ]
 


### PR DESCRIPTION
That supports intersphinx! :tada: See https://github.com/readthedocs/sphinx-hoverxref/pull/86

Rendered as https://poliastro--1231.org.readthedocs.build/en/1231/