### PR TITLE
Frame computation calculation fixing

### DIFF
--- a/src/poliastro/core/fixed.py
+++ b/src/poliastro/core/fixed.py
@@ -60,11 +60,11 @@ def mercury_rot_elements_at_epoch(T, d):
         Right ascension and declination of north pole, and angle of the prime meridian.
 
     """
-    M1 = 174.7910857 + 4.092335 * d
-    M2 = 349.5821714 + 8.184670 * d
-    M3 = 164.3732571 + 12.277005 * d
-    M4 = 339.1643429 + 16.369340 * d
-    M5 = 153.9554286 + 20.461675 * d
+    M1 = np.deg2rad(174.7910857 + 4.092335 * d)
+    M2 = np.deg2rad(349.5821714 + 8.184670 * d)
+    M3 = np.deg2rad(164.3732571 + 12.277005 * d)
+    M4 = np.deg2rad(339.1643429 + 16.369340 * d)
+    M5 = np.deg2rad(153.9554286 + 20.461675 * d)
     ra = 281.0103 - 0.0328 * T
     dec = 61.45 - 0.005 * T
     W = (329.5988 + 6.1385108 * d) + (
@@ -119,11 +119,11 @@ def mars_rot_elements_at_epoch(T, d):
         Right ascension and declination of north pole, and angle of the prime meridian.
 
     """
-    M1 = 198.991226 + 19139.4819985 * T
-    M2 = 226.292679 + 38280.8511281 * T
-    M3 = 249.663391 + 57420.7251593 * T
-    M4 = 266.183510 + 76560.6367950 * T
-    M5 = 79.398797 + 0.5042615 * T
+    M1 = np.deg2rad(198.991226 + 19139.4819985 * T)
+    M2 = np.deg2rad(226.292679 + 38280.8511281 * T)
+    M3 = np.deg2rad(249.663391 + 57420.7251593 * T)
+    M4 = np.deg2rad(266.183510 + 76560.6367950 * T)
+    M5 = np.deg2rad(79.398797 + 0.5042615 * T)
 
     ra = (
         317.269202
@@ -135,11 +135,11 @@ def mars_rot_elements_at_epoch(T, d):
         + 0.419057 * np.sin(M5)
     )
 
-    K1 = 122.433576 + 19139.9407476 * T
-    K2 = 43.058401 + 38280.8753272 * T
-    K3 = 57.663379 + 57420.7517205 * T
-    K4 = 79.476401 + 76560.6495004 * T
-    K5 = 166.325722 + 0.5042615 * T
+    K1 = np.deg2rad(122.433576 + 19139.9407476 * T)
+    K2 = np.deg2rad(43.058401 + 38280.8753272 * T)
+    K3 = np.deg2rad(57.663379 + 57420.7517205 * T)
+    K4 = np.deg2rad(79.476401 + 76560.6495004 * T)
+    K5 = np.deg2rad(166.325722 + 0.5042615 * T)
 
     dec = (
         54.432516
@@ -151,12 +151,12 @@ def mars_rot_elements_at_epoch(T, d):
         + 1.591274 * np.cos(K5)
     )
 
