### PR TITLE
Add some more tests and checks

### DIFF
--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -673,6 +673,8 @@ class Orbit:
             Fundamental plane of the frame.
 
         """
+        if alt < 0:
+            raise ValueError("Altitude of an orbit cannot be negative.")
         a = attractor.R + alt
         ecc = 0 * u.one
         argp = 0 * u.deg
@@ -1019,7 +1021,8 @@ class Orbit:
                     f"This has not been implemented for {attractor.name}"
                 )
 
-            assert alt > 0
+            if alt < 0:
+                raise ValueError("Altitude of an orbit cannot be negative")
 
             argp = critical_argps[0] if argp is None else argp
             a = attractor.R + alt
@@ -1063,7 +1066,7 @@ class Orbit:
 
         except AssertionError as exc:
             raise ValueError(
-                f"The semimajor axis may not be smaller that {attractor.name}'s radius"
+                f"The semimajor axis may not be smaller than the {attractor.name}'s radius"
             ) from exc
 
     def represent_as(self, representation, differential_class=None):

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -74,9 +74,9 @@ def cowell(k, r, v, tofs, rtol=1e-11, *, events=None, f=func_twobody):
 
     Note
     -----
-    This method uses a Dormand & Prince method of order 8(5,3) available
-    in the :py:class:`poliastro.integrators` module. If multiple tofs
-    are provided, the method propagates to the maximum value and
+    This method uses the `solve_ivp` method from `scipy.integrate` using the
+    Dormand & Prince integration method of order 8(5,3) (DOP853).
+    If multiple tofs are provided, the method propagates to the maximum value and
     calculates the other values via dense output
 
     """
@@ -501,5 +501,5 @@ HYPERBOLIC_PROPAGATORS = [
     cowell,
 ]
 ALL_PROPAGATORS = list(
-    set(ELLIPTIC_PROPAGATORS) & set(PARABOLIC_PROPAGATORS) & set(HYPERBOLIC_PROPAGATORS)
+    set(ELLIPTIC_PROPAGATORS + PARABOLIC_PROPAGATORS + HYPERBOLIC_PROPAGATORS)
 )

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -451,7 +451,7 @@ def propagate(orbit, time_of_flight, *, method=farnocchia, rtol=1e-10, **kwargs)
     # Check if propagator fulfills orbit requirements
     if orbit.ecc < 1.0 and method not in ELLIPTIC_PROPAGATORS:
         raise ValueError(
-            "Can not use an parabolic/hyperbolic propagator for elliptical orbits."
+            "Can not use an parabolic/hyperbolic propagator for elliptical/circular orbits."
         )
     elif orbit.ecc == 1.0 and method not in PARABOLIC_PROPAGATORS:
         raise ValueError(
@@ -472,10 +472,6 @@ def propagate(orbit, time_of_flight, *, method=farnocchia, rtol=1e-10, **kwargs)
         rtol=rtol,
         **kwargs
     )
