### PR TITLE
Remove jit `forceobj=True` in a_d inside change_a_inc

### DIFF
--- a/src/poliastro/core/thrust/change_a_inc.py
+++ b/src/poliastro/core/thrust/change_a_inc.py
@@ -15,7 +15,7 @@ def extra_quantities(k, a_0, a_f, inc_0, inc_f, f):
 
 
 @jit
-def beta(t, *, V_0, f, beta_0):
+def beta(t, V_0, f, beta_0):
     """Compute yaw angle (β) as a function of time and the problem parameters."""
     return np.arctan2(V_0 * np.sin(beta_0), V_0 * np.cos(beta_0) - f * t)
 

--- a/src/poliastro/twobody/thrust/change_a_inc.py
+++ b/src/poliastro/twobody/thrust/change_a_inc.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numba import jit
+from numba import njit
 from numpy import cross
 from numpy.linalg import norm
 
@@ -43,17 +43,16 @@ def change_a_inc(k, a_0, a_f, inc_0, inc_f, f):
 
     V_0, beta_0_, _ = compute_parameters(k, a_0, a_f, inc_0, inc_f)
 
-    @jit(forceobj=True)
+    @njit
     def a_d(t0, u_, k):
         r = u_[:3]
         v = u_[3:]
 
         # Change sign of beta with the out-of-plane velocity
-        beta_ = beta(t0, V_0=V_0, f=f, beta_0=beta_0_) * np.sign(r[0] * (inc_f - inc_0))
+        beta_ = beta(t0, V_0, f, beta_0_) * np.sign(r[0] * (inc_f - inc_0))
 
         t_ = v / norm(v)
         w_ = cross(r, v) / norm(cross(r, v))
-        # n_ = cross(t_, w_)
         accel_v = f * (np.cos(beta_) * t_ + np.sin(beta_) * w_)
         return accel_v
 

--- a/tests/tests_twobody/test_thrust.py
+++ b/tests/tests_twobody/test_thrust.py
@@ -15,15 +15,9 @@ from poliastro.twobody.thrust import (
 )
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize(
     "inc_0",
-    [
-        np.radians(28.5),
-        pytest.param(
-            np.radians(90.0), marks=pytest.mark.skip(reason="too long for now")
-        ),
-    ],
+    [np.radians(28.5), np.radians(90.0)],
 )
 def test_leo_geo_numerical(inc_0):
     f = 3.5e-7  # km / s2


### PR DESCRIPTION
This is a follow-up of https://github.com/poliastro/poliastro/issues/1076 and https://github.com/poliastro/poliastro/pull/1250, to remove `forceobj=True` from one of the a_d functions in `thrust.py`, which delivers additional speed improvements:

Current implementation:
```
tests/tests_twobody/test_thrust.py .s................  [100%]

===== slowest 5 durations =====
55.91s call     tests/tests_twobody/test_thrust.py::test_leo_geo_numerical[0.49741883681838395]
3.44s call     tests/tests_twobody/test_thrust.py::test_geo_cases_numerical[0.4-0.0]
3.33s call     tests/tests_twobody/test_thrust.py::test_geo_cases_numerical[0.0-0.4]
2.65s call     tests/tests_twobody/test_thrust.py::test_sso_disposal_numerical[0.0-0.1245]
2.64s call     tests/tests_twobody/test_thrust.py::test_sso_disposal_numerical[0.1245-0.0]
===== 17 passed, 1 skipped in 70.41s (0:01:10) =====
```

New implementation:
```
tests/tests_twobody/test_thrust.py ..................  [100%]

====== slowest 5 durations =====
23.79s call     tests/tests_twobody/test_thrust.py::test_leo_geo_numerical[1.5707963267948966]
15.69s call     tests/tests_twobody/test_thrust.py::test_leo_geo_numerical[0.49741883681838395]
3.57s call     tests/tests_twobody/test_thrust.py::test_geo_cases_numerical[0.4-0.0]
3.37s call     tests/tests_twobody/test_thrust.py::test_geo_cases_numerical[0.0-0.4]
2.67s call     tests/tests_twobody/test_thrust.py::test_sso_disposal_numerical[0.1245-0.0]
===== 18 passed in 54.43s =====
```

Note that one test that was skipped due to being too slow has been enabled.