### PR TITLE
Lat and Lon detector

### DIFF
--- a/src/poliastro/twobody/events.py
+++ b/src/poliastro/twobody/events.py
@@ -95,7 +95,7 @@ class LatitudeCrossEvent(Event):
     orbit: ~poliastro.twobody.orbit.Orbit
         Orbit.
     lat: astropy.quantity.Quantity
-        Threshold latitude (in degrees).
+        Threshold latitude.
     terminal: bool
         Whether to terminate integration if this event occurs, defaults to True.
     direction: float

--- a/src/poliastro/twobody/events.py
+++ b/src/poliastro/twobody/events.py
@@ -1,13 +1,13 @@
 from astropy import units as u
-from numpy.linalg import norm
-
-from astropy.time import Time
 from astropy.coordinates import (
     GCRS,
     ITRS,
     CartesianRepresentation,
     SphericalRepresentation,
 )
+from astropy.time import Time
+from numpy.linalg import norm
+
 
 class Event:
     """Base class for event functionalities.
@@ -105,6 +105,7 @@ class LatitudeCrossEvent(Event):
         or below, defaults to 0, i.e., event is triggered while traversing from both directions.
 
     """
+
     def __init__(self, lat, R, terminal=True, direction=0):
         super().__init__(terminal, direction)
         self._R = R
@@ -116,7 +117,9 @@ class LatitudeCrossEvent(Event):
 
         obstime = Time(self._last_t, format="jd")
         gcrs_xyz = GCRS(
-            xyz, obstime=obstime, representation_type=CartesianRepresentation,
+            xyz,
+            obstime=obstime,
+            representation_type=CartesianRepresentation,
         )
         itrs_xyz = gcrs_xyz.transform_to(ITRS(obstime=obstime))
         itrs_latlon_pos = itrs_xyz.represent_as(SphericalRepresentation)
@@ -140,6 +143,7 @@ class LongitudeCrossEvent(Event):
         or below, defaults to 0, i.e., event is triggered while traversing from both directions.
 
     """
+
     def __init__(self, lon, R, terminal=True, direction=0):
         super().__init__(terminal, direction)
         self._R = R
@@ -151,7 +155,9 @@ class LongitudeCrossEvent(Event):
 
         obstime = Time(self._last_t, format="jd")
         gcrs_xyz = GCRS(
-            xyz, obstime=obstime, representation_type=CartesianRepresentation,
+            xyz,
+            obstime=obstime,
+            representation_type=CartesianRepresentation,
         )
         itrs_xyz = gcrs_xyz.transform_to(ITRS(obstime=obstime))
         itrs_latlon_pos = itrs_xyz.represent_as(SphericalRepresentation)

--- a/src/poliastro/twobody/events.py
+++ b/src/poliastro/twobody/events.py
@@ -111,9 +111,9 @@ class LatitudeCrossEvent(Event):
         self._R = R
         self._lat = lat  # Threshold latitude (in degrees).
 
-    def __call__(self, t, u, k):
+    def __call__(self, t, u_, k):
         self._last_t = t
-        xyz = u[:3]
+        xyz = u_[:3]
 
         obstime = Time(self._last_t, format="jd")
         gcrs_xyz = GCRS(
@@ -123,7 +123,7 @@ class LatitudeCrossEvent(Event):
         )
         itrs_xyz = gcrs_xyz.transform_to(ITRS(obstime=obstime))
         itrs_latlon_pos = itrs_xyz.represent_as(SphericalRepresentation)
-        orbit_lat = itrs_latlon_pos.lat.value
+        orbit_lat = itrs_latlon_pos.lat.to(u.deg).value
         return self._lat - orbit_lat
 
 
@@ -149,9 +149,9 @@ class LongitudeCrossEvent(Event):
         self._R = R
         self._lon = lon  # Threshold longitude (in degrees).
 
-    def __call__(self, t, u, k):
+    def __call__(self, t, u_, k):
         self._last_t = t
-        xyz = u[:3]
+        xyz = u_[:3]
 
         obstime = Time(self._last_t, format="jd")
         gcrs_xyz = GCRS(
@@ -161,6 +161,6 @@ class LongitudeCrossEvent(Event):
         )
         itrs_xyz = gcrs_xyz.transform_to(ITRS(obstime=obstime))
         itrs_latlon_pos = itrs_xyz.represent_as(SphericalRepresentation)
-        orbit_lon = itrs_latlon_pos.lon.value
+        orbit_lon = itrs_latlon_pos.lon.to(u.deg).value
 
         return self._lon - orbit_lon

--- a/src/poliastro/twobody/events.py
+++ b/src/poliastro/twobody/events.py
@@ -1,6 +1,13 @@
 from astropy import units as u
 from numpy.linalg import norm
 
+from astropy.time import Time
+from astropy.coordinates import (
+    GCRS,
+    ITRS,
+    CartesianRepresentation,
+    SphericalRepresentation,
+)
 
 class Event:
     """Base class for event functionalities.