-
-    # TODO: Turn these into unit tests
-    assert rr.ndim == 2
-    assert vv.ndim == 2
 
     cartesian = CartesianRepresentation(
         rr, differentials=CartesianDifferential(vv, xyz_axis=1), xyz_axis=1

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -55,7 +55,7 @@ def cowell(k, r, v, tofs, rtol=1e-11, *, events=None, f=func_twobody):
     rtol : float, optional
         Maximum relative error permitted, default to 1e-10.
     events : function(t, u(t)), optional
-        passed to solve_ivp: integration stops when this function
+        Passed to `solve_ivp`: Integration stops when this function
         returns <= 0., assuming you set events.terminal=True
     f : function(t0, u, k), optional
         Objective function, default to Keplerian-only forces.
@@ -76,8 +76,8 @@ def cowell(k, r, v, tofs, rtol=1e-11, *, events=None, f=func_twobody):
     -----
     This method uses the `solve_ivp` method from `scipy.integrate` using the
     Dormand & Prince integration method of order 8(5,3) (DOP853).
-    If multiple tofs are provided, the method propagates to the maximum value and
-    calculates the other values via dense output
+    If multiple tofs are provided, the method propagates to the maximum value
+    (unless a terminal event is defined) and calculates the other values via dense output.
 
     """
     k = k.to(u.km ** 3 / u.s ** 2).value

--- a/tests/test_czml.py
+++ b/tests/test_czml.py
@@ -859,3 +859,42 @@ def test_czml_invalid_orbit_epoch_error():
         "ValueError: The orbit's epoch cannot exceed the constructor's ending epoch"
         in excinfo.exconly()
     )
+
+
+@pytest.mark.skipif("czml3" not in sys.modules, reason="requires czml3")
+def test_czml_add_ground_station_raises_error_if_invalid_coordinates():
+    start_epoch = iss.epoch
+    end_epoch = iss.epoch + molniya.period
+    sample_points = 10
+
+    extractor = CZMLExtractor(start_epoch, end_epoch, sample_points)
+
+    with pytest.raises(TypeError) as excinfo:
+        extractor.add_ground_station([0.70930 * u.rad])
+
+    assert (
+        "Invalid coordinates. Coordinates must be of the form [u, v] where u, v are astropy units"
+        in excinfo.exconly()
+    )
+
+
+@pytest.mark.skipif("czml3" not in sys.modules, reason="requires czml3")
+def test_czml_add_trajectory_raises_error_for_groundtrack_show():
+    start_epoch = iss.epoch
+    end_epoch = iss.epoch + molniya.period
+
+    sample_points = 10
+
+    x = u.Quantity([1.0, 2.0, 3.0], u.m)
+    y = u.Quantity([4.0, 5.0, 6.0], u.m)
+    z = u.Quantity([7.0, 8.0, 9.0], u.m)
+    positions = CartesianRepresentation(x, y, z)
+
+    time = ["2010-01-01T05:00:00", "2010-01-01T05:00:30", "2010-01-01T05:01:00"]
+    epochs = Time(time, format="isot")
+
+    extractor = CZMLExtractor(start_epoch, end_epoch, sample_points)
+
+    with pytest.raises(NotImplementedError) as excinfo:
+        extractor.add_trajectory(positions, epochs, groundtrack_show=True)
+    assert "Ground tracking for trajectory not implemented yet" in excinfo.exconly()

--- a/tests/test_czml.py
+++ b/tests/test_czml.py
@@ -16,8 +16,9 @@ try:
 except ImportError:
     pass
 
+pytestmark = pytest.mark.skipif("czml3" not in sys.modules, reason="requires czml3")
 
-@pytest.mark.skipif("czml3" not in sys.modules, reason="requires czml3")
+
 def test_czml_get_document():
     start_epoch = iss.epoch
     end_epoch = iss.epoch + molniya.period
@@ -31,7 +32,6 @@ def test_czml_get_document():
     assert repr(doc) == repr(expected_doc)
 
 
-@pytest.mark.skipif("czml3" not in sys.modules, reason="requires czml3")
 def test_czml_custom_packet():
     start_epoch = iss.epoch
     end_epoch = iss.epoch + molniya.period
@@ -74,7 +74,6 @@ def test_czml_custom_packet():
     assert repr(pckt) == expected_packet
 
 
-@pytest.mark.skipif("czml3" not in sys.modules, reason="requires czml3")
 @pytest.mark.xfail(
     strict=False,
     reason="Numerical differences in propagation affect the results, we should change this test",
@@ -426,7 +425,6 @@ def expected_doc_add_trajectory():
     return expected_doc
 
 
-@pytest.mark.skipif("czml3" not in sys.modules, reason="requires czml3")
 def test_czml_add_trajectory(expected_doc_add_trajectory):
     start_epoch = iss.epoch
     end_epoch = iss.epoch + molniya.period
@@ -449,7 +447,6 @@ def test_czml_add_trajectory(expected_doc_add_trajectory):
     assert repr(extractor.packets) == expected_doc_add_trajectory
 
 
-@pytest.mark.skipif("czml3" not in sys.modules, reason="requires czml3")
 def test_czml_raises_error_if_length_of_points_and_epochs_not_same():
     start_epoch = iss.epoch
     end_epoch = iss.epoch + molniya.period
@@ -471,7 +468,6 @@ def test_czml_raises_error_if_length_of_points_and_epochs_not_same():
     assert "Number of Points and Epochs must be equal." in excinfo.exconly()
 
 
-@pytest.mark.skipif("czml3" not in sys.modules, reason="requires czml3")
 def test_czml_groundtrack():
 
     start_epoch = molniya.epoch
@@ -699,7 +695,6 @@ def test_czml_groundtrack():
     assert repr(extractor.packets) == expected_doc
 
 
-@pytest.mark.skipif("czml3" not in sys.modules, reason="requires czml3")
 def test_czml_ground_station():
     start_epoch = iss.epoch
     end_epoch = iss.epoch + molniya.period
@@ -797,7 +792,6 @@ def test_czml_ground_station():
     assert repr(extractor.packets) == expected_doc
 
 
-@pytest.mark.skipif("czml3" not in sys.modules, reason="requires czml3")
 def test_czml_preamble():
     """
     This test checks the basic preamble (preamble is the only mandatory
@@ -846,7 +840,6 @@ def test_czml_preamble():
     assert repr(extractor.packets) == expected_doc
 
 
-@pytest.mark.skipif("czml3" not in sys.modules, reason="requires czml3")
 def test_czml_invalid_orbit_epoch_error():
     start_epoch = molniya.epoch
     end_epoch = molniya.epoch + molniya.period
@@ -861,7 +854,6 @@ def test_czml_invalid_orbit_epoch_error():
     )
 
 
-@pytest.mark.skipif("czml3" not in sys.modules, reason="requires czml3")
 def test_czml_add_ground_station_raises_error_if_invalid_coordinates():
     start_epoch = iss.epoch
     end_epoch = iss.epoch + molniya.period
@@ -878,7 +870,6 @@ def test_czml_add_ground_station_raises_error_if_invalid_coordinates():
     )
 
 
