### PR TITLE
Altitude crossing

### DIFF
--- a/src/poliastro/twobody/events.py
+++ b/src/poliastro/twobody/events.py
@@ -2,67 +2,81 @@ from astropy import units as u
 from numpy.linalg import norm
 
 
-class LithobrakeEvent:
+class Event:
+    """Base class for event functionalities.
+
+    Parameters
+    ----------
+    terminal: bool
+        Whether to terminate integration if this event occurs.
+    direction: float
+        Handle triggering of event.
+
+    """
+
+    def __init__(self, terminal, direction):
+        self._terminal, self._direction = terminal, direction
+        self._last_t = None
+
+    @property
+    def terminal(self):
+        return self._terminal
+
+    @property
+    def direction(self):
+        return self._direction
+
+    @property
+    def last_t(self):
+        return self._last_t * u.s
+
+    def __call__(self, t, u, k):
+        raise NotImplementedError
+
+
+class AltitudeCrossEvent(Event):
+    """Detect if a satellite crosses a specific threshold altitude.
+
+    Parameters
+    ----------
+    alt: float
+        Threshold altitude (km).
+    R: float
+        Radius of the attractor (km).
+    terminal: bool
+        Whether to terminate integration if this event occurs.
+    direction: float
+        Handle triggering of event based on whether altitude is crossed from above
+        or below, defaults to -1, i.e., event is triggered only if altitude is
+        crossed from above (decreasing altitude).
+
+    """
+
+    def __init__(self, alt, R, terminal=True, direction=-1):
+        super().__init__(terminal, direction)
+        self._R = R
+        self._alt = alt  # Threshold altitude from the ground.
+
+    def __call__(self, t, u, k):
+        self._last_t = t
+        r_norm = norm(u[:3])
+
+        return (
+            r_norm - self._R - self._alt
+        )  # If this goes from +ve to -ve, altitude is decreasing.
+
+
+class LithobrakeEvent(AltitudeCrossEvent):
     """Terminal event that detects impact with the attractor surface.
 
     Parameters
     ----------
     R : float
-        Radius of the attractor.
-
-    """
-
-    def __init__(self, R):
-        self._R = R
-        self._last_t = None
-
-    @property
-    def terminal(self):
-        # Tell SciPy to stop the integration at H = R (impact)
-        return True
-
-    @property
-    def last_t(self):
-        return self._last_t * u.s
-
-    def __call__(self, t, u, k):
-        self._last_t = t
-        H = norm(u[:3])
-        # SciPy will search for H - R = 0
-        print(H - self._R)
-        return H - self._R
-
-
-class AltitudeCrossEvent:
-    """Detect if a satellite crosses a specific threshold altitude.
-
-    Parameters
-    ----------
-    R: ~astropy.units.Quantity
         Radius of the attractor (km).
-    thresh_H: ~astropy.units.Quantity
-        Threshold altitude (in km), defaults to 100 km.
     terminal: bool
-        Whether to terminate integration if this event occurs, defaults to True.
+        Whether to terminate integration if this event occurs.
 
     """
-    def __init__(self, R, thresh_H=100*u.km, terminal=True):
-        self._R = R.to(u.km).value
-        self._thresh_H = thresh_H.to(u.km).value  # Threshold height from the ground.
-        self._terminal = terminal
-        self._last_t = None
 
-    @property
-    def terminal(self):
-        # Orekit's API stops propagation when descending, but not when ascending.
-        return self._terminal
-
-    @property
-    def last_t(self):
-        return self._last_t * u.s
-
-    def __call__(self, t, u, k):
-        self._last_t = t
-        H = norm(u[:3])
-        # H is from the center of the attractor.
-        return H - self._R - self._thresh_H  # If this goes from +ve to -ve, altitude is decreasing.
+    def __init__(self, R, terminal=True):
+        super().__init__(0, R, terminal, direction=-1)

--- a/src/poliastro/twobody/events.py
+++ b/src/poliastro/twobody/events.py
@@ -29,4 +29,40 @@ class LithobrakeEvent:
         self._last_t = t
         H = norm(u[:3])
         # SciPy will search for H - R = 0
+        print(H - self._R)
         return H - self._R