@@ -80,3 +87,74 @@ class LithobrakeEvent(AltitudeCrossEvent):
 
     def __init__(self, R, terminal=True):
         super().__init__(0, R, terminal, direction=-1)
+
+
+class LatitudeCrossEvent(Event):
+    """Detect if a satellite crosses a specific threshold latitude.
+
+    Parameters
+    ----------
+    lat: float
+        Threshold latitude (km).
+    R: float
+        Radius of the attractor (km).
+    terminal: bool
+        Whether to terminate integration if this event occurs, defaults to True.
+    direction: float
+        Handle triggering of event based on whether latitude is crossed from above
+        or below, defaults to 0, i.e., event is triggered while traversing from both directions.
+
+    """
+    def __init__(self, lat, R, terminal=True, direction=0):
+        super().__init__(terminal, direction)
+        self._R = R
+        self._lat = lat  # Threshold latitude (in degrees).
+
+    def __call__(self, t, u, k):
+        self._last_t = t
+        xyz = u[:3]
+
+        obstime = Time(self._last_t, format="jd")
+        gcrs_xyz = GCRS(
+            xyz, obstime=obstime, representation_type=CartesianRepresentation,
+        )
+        itrs_xyz = gcrs_xyz.transform_to(ITRS(obstime=obstime))
+        itrs_latlon_pos = itrs_xyz.represent_as(SphericalRepresentation)
+        orbit_lat = itrs_latlon_pos.lat.value
+        return self._lat - orbit_lat
+
+
+class LongitudeCrossEvent(Event):
+    """Detect if a satellite crosses a specific threshold latitude.
+
+    Parameters
+    ----------
+    lon: float
+        Threshold longitude (km).
+    R: float
+        Radius of the attractor (km).
+    terminal: bool
+        Whether to terminate integration if this event occurs, defaults to True.
+    direction: float
+        Handle triggering of event based on whether longitude is crossed from above
+        or below, defaults to 0, i.e., event is triggered while traversing from both directions.
+
+    """
+    def __init__(self, lon, R, terminal=True, direction=0):
+        super().__init__(terminal, direction)
+        self._R = R
+        self._lon = lon  # Threshold longitude (in degrees).
+
+    def __call__(self, t, u, k):
+        self._last_t = t
+        xyz = u[:3]
+
+        obstime = Time(self._last_t, format="jd")
+        gcrs_xyz = GCRS(
+            xyz, obstime=obstime, representation_type=CartesianRepresentation,
+        )
+        itrs_xyz = gcrs_xyz.transform_to(ITRS(obstime=obstime))
+        itrs_latlon_pos = itrs_xyz.represent_as(SphericalRepresentation)
+        orbit_lon = itrs_latlon_pos.lon.value
+
+        return self._lon - orbit_lon

--- a/src/poliastro/twobody/events.py
+++ b/src/poliastro/twobody/events.py
@@ -112,7 +112,9 @@ class LatitudeCrossEvent(Event):
         super().__init__(terminal, direction)
 
         if orbit.attractor != Earth:
-            raise NotImplementedError("Attractors other than the Earth are not supported yet.")
+            raise NotImplementedError(
+                "Attractors other than the Earth are not supported yet."
+            )
         self._R = orbit.attractor.R
         self._epoch = orbit.epoch
         self._lat = lat  # Threshold latitude (in degrees).
@@ -145,7 +147,7 @@ class LongitudeCrossEvent(Event):
     terminal: bool
         Whether to terminate integration if this event occurs, defaults to True.
     direction: float
