### PR TITLE
Unify atmospheric models input parameters

### DIFF
--- a/src/poliastro/earth/atmosphere/jacchia.py
+++ b/src/poliastro/earth/atmosphere/jacchia.py
@@ -14,15 +14,16 @@ k = 1.380622e-23 * u.J / u.K
 class Jacchia77:
     """Holds the model for U.S Standard Atmosphere 1962."""
 
-    def __init__(self):
+    def __init__(self, Texo):
         self.E5M = np.zeros(11)
         self.E6P = np.zeros(11)
         self.x = 0.0
         self.y = 0.0
+        self.Texo = Texo
 
-    def _altitude_profile(self, alt, Texo):
+    def _altitude_profile(self, alt):
         Z, T, CN2, CO2, CO, CAr, CHe, CH, CM, WM = _altitude_profile_fast(
-            alt, Texo, self.x, self.y, self.E5M, self.E6P
+            alt, self.Texo.to(u.K).value, self.x, self.y, self.E5M, self.E6P
         )
         (
             self.Z,
@@ -60,23 +61,21 @@ class Jacchia77:
             self.WM,
         )
 
-    def _H_correction(self, alt, Texo):
+    def _H_correction(self, alt):
         """Calculate [H] from Jacchia 1977 formulas"""
-        _H_correction_fast(alt, Texo)
+        _H_correction_fast(alt, self.Texo)
 
-    def _O_and_O2_correction(self, alt, Texo):
+    def _O_and_O2_correction(self, alt):
         """Add Jacchia 1977 empirical corrections to [O] and [O2]"""
-        _O_and_O2_correction_fast(alt, Texo)
+        _O_and_O2_correction_fast(alt, self.Texo)
 
-    def altitude_profile(self, alt, Texo):
+    def altitude_profile(self, alt):
         """Solves for atmospheric altitude profile at given altitude and exospheric temperature.
 
         Parameters
         ----------
         alt: ~astropy.units.Quantity
             Geometric/Geopotential altitude.
-        Texo: ~astropy.units.Quantity
-            Exospheric temperature
 
         Returns
         -------
@@ -86,31 +85,29 @@ class Jacchia77:
         # checking if the units entered are km
         if alt.unit == u.km:
             if 150 <= alt.value < 500:
-                alt_properties = self._altitude_profile(500, Texo.value)
+                alt_properties = self._altitude_profile(500)
             else:
-                alt_properties = self._altitude_profile(alt.value, Texo.value)
+                alt_properties = self._altitude_profile(alt.value)
 
         return [last[int(alt.value)] for last in alt_properties]
 
-    def temperature(self, alt, Texo):
+    def temperature(self, alt):
         """Solves for temperature at given altitude and exospheric temperature.
 
         Parameters
         ----------
         alt: ~astropy.units.Quantity
             Geometric/Geopotential altitude.
-        Texo: ~astropy.units.Quantity
-            Exospheric temperature
 
         Returns
         -------
         T: ~astropy.units.Quantity
             Absolute temeperature  and exospheric temperature
         """
-        T = self.altitude_profile(alt, Texo)[1]
+        T = self.altitude_profile(alt)[1]
         return T
 
-    def pressure(self, alt, Texo):
+    def pressure(self, alt):
         """Solves pressure at given altitude and exospheric temperature.
 
         Parameters
@@ -125,30 +122,28 @@ class Jacchia77:
         p: ~astropy.units.Quantity
             Pressure at given altitude  and exospheric temperature.
         """
-        alt_profile = self.altitude_profile(alt, Texo)
+        alt_profile = self.altitude_profile(alt)
         T, number_density = alt_profile[1], alt_profile[8]
 
         # using eqn(42) of COESA76
         pressure = number_density * k * T
         return pressure
 
-    def density(self, alt, Texo):
+    def density(self, alt):
         """Solves density at given altitude and exospheric temperature.
 
         Parameters
         ----------
         alt: ~astropy.units.Quantity
             Geometric/Geopotential altitude.