-@pytest.mark.skipif("czml3" not in sys.modules, reason="requires czml3")
 def test_czml_add_trajectory_raises_error_for_groundtrack_show():
     start_epoch = iss.epoch
     end_epoch = iss.epoch + molniya.period

--- a/tests/tests_twobody/test_orbit.py
+++ b/tests/tests_twobody/test_orbit.py
@@ -188,6 +188,12 @@ def test_circular_has_proper_semimajor_axis():
     assert ss.a == expected_a
 
 
+def test_circular_raises_error_if_negative_altitude():
+    with pytest.raises(ValueError) as excinfo:
+        Orbit.circular(Earth, -1 * u.m, epoch=Time(0.0, format="jd", scale="tdb"))
+    assert "Altitude of an orbit cannot be negative." in excinfo.exconly()
+
+
 def test_geosync_has_proper_period():
     expected_period = 1436 * u.min
 
@@ -326,7 +332,7 @@ def test_frozen_orbit_venus_special_case():
     with pytest.raises(NotImplementedError) as excinfo:
         Orbit.frozen(Venus, 1 * u.m)
     assert excinfo.type == NotImplementedError
-    assert str(excinfo.value) == "This has not been implemented for Venus"
+    assert "This has not been implemented for Venus" in excinfo.exconly()
 
 
 def test_frozen_orbit_non_spherical_arguments():
@@ -334,8 +340,7 @@ def test_frozen_orbit_non_spherical_arguments():
         Orbit.frozen(Jupiter, 1 * u.m)
     assert excinfo.type == AttributeError
     assert (
-        str(excinfo.value)
-        == "Attractor Jupiter has not spherical harmonics implemented"
+        "Attractor Jupiter has not spherical harmonics implemented" in excinfo.exconly()
     )
 
 
