### PR TITLE
Remove codeclimate from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Name:         | poliastro
 
 [![azure_pipelines](https://dev.azure.com/poliastro/poliastro/_apis/build/status/poliastro.poliastro?branchName=main)](https://dev.azure.com/poliastro/poliastro/_build/latest?definitionId=1&branchName=main)
 [![codecov](https://img.shields.io/codecov/c/github/poliastro/poliastro.svg?style=flat-square)](https://codecov.io/github/poliastro/poliastro?branch=main)
-[![codeclimate](https://api.codeclimate.com/v1/badges/fd2aa5bf8c4b7984d11b/maintainability)](https://codeclimate.com/github/poliastro/poliastro/maintainability)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/poliastro/poliastro/main.svg)](https://results.pre-commit.ci/latest/github/poliastro/poliastro/main)
 
 [![docs](https://img.shields.io/badge/docs-latest-brightgreen.svg?style=flat-square)](https://docs.poliastro.space/en/latest/?badge=latest)


### PR DESCRIPTION
Codeclimate was removed in #1328 but not from README. Maybe it's a good choice to remove it from README as well?