### PR TITLE
Some more tests

### DIFF
--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -888,7 +888,7 @@ class Orbit:
                         * R_SSO ** 2
                         * J2_SSO
                         * np.sqrt(k_SSO)
-                        * np.cos(inc.to(u.rad))
+                        * np.cos(inc)
                         / (2 * a ** (7 / 2) * n_sunsync)
                     )
                     ecc = np.sqrt(1 - _ecc_0)

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -870,7 +870,7 @@ class Orbit:
 
         try:
             with np.errstate(invalid="raise"):
-                if (a is None) and (ecc is None) and (inc is None):
+                if all(coe is None for coe in [a, ecc, inc]):
                     # We check sufficient number of parameters
                     raise ValueError(
                         "At least two parameters of the set {a, ecc, inc} are required."

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -855,6 +855,10 @@ class Orbit:
             Fundamental plane of the frame.
 
         """
+        # Temporary fix: raan_from_ltan works only for Earth
+        if attractor.name.lower() != "earth":
+            raise NotImplementedError("Attractors other than Earth not supported yet")
+
         mean_elements = get_mean_elements(attractor)
 
         n_sunsync = (
@@ -903,10 +907,6 @@ class Orbit:
                     )
         except FloatingPointError:
             raise ValueError("No SSO orbit with given parameters can be found.")
-
-        # Temporary fix: raan_from_ltan works only for Earth
-        if attractor.name.lower() != "earth":
-            raise NotImplementedError("Attractors other than Earth not supported yet")
 
         raan = raan_from_ltan(epoch, ltan)
         ss = cls.from_classical(

--- a/tests/tests_twobody/test_orbit.py
+++ b/tests/tests_twobody/test_orbit.py
@@ -760,18 +760,6 @@ def test_heliosynchronous_orbit_a():
     assert_quantity_allclose(ss0.ecc, expected_ecc)
 
 
-def test_heliosynchronous_orbit_inc():
-    # Vallado, example 11-2b
-    expected_ecc = 0.0 * u.one
-    expected_inc = 98.6 * u.deg
-    expected_a = 7178.1363 * u.km
-    ss0 = Orbit.heliosynchronous(Earth, a=expected_a, ecc=expected_ecc)
-
-    assert_quantity_allclose(ss0.inc, expected_inc, rtol=1e-4)
-    assert_quantity_allclose(ss0.a, expected_a, rtol=1e-5)
-    assert_quantity_allclose(ss0.ecc, expected_ecc)
-
-
 def test_heliosynchronous_orbit_ecc():
     # Vallado, example 11-2b
     expected_ecc = 0.0 * u.one

--- a/tests/tests_twobody/test_orbit.py
+++ b/tests/tests_twobody/test_orbit.py
@@ -790,7 +790,7 @@ def test_heliosynchronous_orbit_raises_floating_point_error_if_invalid_input():
     inc = 0 * u.rad
 
     with pytest.raises(ValueError) as excinfo:
-        orbit = Orbit.heliosynchronous(Earth, a=a, inc=inc)
+        Orbit.heliosynchronous(Earth, a=a, inc=inc)
     assert "No SSO orbit with given parameters can be found." in excinfo.exconly()
 
 

--- a/tests/tests_twobody/test_orbit.py
+++ b/tests/tests_twobody/test_orbit.py
@@ -769,7 +769,8 @@ def test_heliosynchronous_orbit_ecc():
 
     assert_quantity_allclose(ss0.inc, expected_inc, rtol=1e-4)
     assert_quantity_allclose(ss0.a, expected_a, rtol=1e-5)
-    assert_quantity_allclose(ss0.ecc, expected_ecc)
+    # Vallado uses a slightly different value for n_sunsync, hence `atol` needs to be added.
+    assert_quantity_allclose(ss0.ecc, expected_ecc, atol=1e-1)
 
 
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")

--- a/tests/tests_twobody/test_orbit.py
+++ b/tests/tests_twobody/test_orbit.py
@@ -760,6 +760,40 @@ def test_heliosynchronous_orbit_a():
     assert_quantity_allclose(ss0.ecc, expected_ecc)
 
 
+def test_heliosynchronous_orbit_inc():
+    # Vallado, example 11-2b
+    expected_ecc = 0.0 * u.one
+    expected_inc = 98.6 * u.deg
+    expected_a = 7178.1363 * u.km
+    ss0 = Orbit.heliosynchronous(Earth, a=expected_a, ecc=expected_ecc)
+
+    assert_quantity_allclose(ss0.inc, expected_inc, rtol=1e-4)
+    assert_quantity_allclose(ss0.a, expected_a, rtol=1e-5)
+    assert_quantity_allclose(ss0.ecc, expected_ecc)
+
+
+def test_heliosynchronous_orbit_ecc():
+    # Vallado, example 11-2b
+    expected_ecc = 0.0 * u.one
+    expected_inc = 98.6 * u.deg
+    expected_a = 7178.1363 * u.km
+    ss0 = Orbit.heliosynchronous(Earth, a=expected_a, inc=expected_inc)
+
+    assert_quantity_allclose(ss0.inc, expected_inc, rtol=1e-4)
+    assert_quantity_allclose(ss0.a, expected_a, rtol=1e-5)
+    assert_quantity_allclose(ss0.ecc, expected_ecc)
+
+
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+def test_heliosynchronous_orbit_raises_floating_point_error_if_invalid_input():
+    a = 0 * u.km
+    inc = 0 * u.rad
+
+    with pytest.raises(ValueError) as excinfo:
+        orbit = Orbit.heliosynchronous(Earth, a=a, inc=inc)
+    assert "No SSO orbit with given parameters can be found." in excinfo.exconly()
+
+
 def test_perigee_and_apogee():
     expected_r_a = 500 * u.km
     expected_r_p = 300 * u.km


### PR DESCRIPTION
Some tests for `heliosynchronous`.

### Questions

- Would it be a good option to check for the "unphysical" condition where `a` is less than the radius of Earth and if radius of perigee is less than radius of Earth), as stated in Vallado?
![Screenshot from 2021-07-04 17-30-28](https://user-images.githubusercontent.com/68844397/124384132-92039400-dced-11eb-972e-157c9d906db8.png).
- I think [this](https://github.com/poliastro/poliastro/blob/main/src/poliastro/twobody/orbit.py#L1067) exception would never be raised since [this](https://github.com/poliastro/poliastro/blob/main/src/poliastro/twobody/orbit.py#L1028) line ensures that and also given that the condition for `alt < 0` is already checked in one of the above lines. Would it be a good choice to remove raising that exception?

 Currently, if I try to create an orbit with a < radius of earth, then it doesn't give an error.

The test `test_heliosynchronous_orbit_ecc` fails, but I think it should have passed. That might need more investigation.

---
It seems the difference in expected eccentricities is of the order `1e-5` if I use these parameters:

```py
expected_ecc = 0.2 * u.one
expected_inc = 98.6 * u.deg
expected_a = 7346.846 * u.km
```
instead of the current parameters (giving errors of the order `1e-2`, which may not be negligible):

```py
expected_ecc = 0.0 * u.one
expected_inc = 98.6 * u.deg
expected_a = 7178.1363 * u.km
```

It looks like the calculation is not accurate, or am I missing something?

Thanks!