-    J1 = 129.071773 + 19140.0328244 * T
-    J2 = 36.352167 + 38281.0473591 * T
-    J3 = 56.668646 + 57420.9295360 * T
-    J4 = 67.364003 + 76560.2552215 * T
-    J5 = 104.792680 + 95700.4387578 * T
-    J6 = 95.391654 + 0.5042615 * T
+    J1 = np.deg2rad(129.071773 + 19140.0328244 * T)
+    J2 = np.deg2rad(36.352167 + 38281.0473591 * T)
+    J3 = np.deg2rad(56.668646 + 57420.9295360 * T)
+    J4 = np.deg2rad(67.364003 + 76560.2552215 * T)
+    J5 = np.deg2rad(104.792680 + 95700.4387578 * T)
+    J6 = np.deg2rad(95.391654 + 0.5042615 * T)
 
     W = (
         176.049863
@@ -189,11 +189,11 @@ def jupiter_rot_elements_at_epoch(T, d):
         Right ascension and declination of north pole, and angle of the prime meridian.
 
     """
-    Ja = 99.360714 + 4850.4046 * T
-    Jb = 175.895369 + 1191.9605 * T
-    Jc = 300.323162 + 262.5475 * T
-    Jd = 114.012305 + 6070.2476 * T
-    Je = 49.511251 + 64.3000 * T
+    Ja = np.deg2rad(99.360714 + 4850.4046 * T)
+    Jb = np.deg2rad(175.895369 + 1191.9605 * T)
+    Jc = np.deg2rad(300.323162 + 262.5475 * T)
+    Jd = np.deg2rad(114.012305 + 6070.2476 * T)
+    Je = np.deg2rad(49.511251 + 64.3000 * T)
 
     ra = (
         268.056595
@@ -283,7 +283,7 @@ def neptune_rot_elements_at_epoch(T, d):
         Right ascension and declination of north pole, and angle of the prime meridian.
 
     """
-    N = 357.85 + 52.316 * T
+    N = np.deg2rad(357.85 + 52.316 * T)
 
     ra = 299.36 + 0.70 * np.sin(N)
     dec = 43.46 - 0.51 * np.cos(N)
@@ -309,19 +309,19 @@ def moon_rot_elements_at_epoch(T, d):
         Right ascension and declination of north pole, and angle of the prime meridian.
 
     """
-    E1 = 125.045 - 0.0529921 * d
-    E2 = 250.089 - 0.1059842 * d
-    E3 = 260.008 + 13.0120009 * d
-    E4 = 176.625 + 13.3407154 * d
-    E5 = 357.529 + 0.9856003 * d
-    E6 = 311.589 + 26.4057084 * d
-    E7 = 134.963 + 13.0649930 * d
-    E8 = 276.617 + 0.3287146 * d
-    E9 = 34.226 + 1.7484877 * d
-    E10 = 15.134 - 0.1589763 * d
-    E11 = 119.743 + 0.0036096 * d
-    E12 = 239.961 + 0.1643573 * d
-    E13 = 25.053 + 12.9590088 * d
+    E1 = np.deg2rad(125.045 - 0.0529921 * d)
+    E2 = np.deg2rad(250.089 - 0.1059842 * d)
+    E3 = np.deg2rad(260.008 + 13.0120009 * d)
+    E4 = np.deg2rad(176.625 + 13.3407154 * d)
+    E5 = np.deg2rad(357.529 + 0.9856003 * d)
+    E6 = np.deg2rad(311.589 + 26.4057084 * d)
+    E7 = np.deg2rad(134.963 + 13.0649930 * d)
+    E8 = np.deg2rad(276.617 + 0.3287146 * d)
+    E9 = np.deg2rad(34.226 + 1.7484877 * d)
+    E10 = np.deg2rad(15.134 - 0.1589763 * d)
+    E11 = np.deg2rad(119.743 + 0.0036096 * d)
+    E12 = np.deg2rad(239.961 + 0.1643573 * d)
+    E13 = np.deg2rad(25.053 + 12.9590088 * d)
 
     ra = (
         269.9949

--- a/src/poliastro/frames/fixed.py
+++ b/src/poliastro/frames/fixed.py
@@ -112,7 +112,7 @@ class _PlanetaryFixed(BaseRADecFrame):
         return fixed_frame.realize_frame(r_f)
 
     @classmethod
-    def rot_elements_at_epoch(cls, epoch):
+    def rot_elements_at_epoch(cls, epoch=J2000):
         """Provides rotational elements at epoch.
 
         Provides north pole of body and angle to prime meridian.

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -14,6 +14,7 @@ from poliastro.bodies import (
     Jupiter,
     Mars,
     Mercury,
+    Moon,
     Neptune,
     Saturn,
     Sun,
@@ -39,6 +40,7 @@ from poliastro.frames.fixed import (
     JupiterFixed,
     MarsFixed,
     MercuryFixed,
+    MoonFixed,
     NeptuneFixed,
     SaturnFixed,
     SunFixed,
@@ -268,6 +270,15 @@ def test_GeocentricSolarEcliptic_raises_error_nonscalar_obstime():
             NeptuneFixed,
             (299.33373896 * u.deg, 42.95035902 * u.deg, 249.99600757 * u.deg),
         ),
+        (
+            Moon,
+            MoonFixed,
+            (
+                266.85773344495135 * u.deg,
+                65.64110274784535 * u.deg,
+                41.1952639807452 * u.deg,
+            ),
+        ),
     ],
 )
 def test_fixed_frame_calculation_gives_expected_result(body, fixed_frame, radecW):