@@ -343,10 +348,7 @@ def test_frozen_orbit_altitude():
     with pytest.raises(ValueError) as excinfo:
         Orbit.frozen(Earth, -1 * u.m)
     assert excinfo.type == ValueError
-    assert (
-        str(excinfo.value)
-        == "The semimajor axis may not be smaller that Earth's radius"
-    )
+    assert "Altitude of an orbit cannot be negative" in excinfo.exconly()
 
 
 def test_orbit_representation():
@@ -665,7 +667,7 @@ def test_synchronous_orbit_pericenter_smaller_than_atractor_radius(
     with pytest.raises(ValueError) as excinfo:
         Orbit.synchronous(attractor=attractor, ecc=ecc)
     assert excinfo.type == ValueError
-    assert str(excinfo.value) == "The orbit for the given parameters doesn't exist"
+    assert "The orbit for the given parameters doesn't exist" in excinfo.exconly()
 
 
 @pytest.mark.parametrize(
@@ -1032,8 +1034,8 @@ def test_from_sbdb_raise_valueerror():
         Orbit.from_sbdb(name="Halley")
 
     assert (
-        str(excinfo.value)
-        == "2 different objects found: \n2688 Halley (1982 HG1)\n1P/Halley\n"
+        "2 different objects found: \n2688 Halley (1982 HG1)\n1P/Halley\n"
+        in excinfo.exconly()
     )
 
 

--- a/tests/tests_twobody/test_orbit.py
+++ b/tests/tests_twobody/test_orbit.py
@@ -1034,7 +1034,7 @@ def test_from_sbdb_raise_valueerror():
         Orbit.from_sbdb(name="Halley")
 
     assert (
-        "2 different objects found: \n2688 Halley (1982 HG1)\n1P/Halley\n"
+        "2 different objects found: \n2688 Halley (1982 HG1)\n1P/Halley"
         in excinfo.exconly()
     )
 

--- a/tests/tests_twobody/test_propagation.py
+++ b/tests/tests_twobody/test_propagation.py
@@ -463,3 +463,22 @@ def test_propagator_with_zero_eccentricity(propagator):
     assert_quantity_allclose(orbit.inc, res.inc)
     assert_quantity_allclose(orbit.raan, res.raan)
     assert_quantity_allclose(orbit.argp, res.argp)
+
+
+@pytest.mark.parametrize("propagator", ALL_PROPAGATORS)
+def test_after_propagation_r_and_v_dimensions(propagator):
+    r0 = [111.340, -228.343, 2413.423] * u.km
+    v0 = [-5.64305, 4.30333, 2.42879] * u.km / u.s
+    tof = time.TimeDelta(50 * u.s)
+    orbit = Orbit.from_vectors(Earth, r0, v0)
+
+    rr, vv = propagator(
+        orbit.attractor.k,
+        orbit.r,
+        orbit.v,
+        tof.reshape(-1).to(u.s),
+        rtol=1e-10,
+    )
+
+    assert rr.ndim == 2
+    assert vv.ndim == 2


### PR DESCRIPTION
This pull request is a continuation of addition of some tests and checks.

- The altitude checks were added to prevent creation of an orbit with negative altitude. This might yield unexpected results at some places, for example, in the lithobrake event.

**Questions**

- It looks like `@pytest.mark.skipif("czml3" not in sys.modules, reason="requires czml3")` gets repeated for each test in `test_czml.py`. Could we instead have a global `pytestmark` to skip the whole module if `czml3` is not installed?

```python
pytestmark = pytest.mark.skipif("czml3" not in sys.modules)
```

- `ALL_PROPAGATORS` in `twobody/propagation.py`  seem to not contain `markley` and `danby`. This seems to be contrary to the name of the variable. Is this expected? If not, should we include all the propagators in `ALL_PROPAGATORS`?

- In #1253, you had advised to make `expected_doc` as a fixture. It seems that there are more `expected_doc`'s inside the tests. Is it necessary to have a fixture for each of them?

@astrojuanlu Could you let me know what do you think about the above questions?

Thanks!