### PR TITLE
Continue propagation if `event.terminal` is `False`

### DIFF
--- a/docs/source/examples/Natural and artificial perturbations.mystnb
+++ b/docs/source/examples/Natural and artificial perturbations.mystnb
@@ -130,7 +130,7 @@ print("orbital decay seen after", lithobrake_event.last_t.to(u.d).value, "days")
 
 plt.ylabel("h(t)")
 plt.xlabel("t, days")
-plt.plot(tofs.value, rr.norm() - Earth.R)
+plt.plot(tofs[:len(rr)].value, rr.norm() - Earth.R)
 ```
 
 ## Evolution of RAAN due to the J2 perturbation

--- a/src/poliastro/twobody/events.py
+++ b/src/poliastro/twobody/events.py
@@ -106,7 +106,7 @@ class LatitudeCrossEvent(Event):
 
     """
 
-    def __init__(self, orbit, lat, terminal=True, direction=0):
+    def __init__(self, orbit, lat, terminal=False, direction=0):
         super().__init__(terminal, direction)
 
         self._R = orbit.attractor.R.to(u.m).value

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -113,11 +113,11 @@ def cowell(k, r, v, tofs, rtol=1e-11, *, events=None, f=func_twobody):
         else:
             # Filter the event which triggered first
             last_t = min([event.last_t for event in terminal_events]).to_value(u.s)
-            limiting_event = [event for event in terminal_events if event.last_t == last_t]
+            limiting_event = [
+                event for event in terminal_events if event.last_t == last_t
+            ]
 
-            tofs = [
-                tof for tof in tofs if tof < last_t
-            ] + [last_t]
+            tofs = [tof for tof in tofs if tof < last_t] + [last_t]
 
     rrs = []
     vvs = []

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -101,40 +101,28 @@ def cowell(k, r, v, tofs, rtol=1e-11, *, events=None, f=func_twobody):
     if not result.success:
         raise RuntimeError("Integration failed")
 
-    # t_end = (
-    #     min(result.t_events[0]) if result.t_events and len(result.t_events[0]) else None
-    # )
+    if events is not None:
+        # Collect only the terminal events
+        terminal_events = [event for event in events if event.terminal]
 
-    # if any(event.terminal for event in events):
+        # If there are no terminal events, then the last time of integration is the
+        # greatest one from the original array of propagation times
+        if not terminal_events:
+            last_t = max(tofs)
+            limiting_event = None
+        else:
+            # Filter the event which triggered first
+            last_t = min([event.last_t for event in terminal_events]).to_value(u.s)
+            limiting_event = [event for event in terminal_events if event.last_t == last_t]
 
-    ###
-    # Collect only the terminal events
-    terminal_events = [event for event in events if event.terminal]
-
-    # If there are no terminal events, then the last time of integration is the
-    # greatest one from the original array of propagation times
-    if not terminal_events:
-        last_t = max(tofs)
-        limiting_event = None
-    else:
-        # Filter the event which triggered first
-        last_t = min([event.last_t for event in terminal_events]).to_value(u.s)
-        limiting_event = [event for event in terminal_events if event.last_t == last_t]
-
-    tofs = [tof for tof in tofs if tof <= last_t] # Only this line will return empty `rr` if len(tofs) == 1.
-    # print(tofs)
-    # below_or_equal_last_t = tofs <= last_t
-    # print(below_or_equal_last_t)
-    # tofs = tofs[below_or_equal_last_t]
-    # print(tofs)
-    ###
+            tofs = [
+                tof for tof in tofs if tof < last_t
+            ] + [last_t]
 
     rrs = []
     vvs = []
     for i in range(len(tofs)):
         t = tofs[i]
-        # if t_end is not None and t > t_end:
-        #     t = t_end
         y = result.sol(t)
         rrs.append(y[:3])
         vvs.append(y[3:])

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -110,7 +110,9 @@ def cowell(k, r, v, tofs, rtol=1e-11, *, events=None, f=func_twobody):
     for i in range(len(tofs)):
         t = tofs[i]
         if t_end is not None and t > t_end:
-            t = t_end
+            # Terminate propagation if for atleast one event, event.terminal is True, else continue.
+            if any(event.terminal for event in events):
+                t = t_end
         y = result.sol(t)
         rrs.append(y[:3])
         vvs.append(y[3:])

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -109,14 +109,9 @@ def cowell(k, r, v, tofs, rtol=1e-11, *, events=None, f=func_twobody):
         # greatest one from the original array of propagation times
         if not terminal_events:
             last_t = max(tofs)
-            limiting_event = None
         else:
             # Filter the event which triggered first
             last_t = min([event.last_t for event in terminal_events]).to_value(u.s)
-            limiting_event = [
-                event for event in terminal_events if event.last_t == last_t
-            ]
-
             tofs = [tof for tof in tofs if tof < last_t] + [last_t]
 
     rrs = []

--- a/tests/tests_twobody/test_events.py
+++ b/tests/tests_twobody/test_events.py
@@ -282,7 +282,7 @@ def test_orbit_propagation_position_vector_does_not_repeat_if_events_terminal_is
 
     thresh_lat = 60 * u.deg
     # Event occurs at ~1701.7 s.
-    latitude_cross_event = LatitudeCrossEvent(orbit, thresh_lat, terminal=True)
+    latitude_cross_event = LatitudeCrossEvent(orbit, thresh_lat)
     events = [latitude_cross_event]
 
     # The last two tofs are after the detection of the event.

--- a/tests/tests_twobody/test_events.py
+++ b/tests/tests_twobody/test_events.py
@@ -282,7 +282,7 @@ def test_orbit_propagation_position_vector_does_not_repeat_if_events_terminal_is
 
     thresh_lat = 60 * u.deg
     # Event occurs at ~1701.7 s.
-    latitude_cross_event = LatitudeCrossEvent(orbit, thresh_lat)
+    latitude_cross_event = LatitudeCrossEvent(orbit, thresh_lat, terminal=True)
     events = [latitude_cross_event]
 
     # The last two tofs are after the detection of the event.


### PR DESCRIPTION
From #1285, this prevents hanging of orbit if an event's terminal property is False. I realized this behavior might not have been evident earlier since this condition was not tested.

For the test, would there be any suggestions on whether a single event detector would suffice or should it be parametrized for all events?

Thanks!