@@ -276,4 +287,6 @@ def test_fixed_frame_calculation_gives_expected_result(body, fixed_frame, radecW
         0 * u.deg, 0 * u.deg, body.R, obstime=epoch, representation_type="spherical"
     )
 
-    assert_quantity_allclose(fixed_position.rot_elements_at_epoch(), radecW, atol=1e-7 * u.deg)
+    assert_quantity_allclose(
+        fixed_position.rot_elements_at_epoch(), radecW, atol=1e-7 * u.deg
+    )

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -243,3 +243,37 @@ def test_GeocentricSolarEcliptic_raises_error_nonscalar_obstime():
         "To perform this transformation the "
         "obstime Attribute must be a scalar." in str(excinfo.value)
     )
+
+
+@pytest.mark.parametrize(
+    "body, fixed_frame, radecW",
+    [
+        (Sun, SunFixed, (286.13 * u.deg, 63.87 * u.deg, 84.176 * u.deg)),
+        (Mercury, MercuryFixed, (281.0103 * u.deg, 61.45 * u.deg, 329.5999488 * u.deg)),
+        (Venus, VenusFixed, (272.76 * u.deg, 67.16 * u.deg, 160.2 * u.deg)),
+        (
+            Mars,
+            MarsFixed,
+            (317.68085441 * u.deg, 52.88643928 * u.deg, 176.63205973 * u.deg),
+        ),
+        (
+            Jupiter,
+            JupiterFixed,
+            (268.05720404 * u.deg, 64.49580995 * u.deg, 284.95 * u.deg),
+        ),
+        (Saturn, SaturnFixed, (40.589 * u.deg, 83.537 * u.deg, 38.9 * u.deg)),
+        (Uranus, UranusFixed, (257.311 * u.deg, -15.175 * u.deg, 203.81 * u.deg)),
+        (
+            Neptune,
+            NeptuneFixed,
+            (299.33373896 * u.deg, 42.95035902 * u.deg, 249.99600757 * u.deg),
+        ),
+    ],
+)
+def test_fixed_frame_calculation_gives_expected_result(body, fixed_frame, radecW):
+    epoch = J2000
+    fixed_position = fixed_frame(
+        0 * u.deg, 0 * u.deg, body.R, obstime=epoch, representation_type="spherical"
+    )
+
+    assert_quantity_allclose(fixed_position.rot_elements_at_epoch(), radecW, atol=1e-7 * u.deg)


### PR DESCRIPTION
In this pull request, I have tried to rectify the mistake done by me in #1190 .

**Details**

- The `core` module uses the `np.deg2rad` function to address the needed conversion. It is done since `numba` loves `numpy` and the use of `astropy.Quantity` objects in `core`, I think, is discouraged.
- The `epoch` argument in `rot_elements_at_epoch` is made optional since the docstring earlier signified it to be optional, but the code implicitly assumed it to be always passed by the user.
- A test has been added to make sure the implementation works. (This might contribute a small amount to #1236). The expected values for the test were taken from the output of using `rot_elements_at_epoch` on fixed frames of bodies using the source code before the commit of #1190.

@jorgepiloto I would love to get your thoughts on this!

Thanks!

---
If I run the added test but keeping the code in `core` as per the commits in #1190, I get error:

```bash
FAILED tests/test_frames.py::test_fixed_frame_calculation_gives_expected_result[body1-MercuryFixed-radecW1] - AssertionError: 
FAILED tests/test_frames.py::test_fixed_frame_calculation_gives_expected_result[body3-MarsFixed-radecW3] - AssertionError: 
FAILED tests/test_frames.py::test_fixed_frame_calculation_gives_expected_result[body4-JupiterFixed-radecW4] - AssertionError: 
FAILED tests/test_frames.py::test_fixed_frame_calculation_gives_expected_result[body7-NeptuneFixed-radecW7] - AssertionError: 
FAILED tests/test_frames.py::test_fixed_frame_calculation_gives_expected_result[body8-MoonFixed-radecW8] - AssertionError: 
```
Hence, this might be an indication that this pull request would probably resolve the issue.