### PR TITLE
Alinspace to handle angle differences larger than 2*pi, fix xfailed test

### DIFF
--- a/src/poliastro/core/util.py
+++ b/src/poliastro/core/util.py
@@ -45,7 +45,7 @@ def alinspace(start, stop=None, num=50, endpoint=True):
     if stop is None:
         stop_ = start + 2 * np.pi
     elif stop <= start:
-        stop_ = stop + 2 * np.pi
+        stop_ = stop + (np.floor((start - stop) / 2 / np.pi) + 1) * 2 * np.pi
     else:
         stop_ = stop
 

--- a/tests/tests_core/test_core_util.py
+++ b/tests/tests_core/test_core_util.py
@@ -34,12 +34,6 @@ def test_rotation_matrix_z():
 angles = partial(st.floats, min_value=-2 * np.pi, max_value=2 * np.pi)
 
 
-@pytest.mark.xfail(
-    reason=(
-        "At the moment the function assumes that "
-        "the maximum difference between min and max angles is 2 pi"
-    )
-)
 @settings(deadline=None)
 @given(
     x=angles(),


### PR DESCRIPTION
This is a small change to fix `xfailed` test in `test_core_util.py` due to `alinspace` function not handling angle differences larger than 2*pi.