### PR TITLE
Fix flit installation command error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ dev = [
     "coverage",
     "hypothesis",
     "ipython>=5.0",
-    "ipywidgets>=7.0",
+    "ipywidgets>=7.6",
     "isort",
     "jupyter-client",
     "jupytext",


### PR DESCRIPTION
I followed the contributor guide given by @Yash-10 but I wasn't able to reproduce the same error. Did I miss something?

Anyway, here's the PR with the suggested change.

Fixes #1245 