### PR TITLE
Removed methods from plotting/util and twobody/orbit

### DIFF
--- a/src/poliastro/plotting/util.py
+++ b/src/poliastro/plotting/util.py
@@ -35,13 +35,3 @@ def generate_sphere(radius, center, num=20):
     zz = z_center + radius * np.cos(vv)
 
     return xx, yy, zz
-
-
-def generate_circle(radius, center, num=500):
-    u1 = np.linspace(0, 2 * np.pi, num)
-    x_center, y_center, z_center = center
-
-    xx = x_center + radius * np.cos(u1)
-    yy = y_center + radius * np.sin(u1)
-
-    return xx, yy

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -1393,18 +1393,6 @@ class Orbit:
 
         return cartesian
 
-    def _generate_time_values(self, nu_vals):
-        # Subtract current anomaly to start from the desired point
-        ecc = self.ecc.value
-        k = self.attractor.k.to_value(u.km ** 3 / u.s ** 2)
-        q = self.r_p.to_value(u.km)
-
-        time_values = [
-            delta_t_from_nu_fast(nu_val, ecc, k, q)
-            for nu_val in nu_vals.to(u.rad).value
-        ] * u.s - self.t_p
-        return time_values
-
     def apply_maneuver(self, maneuver, intermediate=False):
         """Returns resulting `Orbit` after applying maneuver to self.
 


### PR DESCRIPTION
Removed these dead methods:
* `Orbit._generate_time_values`
* `poliastro.plotting.util.generate_circle`