### PR TITLE
Resolving astroquery deprecation warnings

### DIFF
--- a/src/poliastro/ephem.py
+++ b/src/poliastro/ephem.py
@@ -247,13 +247,13 @@ class Ephem:
         *,
         attractor=None,
         plane=Planes.EARTH_EQUATOR,
-        id_type="smallbody",
+        id_type=None,
     ):
         """Return `Ephem` for an object using JPLHorizons module of Astroquery.
 
         Parameters
         ----------
-        name : string
+        name : str
             Name of the body to query for.
         epochs: ~astropy.time.Time
             Epochs to sample the body positions.
@@ -262,9 +262,9 @@ class Ephem:
             if not given the Solar System Barycenter will be used.
         plane : ~poliastro.frames.Planes, optional
             Fundamental plane of the frame, default to Earth Equator.
-        id_type : str, optional
-            Use "smallbody" for Asteroids and Comets (default), and "majorbody"
-            for Planets and Satellites.
+        id_type : NoneType or str, optional
+            Use "smallbody" for Asteroids and Comets and None (default) to first
+            search for Planets and Satellites.
 
         """
         if epochs.isscalar:

--- a/tests/tests_twobody/test_orbit.py
+++ b/tests/tests_twobody/test_orbit.py
@@ -1245,7 +1245,7 @@ def test_can_set_iss_attractor_to_earth():
     # See https://github.com/poliastro/poliastro/issues/798
     epoch = Time("2019-11-10 12:00:00")
     ephem = Ephem.from_horizons(
-        "International Space Station", epochs=epoch, attractor=Sun, id_type="majorbody"
+        "International Space Station", epochs=epoch, attractor=Sun, id_type=None
     )
     iss = Orbit.from_ephem(Sun, ephem, epoch)
     iss = iss.change_attractor(Earth)


### PR DESCRIPTION
From #1405. I think this would be a small change to set the default `id_type` to `None` as done upstream.

Thanks!