### PR TITLE
General `LOS` for `LOSEvent`

### DIFF
--- a/src/poliastro/core/events.py
+++ b/src/poliastro/core/events.py
@@ -77,11 +77,6 @@ def line_of_sight(r1, r2, R):
 
     """
     r1_norm = np.linalg.norm(r1)
-    if r1_norm <= R:
-        raise ValueError(
-            "The norm of the position vector r_1 is less than the radius of the attractor."
-        )
-
     r2_norm = np.linalg.norm(r2)
 
     theta = np.arccos(np.dot(r1, r2) / r1_norm / r2_norm)

--- a/src/poliastro/core/events.py
+++ b/src/poliastro/core/events.py
@@ -54,3 +54,15 @@ def eclipse_function(k, u_, r_sec, R_sec, R_primary, umbra=True):
     )
 
     return shadow_function
+
+
+@jit
+def line_of_sight(r1, r2, R):
+    r1_norm = np.linalg.norm(r1)
+    r2_norm = np.linalg.norm(r2)
+
+    theta = np.arccos(np.dot(r1, r2) / r1_norm / r2_norm)
+    theta_1 = np.arccos(R / r1_norm)
+    theta_2 = np.arccos(R / r2_norm)
+
+    return theta <= theta_1 + theta_2

--- a/src/poliastro/core/events.py
+++ b/src/poliastro/core/events.py
@@ -58,11 +58,34 @@ def eclipse_function(k, u_, r_sec, R_sec, R_primary, umbra=True):
 
 @jit
 def line_of_sight(r1, r2, R):
+    """Calculates the line of sight condition between two position vectors, r1 and r2.
+
+    Parameters
+    ----------
+    r1: ~np.array
+        The position vector of the first object with respect to a central attractor.
+    r2: ~np.array
+        The position vector of the second object with respect to a central attractor.
+    R: float
+        The radius of the central attractor.
+
+    Returns
+    -------
+    delta_theta: float
+        Greater than or equal to zero, if there exists a LOS between two objects
+        located by r1 and r2, else negative.
+
+    """
     r1_norm = np.linalg.norm(r1)
+    if r1_norm <= R:
+        raise ValueError(
+            "The norm of the position vector r_1 is less than the radius of the attractor."
+        )
+
     r2_norm = np.linalg.norm(r2)
 
     theta = np.arccos(np.dot(r1, r2) / r1_norm / r2_norm)
     theta_1 = np.arccos(R / r1_norm)
     theta_2 = np.arccos(R / r2_norm)
 
-    return theta <= theta_1 + theta_2
+    return (theta_1 + theta_2) - theta

--- a/src/poliastro/twobody/events.py
+++ b/src/poliastro/twobody/events.py
@@ -1,3 +1,5 @@
+from warnings import warn
+
 import numpy as np
 from astropy import units as u
 from astropy.coordinates import get_body_barycentric_posvel
@@ -270,6 +272,11 @@ class LosEvent(Event):
 
     def __call__(self, t, u_, k):
         self._last_t = t
+
+        if norm(u_[:3]) < self._R:
+            warn(
+                "The norm of the position vector of the primary body is less than the radius of the attractor."
+            )
 
         pos_coord = self._pos_coords.pop(0) if self._pos_coords else self._last_coord
 

--- a/src/poliastro/twobody/events.py
+++ b/src/poliastro/twobody/events.py
@@ -3,7 +3,10 @@ from astropy import units as u
 from astropy.coordinates import get_body_barycentric_posvel
 from numpy.linalg import norm
 
-from poliastro.core.events import eclipse_function as eclipse_function_fast
+from poliastro.core.events import (
+    eclipse_function as eclipse_function_fast,
+    line_of_sight as line_of_sight_fast,
+)
 from poliastro.core.spheroid_location import (
     cartesian_to_ellipsoidal as cartesian_to_ellipsoidal_fast,
 )
@@ -241,3 +244,35 @@ class NodeCrossEvent(Event):
         self._last_t = t
         # Check if the z coordinate of the satellite is zero.
         return u_[2]
+
+
+class LosEvent(Event):
+    """Detect whether there exists a LOS between two satellites.
+
+    Parameters
+    ----------
+    attractor: ~poliastro.bodies.body
+        The central attractor with respect to which the position vectors of the satellites are defined.
+    pos_coords: ~astropy.quantity.Quantity
+        A list of position coordinates for the secondary body. These coordinates
+        can be found by propagating the body for a desired amount of time.
+
+    """
+
+    def __init__(self, attractor, pos_coords, terminal=False, direction=0):
+        super().__init__(terminal, direction)
+        self._attractor = attractor
+        self._pos_coords = (pos_coords << u.km).value.tolist()
+        self._last_coord = (
+            self._pos_coords[-1] << u.km
+        ).value  # Used to prevent any errors if `self._pos_coords` gets exhausted early.
+        self._R = self._attractor.R.to_value(u.km)
+
+    def __call__(self, t, u_, k):
+        self._last_t = t
+
+        pos_coord = self._pos_coords.pop(0) if self._pos_coords else self._last_coord
+
+        # Need to cast `pos_coord` to array since `norm` inside numba only works for arrays, not lists.
+        delta_angle = line_of_sight_fast(u_[:3], np.array(pos_coord), self._R)
+        return delta_angle

--- a/tests/tests_twobody/test_events.py
+++ b/tests/tests_twobody/test_events.py
@@ -7,12 +7,14 @@ from numpy.linalg import norm
 
 from poliastro.bodies import Earth
 from poliastro.constants import H0_earth, rho0_earth
+from poliastro.core.events import line_of_sight
 from poliastro.core.perturbations import atmospheric_drag_exponential
 from poliastro.core.propagation import func_twobody
 from poliastro.twobody import Orbit
 from poliastro.twobody.events import (
     AltitudeCrossEvent,
     LatitudeCrossEvent,
+    LosEvent,
     NodeCrossEvent,
     PenumbraEvent,
     UmbraEvent,
@@ -349,3 +351,56 @@ def test_propagation_stops_if_atleast_one_event_has_terminal_set_to_True(
         assert_quantity_allclose(latitude_cross_event.last_t, t_end)
     else:
         assert_quantity_allclose(t_end, tofs[-1])
+
+
+def test_line_of_sight():
+    # From Vallado example 5.6
+    r1 = np.array([0, -4464.696, -5102.509]) << u.km
+    r2 = np.array([0, 5740.323, 3189.068]) << u.km
+    r_sun = np.array([122233179, -76150708, 33016374]) << u.km
+    R = Earth.R.to(u.km).value
+
+    los = line_of_sight(r1.value, r2.value, R)
+    los_with_sun = line_of_sight(r1.value, r_sun.value, R)
+
+    assert los < 0  # No LOS condition.
+    assert los_with_sun >= 0  # LOS condition.
+
+
+def test_LOS_event_raises_error_if_norm_of_r1_less_than_attractor_radius_during_propagation():
+    r2 = np.array([-500, 1500, 4012.09]) << u.km
+    v2 = np.array([5021.38, -2900.7, 1000.354]) << u.km / u.s
+    orbit = Orbit.from_vectors(Earth, r2, v2)
+
+    tofs = [100, 500, 1000, 2000] << u.s
+    # Propagate the secondary body to generate its position coordinates.
+    rr, vv = cowell(
+        Earth.k,
+        orbit.r,
+        orbit.v,
+        tofs,
+    )
+    pos_coords = rr  # Trajectory of the secondary body.
+
+    r1 = (
+        np.array([0, -5010.696, -5102.509]) << u.km
+    )  # This position vectors' norm gets less than attractor radius.
+    v1 = np.array([736.138, 29899.7, 164.354]) << u.km / u.s
+    orb = Orbit.from_vectors(Earth, r1, v1)
+
+    los_event = LosEvent(Earth, pos_coords, terminal=True)
+    events = [los_event]
+    tofs = [0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.5] << u.s
+
+    with pytest.raises(ValueError) as excinfo:
+        r, v = cowell(
+            Earth.k,
+            orb.r,
+            orb.v,
+            tofs,
+            events=events,
+        )
+    assert (
+        "The norm of the position vector r_1 is less than the radius of the attractor"
+        in excinfo.exconly()
+    )

--- a/tests/tests_twobody/test_events.py
+++ b/tests/tests_twobody/test_events.py
@@ -14,6 +14,7 @@ from poliastro.twobody import Orbit
 from poliastro.twobody.events import (
     AltitudeCrossEvent,
     LatitudeCrossEvent,
+    LithobrakeEvent,
     LosEvent,
     NodeCrossEvent,
     PenumbraEvent,
@@ -367,7 +368,7 @@ def test_line_of_sight():
     assert los_with_sun >= 0  # LOS condition.
 
 
-def test_LOS_event_raises_error_if_norm_of_r1_less_than_attractor_radius_during_propagation():
+def test_LOS_event_raises_warning_if_norm_of_r1_less_than_attractor_radius_during_propagation():
     r2 = np.array([-500, 1500, 4012.09]) << u.km
     v2 = np.array([5021.38, -2900.7, 1000.354]) << u.km / u.s
     orbit = Orbit.from_vectors(Earth, r2, v2)
@@ -392,7 +393,7 @@ def test_LOS_event_raises_error_if_norm_of_r1_less_than_attractor_radius_during_
     events = [los_event]
     tofs = [0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.5] << u.s
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.warns(UserWarning, match="The norm of the position vector"):
         r, v = cowell(
             Earth.k,
             orb.r,
@@ -400,7 +401,74 @@ def test_LOS_event_raises_error_if_norm_of_r1_less_than_attractor_radius_during_
             tofs,
             events=events,
         )
-    assert (
-        "The norm of the position vector r_1 is less than the radius of the attractor"
-        in excinfo.exconly()
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_LOS_event_with_lithobrake_event_raises_warning_when_satellite_cuts_attractor():
+    r2 = np.array([-500, 1500, 4012.09]) << u.km
+    v2 = np.array([5021.38, -2900.7, 1000.354]) << u.km / u.s
+    orbit = Orbit.from_vectors(Earth, r2, v2)
+
+    tofs = [100, 500, 1000, 2000] << u.s
+    # Propagate the secondary body to generate its position coordinates.
+    rr, vv = cowell(
+        Earth.k,
+        orbit.r,
+        orbit.v,
+        tofs,
     )
+    pos_coords = rr  # Trajectory of the secondary body.
+
+    r1 = np.array([0, -5010.696, -5102.509]) << u.km
+    v1 = np.array([736.138, 2989.7, 164.354]) << u.km / u.s
+    orb = Orbit.from_vectors(Earth, r1, v1)
+
+    los_event = LosEvent(Earth, pos_coords, terminal=True)
+    tofs = [0.003, 0.004, 0.01, 0.02, 0.03, 0.04, 0.07, 0.1, 0.2, 0.3, 0.4, 1, 3] << u.s
+
+    lithobrake_event = LithobrakeEvent(Earth.R.to_value(u.km))
+    events = [lithobrake_event, los_event]
+    r, v = cowell(
+        Earth.k,
+        orb.r,
+        orb.v,
+        tofs,
+        events=events,
+    )
+
+    assert lithobrake_event.last_t < los_event.last_t
+
+
+def test_LOS_event():
+    t_los = 2327.165 * u.s
+    r2 = np.array([-500, 1500, 4012.09]) << u.km
+    v2 = np.array([5021.38, -2900.7, 1000.354]) << u.km / u.s
+    orbit = Orbit.from_vectors(Earth, r2, v2)
+
+    tofs = [100, 500, 1000, 2000] << u.s
+    # Propagate the secondary body to generate its position coordinates.
+    rr, vv = cowell(
+        Earth.k,
+        orbit.r,
+        orbit.v,
+        tofs,
+    )
+    pos_coords = rr  # Trajectory of the secondary body.
+
+    orb = Orbit.from_classical(
+        Earth, 16000 * u.km, 0.53 * u.one, 5 * u.deg, 5 * u.deg, 10 * u.deg, 30 * u.deg
+    )
+
+    los_event = LosEvent(Earth, pos_coords, terminal=True)
+    events = [los_event]
+    tofs = [1, 5, 10, 100, 1000, 2000, 3000, 5000] << u.s
+
+    r, v = cowell(
+        Earth.k,
+        orb.r,
+        orb.v,
+        tofs,
+        events=events,
+    )
+
+    assert_quantity_allclose(los_event.last_t, t_los)


### PR DESCRIPTION
The current `shadow_function` used trigonometric manipulation (from Howard Curtis). In this pull request:

- An attempt has been made to add a general line of sight functionality that can be used to detect LOS between any given two position vectors (eg: between two satellites, or between a satellite and the Sun).
- `shadow_function` has been modified to use this general LOS implementation.

Currently, the LOS function allows both ellipsoidal and circular shape of the attractor, but I think bodies are taken to be a general case of ellipsoid. So the existence of the `ellipsoid` parameter in the functions might be in doubt.

---
This was an older comment :)

Thanks!