+
+
+class AltitudeCrossEvent:
+    """Detect if a satellite crosses a specific threshold altitude.
+
+    Parameters
+    ----------
+    R: ~astropy.units.Quantity
+        Radius of the attractor (km).
+    thresh_H: ~astropy.units.Quantity
+        Threshold altitude (in km), defaults to 100 km.
+    terminal: bool
+        Whether to terminate integration if this event occurs, defaults to True.
+
+    """
+    def __init__(self, R, thresh_H=100*u.km, terminal=True):
+        self._R = R.to(u.km).value
+        self._thresh_H = thresh_H.to(u.km).value  # Threshold height from the ground.
+        self._terminal = terminal
+        self._last_t = None
+
+    @property
+    def terminal(self):
+        # Orekit's API stops propagation when descending, but not when ascending.
+        return self._terminal
+
+    @property
+    def last_t(self):
+        return self._last_t * u.s
+
+    def __call__(self, t, u, k):
+        self._last_t = t
+        H = norm(u[:3])
+        # H is from the center of the attractor.
+        return H - self._R - self._thresh_H  # If this goes from +ve to -ve, altitude is decreasing.

--- a/tests/tests_twobody/test_events.py
+++ b/tests/tests_twobody/test_events.py
@@ -1,0 +1,80 @@
+import numpy as np
+import pytest
+from astropy import units as u
+from astropy.tests.helper import assert_quantity_allclose
+from numpy.linalg import norm
+
+from poliastro.bodies import Earth
+from poliastro.constants import H0_earth, rho0_earth
+from poliastro.core.perturbations import atmospheric_drag_exponential
+from poliastro.core.propagation import func_twobody
+from poliastro.twobody import Orbit
+from poliastro.twobody.events import AltitudeCrossEvent
+from poliastro.twobody.propagation import cowell
+
+
+@pytest.mark.slow
+def test_altitude_crossing():
+    # Test decreasing altitude cross over Earth. No analytic solution.
+    R = Earth.R.to(u.km).value
+
+    orbit = Orbit.circular(Earth, 230 * u.km)
+    t_flight = 48.209538 * u.d
+
+    # Parameters of a body
+    C_D = 2.2  # Dimensionless (any value would do)
+    A_over_m = ((np.pi / 4.0) * (u.m ** 2) / (100 * u.kg)).to_value(
+        u.km ** 2 / u.kg
+    )  # km^2/kg
+
+    # Parameters of the atmosphere
+    rho0 = rho0_earth.to(u.kg / u.km ** 3).value  # kg/km^3
+    H0 = H0_earth.to(u.km).value  # km
+
+    tofs = [50] * u.d
+
+    thresh_alt = 50  # km
+    altitude_cross_event = AltitudeCrossEvent(thresh_alt, R)
+    events = [altitude_cross_event]
+
+    def f(t0, u_, k):
+        du_kep = func_twobody(t0, u_, k)
+        ax, ay, az = atmospheric_drag_exponential(
+            t0, u_, k, R=R, C_D=C_D, A_over_m=A_over_m, H0=H0, rho0=rho0
+        )
+        du_ad = np.array([0, 0, 0, ax, ay, az])
+        return du_kep + du_ad
+
+    rr, _ = cowell(
+        Earth.k,
+        orbit.r,
+        orbit.v,
+        tofs,
+        events=events,
+        f=f,
+    )
+
+    assert_quantity_allclose(norm(rr[0].to(u.km).value) - thresh_alt, R)
+    assert_quantity_allclose(altitude_cross_event.last_t, t_flight, rtol=1e-2)
+
+
+def test_altitude_cross_not_happening_is_ok():
+    R = Earth.R.to(u.km).value
+
+    orbit = Orbit.circular(Earth, 230 * u.km)
+
+    tofs = [25] * u.d
+
+    thresh_alt = 50  # km
+    altitude_cross_event = AltitudeCrossEvent(thresh_alt, R)
+    events = [altitude_cross_event]
+
+    rr, _ = cowell(
+        Earth.k,
+        orbit.r,
+        orbit.v,
+        tofs,
+        events=events,
+    )
+
+    assert altitude_cross_event.last_t == tofs[-1]


### PR DESCRIPTION
In this pull request, an attempt has been made to include altitude crossing detection. The structure seems to be similar to `LithobrakeEvent`.


Orekit's implementation stops propagation if the altitude starts to get lower than the threshold but continues propagation while ascending. Here, even though there are `terminal` and `direction` attributes, I immediately couldn't find a way to handle both at the same time, i.e. if `direction` is from up to down, `terminal=False` and if `direction` is down to up, `terminal=True`. But this might be done in some way...

- [ ] Based on the above, handle the `terminal` attribute? 

**Question**

- Is it a good choice to have a default threshold altitude or should the user compulsorily pass it?
- It seems there is currently no way to get an orbit's altitude (eg: `orbit.alt`)? If it looks like a plausible addition, `H - self._R` can be changed to `orbit.alt`.

Thanks!