### PR TITLE
DOC: remove myst_parser extension

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,7 +52,6 @@ extensions = [
     'sphinx.ext.graphviz',  # Dependency diagrams
     'notfound.extension',
     'hoverxref.extension',
-    'myst_parser',
 ]
 
 # Hoverxref Extension
@@ -367,5 +366,3 @@ exclude_patterns.append('_autoapi_templates/python/module.rst')
 
 # Ignore sphinx-autoapi warnings on multiple target description
 suppress_warnings.append('ref.python')
-
-myst_update_mathjax = False

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -353,6 +353,7 @@ nbsphinx_thumbnails = {
 
 nbsphinx_custom_formats = {
     '.mystnb': ['jupytext.reads', {'fmt': 'mystnb'}],
+    '.md': ['jupytext.reads', {'fmt': 'Rmd'}],
 }
 
 # The sphinx-autoapi tool configuration


### PR DESCRIPTION
I'm not quite sure how `nbsphinx` and `myst_parser` interact, but I think latter isn't needed (because it is used only indirectly by Jupytext).

I haven't installed everything locally, so I'll try it here with the RTD integration.