### PR TITLE
Minor event module and other changes

### DIFF
--- a/src/poliastro/core/events.py
+++ b/src/poliastro/core/events.py
@@ -18,9 +18,9 @@ def eclipse_function(k, u_, r_sec, R_sec, R_primary, umbra=True):
     r_sec: ~np.array
         Position vector of the secondary body with respect to the primary body.
     R_sec: float
-        Radius of the secondary body.
+        Equatorial radius of the secondary body.
     R_primary: float
-        Radius of the primary body.
+        Equatorial radius of the primary body.
     umbra: bool
         Whether to calculate the shadow function for umbra or penumbra, defaults to True
         i.e. calculates for umbra.
@@ -28,6 +28,7 @@ def eclipse_function(k, u_, r_sec, R_sec, R_primary, umbra=True):
     Note
     ----
     The shadow function is taken from Escobal, P. (1985). Methods of orbit determination.
+    The current implementation assumes circular bodies and doesn't account for flattening.
 
     """
     # Plus or minus condition

--- a/src/poliastro/core/events.py
+++ b/src/poliastro/core/events.py
@@ -25,6 +25,10 @@ def eclipse_function(k, u_, r_sec, R_sec, R_primary, umbra=True):
         Whether to calculate the shadow function for umbra or penumbra, defaults to True
         i.e. calculates for umbra.
 
+    Note
+    ----
+    The shadow function is taken from Escobal, P. (1985). Methods of orbit determination.
+
     """
     # Plus or minus condition
     pm = 1 if umbra else -1

--- a/src/poliastro/ephem.py
+++ b/src/poliastro/ephem.py
@@ -151,8 +151,7 @@ def _get_destination_frame(attractor, plane, epochs):
 class Ephem:
     """Time history of position and velocity of some object at particular epochs.
 
-    Instead of creating Ephem objects directly,
-    the user is encouraged to use the available classmethods.
+    Instead of creating Ephem objects directly, use the available classmethods.
 
     Parameters
     ----------

--- a/src/poliastro/ephem.py
+++ b/src/poliastro/ephem.py
@@ -152,7 +152,7 @@ class Ephem:
     """Time history of position and velocity of some object at particular epochs.
 
     Instead of creating Ephem objects directly,
-    you are encouraged to use the available classmethods.
+    the user is encouraged to use the available classmethods.
 
     Parameters
     ----------

--- a/src/poliastro/twobody/events.py
+++ b/src/poliastro/twobody/events.py
@@ -239,5 +239,5 @@ class NodeCrossEvent(Event):
 
     def __call__(self, t, u_, k):
         self._last_t = t
-        # Check if z-coordinate of the satellite is zero or not.
+        # Check if the z coordinate of the satellite is zero.
         return u_[2]

--- a/src/poliastro/twobody/events.py
+++ b/src/poliastro/twobody/events.py
@@ -98,9 +98,9 @@ class LatitudeCrossEvent(Event):
         Orbit.
     lat: astropy.quantity.Quantity
         Threshold latitude.
-    terminal: bool
+    terminal: bool, optional
         Whether to terminate integration if this event occurs, defaults to True.
-    direction: float
+    direction: float, optional
         Handle triggering of event based on whether latitude is crossed from above
         or below, defaults to 0, i.e., event is triggered while traversing from both directions.
 
@@ -221,9 +221,23 @@ class UmbraEvent(EclipseEvent):
 
 
 class NodeCrossEvent(Event):
+    """Detect equatorial node (ascending or descending) crossings.
+
+    Parameters
+    ----------
+    terminal: bool, optional
+        Whether to terminate integration when the event occurs, defaults to False.
+    direction: float, optional
+        Handle triggering of event based on whether the node is crossed from above
+        i.e. descending node, or is crossed from below i.e. ascending node, defaults to 0,
+        i.e. event is triggered during both crossings.
+
+    """
+
     def __init__(self, terminal=False, direction=0):
         super().__init__(terminal, direction)
 
     def __call__(self, t, u_, k):
         self._last_t = t
+        # Check if z-coordinate of the satellite is zero or not.
         return u_[2]

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -465,8 +465,6 @@ def propagate(orbit, time_of_flight, *, method=farnocchia, rtol=1e-10, **kwargs)
         raise ValueError(
             "Can not use an elliptic/parabolic propagator for hyperbolic orbits."
         )
-    else:
-        pass
 
     rr, vv = method(
         orbit.attractor.k,


### PR DESCRIPTION
- Reference for the eclipse was added.
- Docstring for node event was missing earlier, here it is added.

I also wonder if `EclipseEvent` should be made an abstract class since objects of `EclipseEvent` don't have any useful existence, right? In fact, its `__call__` method just returns the position vector of the secondary body, which doesn't seem to be related to any event.