-        Handle triggering of event based on whether latitude is crossed from above
+        Handle triggering of event based on whether longitude is crossed from above
         or below, defaults to 0, i.e., event is triggered while traversing from both directions.
 
     """
@@ -159,7 +161,7 @@ class LongitudeCrossEvent(Event):
             )
         self._R = orbit.attractor.R
         self._epoch = orbit.epoch
-        self._lon = lon  # Threshold latitude (in degrees).
+        self._lon = lon  # Threshold longitude (in degrees).
 
     def __call__(self, t, u_, k):
         self._last_t = t

--- a/src/poliastro/twobody/events.py
+++ b/src/poliastro/twobody/events.py
@@ -94,7 +94,7 @@ class LatitudeCrossEvent(Event):
     ----------
     orbit: ~poliastro.twobody.orbit.Orbit
         Orbit.
-    lat: float
+    lat: astropy.quantity.Quantity
         Threshold latitude (in degrees).
     terminal: bool
         Whether to terminate integration if this event occurs, defaults to True.
@@ -110,7 +110,7 @@ class LatitudeCrossEvent(Event):
         self._R = orbit.attractor.R
         self._R_polar = orbit.attractor.R_polar
         self._epoch = orbit.epoch
-        self._lat = lat  # Threshold latitude (in degrees).
+        self._lat = lat.to(u.deg).value  # Threshold latitude (in degrees).
 
     def __call__(self, t, u_, k):
         self._last_t = t

--- a/src/poliastro/twobody/events.py
+++ b/src/poliastro/twobody/events.py
@@ -107,8 +107,8 @@ class LatitudeCrossEvent(Event):
     def __init__(self, orbit, lat, terminal=True, direction=0):
         super().__init__(terminal, direction)
 
-        self._R = orbit.attractor.R
-        self._R_polar = orbit.attractor.R_polar
+        self._R = orbit.attractor.R.to(u.m).value
+        self._R_polar = orbit.attractor.R_polar.to(u.m).value
         self._epoch = orbit.epoch
         self._lat = lat.to(u.deg).value  # Threshold latitude (in degrees).
 

--- a/tests/tests_twobody/test_events.py
+++ b/tests/tests_twobody/test_events.py
@@ -10,7 +10,7 @@ from astropy.coordinates import (
 from astropy.tests.helper import assert_quantity_allclose
 from numpy.linalg import norm
 
-from poliastro.bodies import Earth
+from poliastro.bodies import Earth, Venus
 from poliastro.constants import H0_earth, rho0_earth
 from poliastro.core.perturbations import atmospheric_drag_exponential
 from poliastro.core.propagation import func_twobody
@@ -90,14 +90,45 @@ def test_altitude_cross_not_happening_is_ok():
     assert altitude_cross_event.last_t == tofs[-1]
 
 
-def test_latitude_longitude_cross_event():
-    R = Earth.R.to(u.km).value
+def test_latitude_event_raises_not_implemented_error_if_not_earth():
+    lat = 50 * u.deg  # Unused
+    orbit = Orbit.from_classical(
+        Venus,
+        1000 * u.km,
+        0.1 * u.one,
+        0 * u.deg,
+        0 * u.deg,
+        0 * u.deg,
+        0 * u.deg,
+    )
+    with pytest.raises(NotImplementedError) as excinfo:
+        LatitudeCrossEvent(orbit, lat)
+    assert "Attractors other than the Earth are not supported yet." in excinfo.exconly()
+
+
+def test_longitude_event_raises_not_implemented_error_if_not_earth():
+    lon = 50 * u.deg  # Unused
+    orbit = Orbit.from_classical(
+        Venus,
+        1000 * u.km,
+        0.1 * u.one,
+        0 * u.deg,
+        0 * u.deg,
+        0 * u.deg,
+        0 * u.deg,
+    )
+    with pytest.raises(NotImplementedError) as excinfo:
+        LongitudeCrossEvent(orbit, lon)
+    assert "Attractors other than the Earth are not supported yet." in excinfo.exconly()
+
+
+def test_latitude_cross_event():
     orbit = Orbit.circular(Earth, 230 * u.km)
 
-    t_lat = 1989.9932 * u.s
+    t_lat = 2036.314196 * u.s
 
     thresh_lat = 0 * u.deg
-    latitude_cross_event = LatitudeCrossEvent(thresh_lat.value, R)
+    latitude_cross_event = LatitudeCrossEvent(orbit, thresh_lat.value)
 
     tofs = [5] * u.d
 
@@ -124,14 +155,13 @@ def test_latitude_longitude_cross_event():
     assert_quantity_allclose(orbit_lat, thresh_lat, atol=1.2e-4 * u.deg)
 
 
-def test_longitude_cross():
-    R = Earth.R.to(u.km).value
+def test_longitude_cross_event():
     orbit = Orbit.circular(Earth, 230 * u.km)
 
-    t_lon = 0.06289492 * u.s
+    t_lon = 0.06289322 * u.s
 
     thresh_lon = 79.810036 * u.deg
-    longitude_cross_event = LongitudeCrossEvent(thresh_lon.value, R)
+    longitude_cross_event = LongitudeCrossEvent(orbit, thresh_lon.value)
 
     tofs = [5] * u.d
 

--- a/tests/tests_twobody/test_events.py
+++ b/tests/tests_twobody/test_events.py
@@ -9,7 +9,11 @@ from poliastro.constants import H0_earth, rho0_earth
 from poliastro.core.perturbations import atmospheric_drag_exponential
 from poliastro.core.propagation import func_twobody
 from poliastro.twobody import Orbit
-from poliastro.twobody.events import AltitudeCrossEvent
+from poliastro.twobody.events import (
+    AltitudeCrossEvent,
+    LatitudeCrossEvent,
+    LongitudeCrossEvent,
+)
 from poliastro.twobody.propagation import cowell
 
 
@@ -78,3 +82,52 @@ def test_altitude_cross_not_happening_is_ok():
     )
 
     assert altitude_cross_event.last_t == tofs[-1]
+
+
+def test_latitude_longitude_cross_event():
+    R = Earth.R.to(u.km).value
+    orbit = Orbit.circular(Earth, 230 * u.km)
+
+    t_lat = 1989.9932 * u.s
+
+    thresh_lat = 0 * u.deg
+    latitude_cross_event = LatitudeCrossEvent(thresh_lat.value, R)
+
+    tofs = [5] * u.d
+
+    events = [
+        latitude_cross_event,
+    ]  # longitude_cross_event]
+    rr, _ = cowell(
+        Earth.k,
+        orbit.r,
+        orbit.v,
+        tofs,
+        events=events,
+    )
+
+    assert_quantity_allclose(latitude_cross_event.last_t, t_lat)
+    assert_quantity_allclose()
+
+
+def test_longitude_cross():
+    R = Earth.R.to(u.km).value
+    orbit = Orbit.circular(Earth, 230 * u.km)
+
+    t_lon = 0.062894918 * u.s
+
+    thresh_lon = 3 * u.deg
+    longitude_cross_event = LongitudeCrossEvent(thresh_lon.value, R)
+
+    tofs = [5] * u.d
+
+    events = [longitude_cross_event]
+    rr, _ = cowell(
+        Earth.k,
+        orbit.r,
+        orbit.v,
+        tofs,
+        events=events,
+    )
+
+    assert_quantity_allclose(longitude_cross_event.last_t, t_lon)

--- a/tests/tests_twobody/test_events.py
+++ b/tests/tests_twobody/test_events.py
@@ -84,8 +84,7 @@ def test_altitude_cross_not_happening_is_ok():
 def test_latitude_cross_event():
     r = [-6142438.668, 3492467.56, -25767.257] << u.km
     v = [505.848, 942.781, 7435.922] << u.km / u.s
-    epoch = Time("2003-09-16", scale="utc")
-    orbit = Orbit.from_vectors(Earth, r, v, epoch)
+    orbit = Orbit.from_vectors(Earth, r, v)
 
     thresh_lat = 60 * u.deg
     latitude_cross_event = LatitudeCrossEvent(orbit, thresh_lat, terminal=True)

--- a/tests/tests_twobody/test_events.py
+++ b/tests/tests_twobody/test_events.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose
-from astropy.time import Time
 from numpy.linalg import norm
 
 from poliastro.bodies import Earth


### PR DESCRIPTION
A draft for detecting latitude and longitude crossing.

- [ ] Change ITRS and GCRS to account for a general attractor and not just the Earth.
- [ ] Find a way to get rid of the warnings from tests.