-        Texo: ~astropy.units.Quantity
-            Exospheric Temperature
 
         Returns
         -------
         rho: ~astropy.units.Quantity
             Density at given altitude and exospheric temperature.
         """
-        alt_profile = self.altitude_profile(alt, Texo)
-        P = self.pressure(alt, Texo)
+        alt_profile = self.altitude_profile(alt)
+        P = self.pressure(alt)
 
         # using eqn(42) of COESA76
         rho = P * alt_profile[9] / (R * alt_profile[1])

--- a/tests/tests_earth/tests_atmosphere/test_jacchia77.py
+++ b/tests/tests_earth/tests_atmosphere/test_jacchia77.py
@@ -219,7 +219,7 @@ def test_jacchia77(z):
     expected_CM = jacchia77_solutions[z][7] * (u.m) ** -3
     expected_WM = jacchia77_solutions[z][8] * (u.kg)
 
-    properties = Jacchia77().altitude_profile(z, 1000 * u.K)
+    properties = Jacchia77(1000 * u.K).altitude_profile(z)
 
     for i in range(2, len(properties) - 1):
         if properties[i].value > 1.26e-10:
@@ -242,7 +242,7 @@ def test_jacchia77(z):
 @pytest.mark.parametrize("z", jacchia77_solutions.keys())
 def test_tempertaure(z):
     expected_T = jacchia77_solutions[z][0] * u.K
-    T = Jacchia77().temperature(z, 1000 * u.K)
+    T = Jacchia77(1000 * u.K).temperature(z)
 
     assert_quantity_allclose(T, expected_T, rtol=1e-4)
 
@@ -250,7 +250,7 @@ def test_tempertaure(z):
 @pytest.mark.parametrize("z", jacchia77_solutions.keys())
 def test_pressure(z):
     expected_p = jacchia77_solutions[z][9] * (u.N * u.m ** -2)
-    pressure = Jacchia77().pressure(z, 1000 * u.K)
+    pressure = Jacchia77(1000 * u.K).pressure(z)
     p = np.log10(pressure.value) * pressure.unit
 
     assert_quantity_allclose(p, expected_p, rtol=1e-3)
@@ -261,7 +261,7 @@ def test_density(z):
     expected_rho = jacchia77_solutions[z][10] * (
         u.kg ** 2 * u.mol * u.K ** -1 * u.m ** -3
     )
-    density = Jacchia77().density(z, 1000 * u.K)
+    density = Jacchia77(1000 * u.K).density(z)
     rho = np.log10(density.value) * density.unit
 
     assert_quantity_allclose(rho, expected_rho, rtol=1e-2)
@@ -271,7 +271,7 @@ def test_outside_upper_limit_coesa76():
     with pytest.raises(ValueError) as excinfo:
         alt = 2501.0 * u.km
         Texo = 1000 * u.K
-        Jacchia77().altitude_profile(alt, Texo)
+        Jacchia77(Texo).altitude_profile(alt)
     assert (
         "ValueError: Jacchia77 has been implemented in range 90km - 2500km."
         in excinfo.exconly()
@@ -282,7 +282,7 @@ def test_outside_lower_limit_coesa76():
     with pytest.raises(ValueError) as excinfo:
         alt = 89.0 * u.km
         Texo = 1000 * u.K
-        Jacchia77().altitude_profile(alt, Texo)
+        Jacchia77(Texo).altitude_profile(alt)
     assert (
         "ValueError: Jacchia77 has been implemented in range 90km - 2500km."
         in excinfo.exconly()


### PR DESCRIPTION
This solves for #1302 by unifying the different input parameters of the current available atmospheric models. Taking advantage of the high-level API, the `Texo` is passed now when instantiating the class, so it becomes an attribute of the `Jacchia77` object.