### PR TITLE
Remove use of units in `poliastro.core`

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -1,5 +1,9 @@
 [importlinter]
-root_package = poliastro
+# Include Astropy to properly analyze external submodules,
+# see https://github.com/seddonym/import-linter/issues/111
+root_packages =
+    poliastro
+    astropy
 include_external_packages=True
 
 [importlinter:contract:1]
@@ -7,7 +11,5 @@ name=poliastro.core does not import astropy.units
 type=forbidden
 source_modules=
     poliastro.core
-# astropy.units is not supported,
-# see https://github.com/seddonym/import-linter/issues/111
 forbidden_modules=
-    astropy
+    astropy.units

--- a/.importlinter
+++ b/.importlinter
@@ -1,0 +1,13 @@
+[importlinter]
+root_package = poliastro
+include_external_packages=True
+
+[importlinter:contract:1]
+name=poliastro.core does not import astropy.units
+type=forbidden
+source_modules=
+    poliastro.core
+# astropy.units is not supported,
+# see https://github.com/seddonym/import-linter/issues/111
+forbidden_modules=
+    astropy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ dev = [
     "black==21.9b0",
     "coverage",
     "hypothesis",
+    "import-linter",
     "ipython>=5.0",
     "ipywidgets>=7.6",
     "isort",

--- a/src/poliastro/earth/__init__.py
+++ b/src/poliastro/earth/__init__.py
@@ -6,7 +6,7 @@ import numpy as np
 from astropy import units as u
 
 from poliastro.bodies import Earth
-from poliastro.core.perturbations import J2_perturbation, atmospheric_drag_model
+from poliastro.core.perturbations import J2_perturbation
 from poliastro.core.propagation import func_twobody
 from poliastro.earth.enums import EarthGravity
 from poliastro.spacecraft import Spacecraft

--- a/src/poliastro/earth/__init__.py
+++ b/src/poliastro/earth/__init__.py
@@ -98,12 +98,10 @@ class EarthSatellite:
                 "R": Earth.R.to_value(u.km),
             }
         if atmosphere is not None:
-            perturbations[atmospheric_drag_model] = {
-                "R": Earth.R.to_value(u.km),
-                "C_D": self.spacecraft.C_D,
-                "A_over_m": (self.spacecraft.A / self.spacecraft.m),
-                "model": atmosphere,
-            }
+            # Cannot compute density without knowing the state,
+            # the perturbations parameters are not always fixed
+            # TODO: This whole function probably needs a refactoring
+            raise NotImplementedError
 
         def f(t0, state, k):
             du_kep = func_twobody(t0, state, k)

--- a/tests/tests_earth/test_earthsatellite.py
+++ b/tests/tests_earth/test_earthsatellite.py
@@ -4,7 +4,6 @@ from astropy import units as u
 
 from poliastro.bodies import Earth, Mars
 from poliastro.earth import EarthSatellite
-from poliastro.earth.atmosphere import COESA76
 from poliastro.earth.enums import EarthGravity
 from poliastro.spacecraft import Spacecraft
 from poliastro.twobody.orbit import Orbit
@@ -53,9 +52,9 @@ def test_propagate_instance():
     earth_satellite = EarthSatellite(ss0, spacecraft)
     orbit_with_j2 = earth_satellite.propagate(tof=tof, gravity=EarthGravity.J2)
     orbit_without_perturbation = earth_satellite.propagate(tof)
-    orbit_with_atmosphere_and_j2 = earth_satellite.propagate(
-        tof=tof, gravity=EarthGravity.J2, atmosphere=COESA76()
-    )
+    # orbit_with_atmosphere_and_j2 = earth_satellite.propagate(
+    #     tof=tof, gravity=EarthGravity.J2, atmosphere=COESA76()
+    # )
     assert isinstance(orbit_with_j2, EarthSatellite)
-    assert isinstance(orbit_with_atmosphere_and_j2, EarthSatellite)
+    # assert isinstance(orbit_with_atmosphere_and_j2, EarthSatellite)
     assert isinstance(orbit_without_perturbation, EarthSatellite)

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,7 @@ extras =
 # see https://tox.readthedocs.io/en/latest/config.html#conf-usedevelop
 usedevelop = False
 commands =
+    lint-imports
     pytest {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
 
 [testenv:check]


### PR DESCRIPTION
Fix #1256, and enforce it forever using import-linter.

I had to make several other changes along the way:

- Refactor `atmospheric_drag` to take the density as a float rather than a callable. This introduces a minor redundancy because the user needs to compute the height outside, but the advantage is that the perturbation can be jitted, and no units are needed.
- Disable the atmosphere perturbation in `EarthSatellite`. The design of the class is not very flexible and does not support the new `atmospheric_drag` function easily. Rather than trying to find a way out, since these classes are experimental, I temporarily introduced a `NotImplementedError` until we find a better solution.
- Add a `lint-imports` command to our `test` environment in tox, since import-linter requires the package to be installed.