### PR TITLE
Mark tests that potentially fail

### DIFF
--- a/tests/test_maneuver.py
+++ b/tests/test_maneuver.py
@@ -225,6 +225,7 @@ def test_correct_pericenter_ecc_exception():
     )
 
 
+@pytest.mark.remote_data
 def test_apply_manuever_correct_plane():
     ceres = Orbit.from_sbdb("Ceres")
     imp = Maneuver.impulse([0, 0, 0] * u.km / u.s)

--- a/tests/tests_plotting/test_static.py
+++ b/tests/tests_plotting/test_static.py
@@ -254,6 +254,7 @@ def test_body_frame_raises_warning_if_time_is_not_tdb_with_proper_time(recwarn):
     assert expected_epoch_string in str(w.message)
 
 
+@pytest.mark.xfail(sys.maxsize < 2 ** 32, reason="not supported for 32 bit systems")
 @pytest.mark.mpl_image_compare
 def test_plot_maneuver():
     # Data from Vallado, example 6.1


### PR DESCRIPTION
For the new Debian package, I found two tests that fail under some circumstances:

* test_apply_manuever_correct_plane wants to retrieve some remotel data for Ceres,
* test_plot_maneuver requires the numba "parallel" extension nor-existent on 32-bit (#1315) 

This PR marks them properly.