### PR TITLE
jit a_d functions inside thrust.py

### DIFF
--- a/src/poliastro/twobody/thrust/change_a_inc.py
+++ b/src/poliastro/twobody/thrust/change_a_inc.py
@@ -1,7 +1,7 @@
 import numpy as np
+from numba import jit
 from numpy import cross
 from numpy.linalg import norm
-from numba import jit
 
 from poliastro.core.thrust.change_a_inc import (
     beta,

--- a/src/poliastro/twobody/thrust/change_a_inc.py
+++ b/src/poliastro/twobody/thrust/change_a_inc.py
@@ -1,6 +1,7 @@
 import numpy as np
 from numpy import cross
 from numpy.linalg import norm
+from numba import jit
 
 from poliastro.core.thrust.change_a_inc import (
     beta,
@@ -42,6 +43,7 @@ def change_a_inc(k, a_0, a_f, inc_0, inc_f, f):
 
     V_0, beta_0_, _ = compute_parameters(k, a_0, a_f, inc_0, inc_f)
 
+    @jit(forceobj=True)
     def a_d(t0, u_, k):
         r = u_[:3]
         v = u_[3:]

--- a/src/poliastro/twobody/thrust/change_argp.py
+++ b/src/poliastro/twobody/thrust/change_argp.py
@@ -13,6 +13,7 @@ from numpy.linalg import norm
 
 from poliastro.core.elements import rv2coe
 from poliastro.core.thrust.change_argp import extra_quantities
+from numba import njit
 
 
 def change_argp(k, a, ecc, argp_0, argp_f, f):
@@ -26,6 +27,7 @@ def change_argp(k, a, ecc, argp_0, argp_f, f):
         Magnitude of constant acceleration
     """
 
+    @njit
     def a_d(t0, u_, k):
         r = u_[:3]
         v = u_[3:]

--- a/src/poliastro/twobody/thrust/change_argp.py
+++ b/src/poliastro/twobody/thrust/change_argp.py
@@ -8,12 +8,12 @@ References
 
 """
 import numpy as np
+from numba import njit
 from numpy import cross
 from numpy.linalg import norm
 
 from poliastro.core.elements import rv2coe
 from poliastro.core.thrust.change_argp import extra_quantities
-from numba import njit
 
 
 def change_argp(k, a, ecc, argp_0, argp_f, f):

--- a/src/poliastro/twobody/thrust/change_ecc_quasioptimal.py
+++ b/src/poliastro/twobody/thrust/change_ecc_quasioptimal.py
@@ -8,9 +8,9 @@ References
 """
 import numpy as np
 from astropy import units as u
+from numba import njit
 from numpy import cross
 from numpy.linalg import norm
-from numba import njit
 
 from poliastro.core.thrust.change_ecc_quasioptimal import extra_quantities
 

--- a/src/poliastro/twobody/thrust/change_ecc_quasioptimal.py
+++ b/src/poliastro/twobody/thrust/change_ecc_quasioptimal.py
@@ -10,6 +10,7 @@ import numpy as np
 from astropy import units as u
 from numpy import cross
 from numpy.linalg import norm
+from numba import njit
 
 from poliastro.core.thrust.change_ecc_quasioptimal import extra_quantities
 
@@ -40,6 +41,7 @@ def change_ecc_quasioptimal(ss_0, ecc_f, f):
     h_unit = ss_0.h_vec / norm(ss_0.h_vec)
     thrust_unit = cross(h_unit, ref_vec) * np.sign(ecc_f - ecc_0)
 
+    @njit
     def a_d(t0, u_, k):
         accel_v = f * thrust_unit
         return accel_v

--- a/src/poliastro/twobody/thrust/change_inc_ecc.py
+++ b/src/poliastro/twobody/thrust/change_inc_ecc.py
@@ -7,9 +7,9 @@ References
 """
 import numpy as np
 from astropy import units as u
+from numba import njit
 from numpy import cross
 from numpy.linalg import norm
-from numba import njit
 
 from poliastro.core.elements import rv2coe
 from poliastro.core.thrust.change_inc_ecc import beta, extra_quantities

--- a/src/poliastro/twobody/thrust/change_inc_ecc.py
+++ b/src/poliastro/twobody/thrust/change_inc_ecc.py
@@ -9,6 +9,7 @@ import numpy as np
 from astropy import units as u
 from numpy import cross
 from numpy.linalg import norm
+from numba import njit
 
 from poliastro.core.elements import rv2coe
 from poliastro.core.thrust.change_inc_ecc import beta, extra_quantities
@@ -46,6 +47,7 @@ def change_inc_ecc(ss_0, ecc_f, inc_f, f):
 
     beta_0_ = beta(ecc_0, ecc_f, inc_0, inc_f, argp)
 
+    @njit
     def a_d(t0, u_, k):
         r = u_[:3]
         v = u_[3:]

--- a/tests/tests_twobody/test_thrust.py
+++ b/tests/tests_twobody/test_thrust.py
@@ -53,7 +53,6 @@ def test_leo_geo_numerical(inc_0):
     assert_allclose(sf.inc.to(u.rad).value, inc_f, atol=2e-3)
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize(
     "ecc_0,ecc_f", [[0.0, 0.1245], [0.1245, 0.0]]  # Reverse-engineered from results
 )
@@ -72,7 +71,6 @@ def test_sso_disposal_time_and_delta_v(ecc_0, ecc_f):
     assert_allclose(t_f / 86400, expected_t_f, rtol=1e-4)
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize(
     "ecc_0,ecc_f", [[0.0, 0.1245], [0.1245, 0.0]]  # Reverse-engineered from results
 )
@@ -98,7 +96,6 @@ def test_sso_disposal_numerical(ecc_0, ecc_f):
     assert_allclose(sf.ecc.value, ecc_f, rtol=1e-4, atol=1e-4)
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize(
     "ecc_0,inc_f,expected_beta,expected_delta_V",
     [
@@ -135,7 +132,6 @@ def test_geo_cases_beta_dnd_delta_v(ecc_0, inc_f, expected_beta, expected_delta_
     assert_allclose(beta, expected_beta, rtol=1e-2)
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("ecc_0,ecc_f", [[0.4, 0.0], [0.0, 0.4]])
 def test_geo_cases_numerical(ecc_0, ecc_f):
     a = 42164  # km
@@ -169,7 +165,6 @@ def test_geo_cases_numerical(ecc_0, ecc_f):
     assert_allclose(sf.inc.to(u.rad).value, inc_f, rtol=1e-1)
 
 
-@pytest.mark.slow
 def test_soyuz_standard_gto_delta_v():
     # Data from Soyuz Users Manual, issue 2 revision 0
     r_a = (Earth.R + 35950 * u.km).to(u.km).value
@@ -192,7 +187,6 @@ def test_soyuz_standard_gto_delta_v():
     assert_allclose(t_f / 86400, expected_t_f, rtol=1e-2)
 
 
-@pytest.mark.slow
 def test_soyuz_standard_gto_numerical():
     # Data from Soyuz Users Manual, issue 2 revision 0
     r_a = (Earth.R + 35950 * u.km).to(u.km).value
@@ -231,7 +225,6 @@ def test_soyuz_standard_gto_numerical():
     assert_allclose(sf.argp.to(u.rad).value, argp_f, rtol=1e-4)
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize(
     "inc_0, expected_t_f, expected_delta_V, rtol",
     [


### PR DESCRIPTION
This implements a recommendation from @astrojuanlu in https://github.com/poliastro/poliastro/issues/1076 to jit some functions on `trust.py`, which makes a significant speed improvement.

Execution times of `test_thrust.py` test:

Current (without jit):
```
============================= slowest 15 durations ==============================
83.19s call     tests/tests_twobody/test_thrust.py::test_leo_geo_numerical[0.49741883681838395]
33.42s call     tests/tests_twobody/test_thrust.py::test_geo_cases_numerical[0.0-0.4]
29.90s call     tests/tests_twobody/test_thrust.py::test_geo_cases_numerical[0.4-0.0]
10.02s call     tests/tests_twobody/test_thrust.py::test_sso_disposal_numerical[0.0-0.1245]
9.41s call     tests/tests_twobody/test_thrust.py::test_sso_disposal_numerical[0.1245-0.0]
4.78s call     tests/tests_twobody/test_thrust.py::test_soyuz_standard_gto_numerical
0.55s call     tests/tests_twobody/test_thrust.py::test_geo_cases_beta_dnd_delta_v[0.1-20.0-83.043-1.6789]
0.27s call     tests/tests_twobody/test_thrust.py::test_soyuz_standard_gto_delta_v
0.26s call     tests/tests_twobody/test_thrust.py::test_sso_disposal_time_and_delta_v[0.0-0.1245]
0.01s call     tests/tests_twobody/test_thrust.py::test_geo_cases_beta_dnd_delta_v[0.4-20.0-61.522-1.7592]
============= 17 passed, 1 skipped, 2 warnings in 172.84s (0:02:52) =============
```

New (with jit):
```
============================= slowest 15 durations ==============================
78.02s call     tests/tests_twobody/test_thrust.py::test_leo_geo_numerical[0.49741883681838395]
4.01s call     tests/tests_twobody/test_thrust.py::test_geo_cases_numerical[0.4-0.0]
3.99s call     tests/tests_twobody/test_thrust.py::test_geo_cases_numerical[0.0-0.4]
3.51s call     tests/tests_twobody/test_thrust.py::test_sso_disposal_numerical[0.0-0.1245]
3.37s call     tests/tests_twobody/test_thrust.py::test_sso_disposal_numerical[0.1245-0.0]
1.47s call     tests/tests_twobody/test_thrust.py::test_soyuz_standard_gto_numerical
0.44s call     tests/tests_twobody/test_thrust.py::test_geo_cases_beta_dnd_delta_v[0.1-20.0-83.043-1.6789]
0.31s call     tests/tests_twobody/test_thrust.py::test_soyuz_standard_gto_delta_v
0.24s call     tests/tests_twobody/test_thrust.py::test_sso_disposal_time_and_delta_v[0.0-0.1245]
0.01s call     tests/tests_twobody/test_thrust.py::test_geo_cases_beta_dnd_delta_v[0.8-10.0-16.304-1.9799]
0.01s call     tests/tests_twobody/test_thrust.py::test_geo_cases_beta_dnd_delta_v[0.6-16.0-40.0-1.7241]
0.01s call     tests/tests_twobody/test_thrust.py::test_geo_cases_beta_dnd_delta_v[0.4-20.0-61.522-1.7592]
0.01s call     tests/tests_twobody/test_thrust.py::test_geo_cases_beta_dnd_delta_v[0.2-20.0-76.087-1.689]
============= 17 passed, 1 skipped, 2 warnings in 96.86s (0:01:36) ==============
```