### PR TITLE
docs: Add sphinx-copybutton extension

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ Next, configure your Python environment:
 7. Create a Python virtual environment using `python -m venv .venv`
 8. Activate it using `source .venv/bin/activate`
 9. Upgrade the development dependencies using `python -m pip install -U pip setuptools wheel flit tox`
-10. Install the code in development mode using `flit install --simlink`
+10. Install the code in development mode using `flit install --symlink`
     (this means that the installed code will change as soon as you change it in the
     download location).
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,6 +50,7 @@ extensions = [
     'IPython.sphinxext.ipython_console_highlighting',
     'sphinx.ext.mathjax',  # Maths visualization
     'sphinx.ext.graphviz',  # Dependency diagrams
+    'sphinx_copybutton',
     'notfound.extension',
     'hoverxref.extension',
     'myst_parser',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ dev = [
     "sphinx_rtd_theme~=1.0.0rc1",
     "sphinx-hoverxref==0.7b1",
     "sphinx-notfound-page",
+    "sphinx-copybutton>0.2.9",
 ]
 
 [tool.flit.sdist]


### PR DESCRIPTION
Resolves #1324 

This PR adds `sphinx-copybutton` as a `dev` dependency in `pyproject.toml` and then adds it to the list of Sphinx extensions in `docs/source/conf.py`.

Resulting in the ability to do things like this in the docs

![copybutton](https://user-images.githubusercontent.com/5142394/135960440-aaefc0cc-ae8e-4a10-a50a-405ab211905c.png)


This PR also corrects a very tiny typo in the CONTRIBUTING docs.