### PR TITLE
Fix izzo2015 initial guess

### DIFF
--- a/src/poliastro/core/iod.py
+++ b/src/poliastro/core/iod.py
@@ -380,6 +380,9 @@ def _initial_guess(T, ll, M):
         else:
             # This is the real condition, which is not exactly equivalent
             # elif T_1 < T < T_0
+            # Corrected initial guess,
+            # piecewise equation right after expression (30) in the original paper is incorrect
+            # See https://github.com/poliastro/poliastro/issues/1362
             x_0 = np.exp(np.log(2) * np.log(T / T_0) / np.log(T_1 / T_0)) - 1
 
         return [x_0]

--- a/src/poliastro/core/iod.py
+++ b/src/poliastro/core/iod.py
@@ -380,7 +380,7 @@ def _initial_guess(T, ll, M):
         else:
             # This is the real condition, which is not exactly equivalent
             # elif T_1 < T < T_0
-            x_0 = (T_0 / T) ** (np.log2(T_1 / T_0)) - 1
+            x_0 = np.exp(np.log(2) * np.log(T / T_0) / np.log(T_1 / T_0)) - 1
 
         return [x_0]
     else:

--- a/tests/test_iod.py
+++ b/tests/test_iod.py
@@ -143,3 +143,20 @@ def test_issue840(lambert_vallado, lambert_izzo):
     assert_quantity_allclose(vb_v, expected_vb, rtol=1e-6)
     assert_quantity_allclose(va_i, expected_va, rtol=1e-6)
     assert_quantity_allclose(vb_i, expected_vb, rtol=1e-6)
+
+
+@pytest.mark.parametrize(
+    "lambert_vallado,lambert_izzo", [(vallado.lambert, izzo.lambert)]
+)
+def test_issue1362(lambert_vallado, lambert_izzo):
+
+    k = 1.32712440018e11 * u.km ** 3 / u.s ** 2
+    r0 = [-7.52669489e07, -3.72205805e08, -9.17950811e06] * u.km
+    rf = [-6.15200041e06, -3.91985660e08, -5.06520860e05] * u.km
+    tof = 3489390.108265222 * u.s
+
+    va_v, vb_v = next(lambert_vallado(k, r0, rf, tof))
+    va_i, vb_i = next(lambert_izzo(k, r0, rf, tof))
+
+    assert_quantity_allclose(va_v, va_i, rtol=1e-6)
+    assert_quantity_allclose(vb_v, vb_i, rtol=1e-6)


### PR DESCRIPTION
Solves #1362 by properly computing the initial guess for Izzo's 2015 solver. This bug was caused because the piecewise equation right after expression (30) in the original paper is wrong. 