### PR TITLE
Docstring cleanup

### DIFF
--- a/src/poliastro/_math/special.py
+++ b/src/poliastro/_math/special.py
@@ -11,8 +11,8 @@ def hyp2f1b(x):
     .. todo::
         Add more information about this function
 
-    Note
-    ----
+    Notes
+    -----
     More information about hypergeometric function can be checked at
     https://en.wikipedia.org/wiki/Hypergeometric_function
 

--- a/src/poliastro/bodies.py
+++ b/src/poliastro/bodies.py
@@ -133,6 +133,8 @@ class SolarSystemPlanet(Body):
         interactive : bool, optional
             Produce an interactive (rather than static) image of the orbit, default to False.
             This option requires Plotly properly installed and configured for your environment.
+        plane : ~poliastro.frames.Planes
+            Reference plane of the coordinates.
 
         """
         if not interactive and use_3d:

--- a/src/poliastro/core/angles.py
+++ b/src/poliastro/core/angles.py
@@ -460,9 +460,9 @@ def fp_angle(nu, ecc):
 
     Parameters
     ----------
-    nu: float
+    nu : float
         True anomaly in radians.
-    ecc: float
+    ecc : float
         Eccentricity.
 
     Returns

--- a/src/poliastro/core/czml_utils.py
+++ b/src/poliastro/core/czml_utils.py
@@ -9,16 +9,16 @@ def intersection_ellipsoid_line(x, y, z, u1, u2, u3, a, b, c):
 
     Parameters
     ----------
-    x, y, z: float
+    x, y, z : float
         A point of the line
-    u1, u2, u3: float
+    u1, u2, u3 : float
         The line vector
-    a, b, c: float
+    a, b, c : float
         The ellipsoidal axises
 
     Returns
     -------
-    p0, p1: ~np.array
+    p0, p1: numpy.ndarray
         This returns both of the points intersecting the ellipsoid.
 
     """
@@ -85,10 +85,9 @@ def project_point_on_ellipsoid(x, y, z, a, b, c):
 
     Parameters
     ----------
-    x, y, z: float
+    x, y, z : float
         Cartesian coordinates of point
-
-    a, b, c: float
+    a, b, c : float
         Semi-axes of the ellipsoid
 
     """

--- a/src/poliastro/core/earth_atmosphere/util.py
+++ b/src/poliastro/core/earth_atmosphere/util.py
@@ -9,9 +9,9 @@ def geometric_to_geopotential(z, r0):
 
     Parameters
     ----------
-    z: float
+    z : float
         Geometric altitude.
-    r0: float
+    r0 : float
         Planet/Natural satellite radius.
 
     Returns
@@ -33,9 +33,9 @@ def geopotential_to_geometric(h, r0):
 
     Parameters
     ----------
-    h: float
+    h : float
         Geopotential altitude.
-    r0: float
+    r0 : float
         Planet/Natural satellite radius.
 
     Returns
@@ -57,11 +57,11 @@ def gravity(z, g0, r0):
 
     Parameters
     ----------
-    z: float
+    z : float
         Geometric height.
-    g0: float
+    g0 : float
         Gravity value at sea level.
-    r0: float
+    r0 : float
         Planet/Natural satellite radius.
 
     Returns
@@ -80,9 +80,9 @@ def _get_index(x, x_levels):
 
     Parameters
     ----------
-    x: float
+    x : float
         Element to be searched.
-    x_levels: list
+    x_levels : list
         List for searching.
 
     Returns

--- a/src/poliastro/core/elements.py
+++ b/src/poliastro/core/elements.py
@@ -43,7 +43,6 @@ def circular_velocity(k, a):
 
     Parameters
     ----------
-
     k : float
         Gravitational Parameter
     a : float
@@ -65,12 +64,11 @@ def rv_pqw(k, p, ecc, nu):
         Semi-latus rectum or parameter (km).
     ecc : float
         Eccentricity.
-    nu: float
+    nu : float
         True anomaly (rad).
 
     Returns
     -------
-
     r: ndarray
         Position. Dimension 3 vector
     v: ndarray
@@ -158,7 +156,6 @@ def coe2rv(k, p, ecc, inc, raan, argp, nu):
 
     Notes
     -----
-
     .. math::
         \begin{align}
             \vec{r}_{IJK} &= [ROT3(-\Omega)][ROT1(-i)][ROT3(-\omega)]\vec{r}_{PQW}
@@ -229,7 +226,7 @@ def coe2mee(p, ecc, inc, raan, argp, nu):
     argp : float
         Argument of perigee (rad).
     nu : float
-       True anomaly (rad).
+        True anomaly (rad).
 
     Returns
     -------
@@ -283,9 +280,9 @@ def rv2coe(k, r, v, tol=1e-8):
     ----------
     k : float
         Standard gravitational parameter (km^3 / s^2)
-    r : array
+    r : numpy.ndarray
         Position vector (km)
-    v : array
+    v : numpy.ndarray
         Velocity vector (km / s)
     tol : float, optional
         Tolerance for eccentricity and inclination checks, default to 1e-8
@@ -447,17 +444,17 @@ def mee2coe(p, f, g, h, k, L):
 
     Parameters
     ----------
-    p: float
+    p : float
         Semi-latus rectum
-    f: float
+    f : float
         Equinoctial parameter f
-    g: float
+    g : float
         Equinoctial parameter g
-    h: float
+    h : float
         Equinoctial parameter h
-    k: float
+    k : float
         Equinoctial parameter k
-    L: float
+    L : float
         Longitude
 
     Returns
@@ -475,7 +472,7 @@ def mee2coe(p, f, g, h, k, L):
     nu: float
         True anomaly
 
-    Note
+    Notes
     -----
     The conversion is always safe because arctan2 works also for 0, 0
     arguments.

--- a/src/poliastro/core/elements.py
+++ b/src/poliastro/core/elements.py
@@ -200,11 +200,9 @@ def coe2rv_many(k, p, ecc, inc, raan, argp, nu):
 
 @jit
 def coe2mee(p, ecc, inc, raan, argp, nu):
-    r"""Converts from classical orbital elements to modified equinoctial
-    orbital elements.
+    r"""Converts from classical orbital elements to modified equinoctial orbital elements.
 
-    The definition of the modified equinoctial orbital elements is taken from
-    [Walker, 1985].
+    The definition of the modified equinoctial orbital elements is taken from [Walker, 1985].
 
     The modified equinoctial orbital elements are a set of orbital elements that are useful for
     trajectory analysis and optimization. They are valid for circular, elliptic, and hyperbolic
@@ -221,7 +219,7 @@ def coe2mee(p, ecc, inc, raan, argp, nu):
         Eccentricity.
     inc : float
         Inclination (rad).
-    omega : float
+    raan : float
         Longitude of ascending node (rad).
     argp : float
         Argument of perigee (rad).

--- a/src/poliastro/core/events.py
+++ b/src/poliastro/core/events.py
@@ -11,22 +11,22 @@ def eclipse_function(k, u_, r_sec, R_sec, R_primary, umbra=True):
 
     Parameters
     ----------
-    k: float
+    k : float
         Standard gravitational parameter (km^3 / s^2).
-    u_: ~np.array
+    u_ : numpy.ndarray
         Satellite position and velocity vector with respect to the primary body.
-    r_sec: ~np.array
+    r_sec : numpy.ndarray
         Position vector of the secondary body with respect to the primary body.
-    R_sec: float
+    R_sec : float
         Equatorial radius of the secondary body.
-    R_primary: float
+    R_primary : float
         Equatorial radius of the primary body.
-    umbra: bool
+    umbra : bool
         Whether to calculate the shadow function for umbra or penumbra, defaults to True
         i.e. calculates for umbra.
 
-    Note
-    ----
+    Notes
+    -----
     The shadow function is taken from Escobal, P. (1985). Methods of orbit determination.
     The current implementation assumes circular bodies and doesn't account for flattening.
 
@@ -62,11 +62,11 @@ def line_of_sight(r1, r2, R):
 
     Parameters
     ----------
-    r1: ~np.array
+    r1 : numpy.ndarray
         The position vector of the first object with respect to a central attractor.
-    r2: ~np.array
+    r2 : numpy.ndarray
         The position vector of the second object with respect to a central attractor.
-    R: float
+    R : float
         The radius of the central attractor.
 
     Returns

--- a/src/poliastro/core/fixed.py
+++ b/src/poliastro/core/fixed.py
@@ -25,9 +25,9 @@ def sun_rot_elements_at_epoch(T, d):
 
     Parameters
     ----------
-    T: float
+    T : float
         Interval from the standard epoch, in Julian centuries i.e. 36525 days.
-    d: float
+    d : float
         Interval in days from the standard epoch.
 
     Returns
@@ -49,9 +49,9 @@ def mercury_rot_elements_at_epoch(T, d):
 
     Parameters
     ----------
-    T: float
+    T : float
         Interval from the standard epoch, in Julian centuries.
-    d: float
+    d : float
         Interval in days from the standard epoch.
 
     Returns
@@ -84,9 +84,9 @@ def venus_rot_elements_at_epoch(T, d):
 
     Parameters
     ----------
-    T: float
+    T : float
         Interval from the standard epoch, in Julian centuries.
-    d: float
+    d : float
         Interval in days from the standard epoch.
 
     Returns
@@ -108,9 +108,9 @@ def mars_rot_elements_at_epoch(T, d):
 
     Parameters
     ----------
-    T: float
+    T : float
         Interval from the standard epoch, in Julian centuries
-    d: float
+    d : float
         Interval in days from the standard epoch
 
     Returns
@@ -178,9 +178,9 @@ def jupiter_rot_elements_at_epoch(T, d):
 
     Parameters
     ----------
-    T: float
+    T : float
         Interval from the standard epoch, in Julian centuries
-    d: float
+    d : float
         Interval in days from the standard epoch
 
     Returns
@@ -224,9 +224,9 @@ def saturn_rot_elements_at_epoch(T, d):
 
     Parameters
     ----------
-    T: float
+    T : float
         Interval from the standard epoch, in Julian centuries.
-    d: float
+    d : float
         Interval in days from the standard epoch.
 
     Returns
@@ -248,9 +248,9 @@ def uranus_rot_elements_at_epoch(T, d):
 
     Parameters
     ----------
-    T: float
+    T : float
         Interval from the standard epoch, in Julian centuries.
-    d: float
+    d : float
         Interval in days from the standard epoch.
 
     Returns
@@ -272,9 +272,9 @@ def neptune_rot_elements_at_epoch(T, d):
 
     Parameters
     ----------
-    T: float
+    T : float
         Interval from the standard epoch, in Julian centuries.
-    d: float
+    d : float
         Interval in days from the standard epoch.
 
     Returns
@@ -298,9 +298,9 @@ def moon_rot_elements_at_epoch(T, d):
 
     Parameters
     ----------
-    T: float
+    T : float
         Interval from the standard epoch, in Julian centuries.
-    d: float
+    d : float
         Interval in days from the standard epoch.
 
     Returns

--- a/src/poliastro/core/flybys.py
+++ b/src/poliastro/core/flybys.py
@@ -14,13 +14,13 @@ def compute_flyby(v_spacecraft, v_body, k, r_p, theta):
     ----------
     k : float
         Standard Gravitational parameter.
-    r_p: float
+    r_p : float
         Radius of periapsis, measured from the center of the body.
-    v_spacecraft: float
+    v_spacecraft : float
         Velocity of the spacecraft, relative to the attractor of the body.
-    v_body: float
+    v_body : float
         Velocity of the body, relative to its attractor.
-    theta: float
+    theta : float
         Aim angle of the B vector.
 
     Returns

--- a/src/poliastro/core/iod.py
+++ b/src/poliastro/core/iod.py
@@ -51,29 +51,28 @@ def vallado(k, r0, r, tof, short, numiter, rtol):
 
     Parameters
     ----------
-    k: float
+    k : float
         Gravitational Parameter
-    r0: ~np.array
+    r0 : numpy.ndarray
         Initial position vector
-    r: ~np.array
+    r : numpy.ndarray
         Final position vector
-    tof: ~float
+    tof : ~float
         Time of flight
-    numiter: int
+    numiter : int
         Number of iterations to
-    rtol: int
+    rtol : int
         Number of revolutions
 
     Returns
     -------
-    v0: ~np.array
+    v0: numpy.ndarray
         Initial velocity vector
-    v: ~np.array
+    v: numpy.ndarray
         Final velocity vector
 
     Examples
     --------
-
     >>> from poliastro.core.iod import vallado
     >>> from astropy import units as u
     >>> import numpy as np
@@ -88,8 +87,8 @@ def vallado(k, r0, r, tof, short, numiter, rtol):
     >>> print(v1, v2)
     [-5.99249503  1.92536671  3.24563805] km / s [-3.31245851 -4.19661901 -0.38528906] km / s
 
-    Note
-    ----
+    Notes
+    -----
     This procedure can be found in section 5.3 of Curtis, with all the
     theoretical description of the problem. Analytical example can be found
     in the same book under name Example 5.2.
@@ -162,24 +161,23 @@ def izzo(k, r1, r2, tof, M, numiter, rtol):
 
     Parameters
     ----------
-    k: float
+    k : float
         Gravitational Constant
-    r1: ~numpy.array
+    r1 : ~numpy.array
         Initial position vector
-    r2: ~numpy.array
+    r2 : ~numpy.array
         Final position vector
-    tof: float
+    tof : float
         Time of flight between both positions
-    M: int
+    M : int
         Number of revolutions
-    numiter: int
+    numiter : int
         Number of iterations
-    rtol: float
+    rtol : float
         Error tolerance
 
     Returns
     -------
-
     v1: ~numpy.array
         Initial velocity vector
     v2: ~numpy.array
@@ -401,8 +399,8 @@ def _initial_guess(T, ll, M):
 def _halley(p0, T0, ll, tol, maxiter):
     """Find a minimum of time of flight equation using the Halley method.
 
-    Note
-    ----
+    Notes
+    -----
     This function is private because it assumes a calling convention specific to
     this module and is not really reusable.
 
@@ -429,8 +427,8 @@ def _halley(p0, T0, ll, tol, maxiter):
 def _householder(p0, T0, ll, M, tol, maxiter):
     """Find a zero of time of flight equation using the Householder method.
 
-    Note
-    ----
+    Notes
+    -----
     This function is private because it assumes a calling convention specific to
     this module and is not really reusable.
 

--- a/src/poliastro/core/iod.py
+++ b/src/poliastro/core/iod.py
@@ -57,6 +57,8 @@ def vallado(k, r0, r, tof, short, numiter, rtol):
         Initial position vector
     r : numpy.ndarray
         Final position vector
+    short : bool
+        True for short path, False for long one.
     tof : ~float
         Time of flight
     numiter : int

--- a/src/poliastro/core/maneuver.py
+++ b/src/poliastro/core/maneuver.py
@@ -34,9 +34,9 @@ def hohmann(k, rv, r_f):
     ----------
     k : float
         Standard Gravitational parameter
-    rv: ~np.array, ~np.array
+    rv : numpy.ndarray, numpy.ndarray
         Position and velocity vectors
-    r_f: float
+    r_f : float
         Final altitude of the orbit
 
     """
@@ -100,13 +100,13 @@ def bielliptic(k, r_b, r_f, rv):
 
     Parameters
     ----------
-    k: float
+    k : float
         Standard Gravitational parameter
-    r_b: float
+    r_b : float
         Altitude of the intermediate orbit
-    r_f: float
+    r_f : float
         Final altitude of the orbit
-    rv: ~np.array, ~np.array
+    rv : numpy.ndarray, numpy.ndarray
         Position and velocity vectors
 
     """
@@ -147,21 +147,21 @@ def correct_pericenter(k, R, J2, max_delta_r, v, a, inc, ecc):
 
     Parameters
     ----------
-    k: float
+    k : float
         Standard Gravitational parameter
-    R: float
+    R : float
         Radius of the attractor
-    J2: float
+    J2 : float
         Oblateness factor
-    max_delta_r: float
+    max_delta_r : float
         Maximum satellite’s geocentric distance
-    v: ~np.array
+    v : numpy.ndarray
         Velocity vector
-    a: float
+    a : float
         Semi-major axis
-    inc: float
+    inc : float
         Inclination
-    ecc: float
+    ecc : float
         Eccentricity
 
     Notes

--- a/src/poliastro/core/perturbations.py
+++ b/src/poliastro/core/perturbations.py
@@ -23,13 +23,13 @@ def J2_perturbation(t0, state, k, J2, R):
         Six component state vector [x, y, z, vx, vy, vz] (km, km/s).
     k : float
         Standard Gravitational parameter. (km^3/s^2)
-    J2: float
+    J2 : float
         Oblateness factor
-    R: float
+    R : float
         Attractor radius
 
-    Note
-    ----
+    Notes
+    -----
     The J2 accounts for the oblateness of the attractor. The formula is given in
     Howard Curtis, (12.30)
 
@@ -57,13 +57,13 @@ def J3_perturbation(t0, state, k, J3, R):
         Six component state vector [x, y, z, vx, vy, vz] (km, km/s).
     k : float
         Standard Gravitational parameter. (km^3/s^2)
-    J3: float
+    J3 : float
         Oblateness factor
-    R: float
+    R : float
         Attractor radius
 
-    Note
-    ----
+    Notes
+    -----
     The J3 accounts for the oblateness of the attractor. The formula is given in
     Howard Curtis, problem 12.8
     This perturbation has not been fully validated, see https://github.com/poliastro/poliastro/pull/398
@@ -89,7 +89,6 @@ def atmospheric_drag_exponential(t0, state, k, R, C_D, A_over_m, H0, rho0):
 
         \vec{p} = -\frac{1}{2}\rho v_{rel}\left ( \frac{C_{d}A}{m} \right )\vec{v_{rel}}
 
-
     .. versionadded:: 0.9.0
 
     Parameters
@@ -102,17 +101,17 @@ def atmospheric_drag_exponential(t0, state, k, R, C_D, A_over_m, H0, rho0):
         Standard Gravitational parameter (km^3/s^2).
     R : float
         Radius of the attractor (km)
-    C_D: float
+    C_D : float
         Dimensionless drag coefficient ()
-    A_over_m: float
+    A_over_m : float
         Frontal area/mass of the spacecraft (km^2/kg)
     H0 : float
         Atmospheric scale height, (km)
-    rho0: float
+    rho0 : float
         Exponent density pre-factor, (kg / km^3)
 
-    Note
-    ----
+    Notes
+    -----
     This function provides the acceleration due to atmospheric drag
     using an overly-simplistic exponential atmosphere model. We follow
     Howard Curtis, section 12.4
@@ -137,7 +136,6 @@ def atmospheric_drag(t0, state, k, C_D, A_over_m, rho):
 
         \vec{p} = -\frac{1}{2}\rho v_{rel}\left ( \frac{C_{d}A}{m} \right )\vec{v_{rel}}
 
-
     .. versionadded:: 1.14
 
     Parameters
@@ -148,15 +146,15 @@ def atmospheric_drag(t0, state, k, C_D, A_over_m, rho):
         Six component state vector [x, y, z, vx, vy, vz] (km, km/s).
     k : float
         Standard Gravitational parameter (km^3/s^2)
-    C_D: float
+    C_D : float
         Dimensionless drag coefficient ()
-    A_over_m: float
+    A_over_m : float
         Frontal area/mass of the spacecraft (km^2/kg)
-    rho: float
+    rho : float
         Air density at corresponding state (kg/m^3)
 
-    Note
-    ----
+    Notes
+    -----
     This function provides the acceleration due to atmospheric drag, as
     computed by a model from poliastro.earth.atmosphere
 
@@ -183,10 +181,12 @@ def third_body(t0, state, k, k_third, perturbation_body):
         Six component state vector [x, y, z, vx, vy, vz] (km, km/s).
     k : float
         Standard Gravitational parameter (km^3/s^2).
-    perturbation_body: A callable object returning the position of the pertubation body that causes the perturbation
+    perturbation_body : callable
+        A callable object returning the position of the body that causes the perturbation
+        in the attractor frame.
 
-    Note
-    ----
+    Notes
+    -----
     This formula is taken from Howard Curtis, section 12.10. As an example, a third body could be
     the gravity from the Moon acting on a small satellite.
 
@@ -213,17 +213,18 @@ def radiation_pressure(t0, state, k, R, C_R, A_over_m, Wdivc_s, star):
         Standard Gravitational parameter (km^3/s^2).
     R : float
         Radius of the attractor.
-    C_R: float
+    C_R : float
         Dimensionless radiation pressure coefficient, 1 < C_R < 2 ().
-    A_over_m: float
+    A_over_m : float
         Effective spacecraft area/mass of the spacecraft (km^2/kg).
     Wdivc_s : float
         Total star emitted power divided by the speed of light (W * s / km).
-    star: a callable object returning the position of star in attractor frame
-        Star position.
+    star : callable
+        A callable object returning the position of radiating star
+        in the attractor frame.
 
-    Note
-    ----
+    Notes
+    -----
     This function provides the acceleration due to star light pressure. We follow
     Howard Curtis, section 12.9
 

--- a/src/poliastro/core/perturbations.py
+++ b/src/poliastro/core/perturbations.py
@@ -167,7 +167,7 @@ def atmospheric_drag(t0, state, k, C_D, A_over_m, rho):
 
 
 def third_body(t0, state, k, k_third, perturbation_body):
-    r"""Calculates 3rd body acceleration (km/s2)
+    r"""Calculate third body acceleration (km/s2).
 
     .. math::
 
@@ -180,7 +180,9 @@ def third_body(t0, state, k, k_third, perturbation_body):
     state : numpy.ndarray
         Six component state vector [x, y, z, vx, vy, vz] (km, km/s).
     k : float
-        Standard Gravitational parameter (km^3/s^2).
+        Standard Gravitational parameter of the attractor (km^3/s^2).
+    k_third : float
+        Standard Gravitational parameter of the third body (km^3/s^2).
     perturbation_body : callable
         A callable object returning the position of the body that causes the perturbation
         in the attractor frame.

--- a/src/poliastro/core/propagation/__init__.py
+++ b/src/poliastro/core/propagation/__init__.py
@@ -39,7 +39,7 @@ def func_twobody(t0, u_, k):
     ----------
     t0 : float
         Time.
-    u_ : ~np.array
+    u_ : numpy.ndarray
         Six component state vector [x, y, z, vx, vy, vz] (km, km/s).
     k : float
         Standard gravitational parameter.

--- a/src/poliastro/core/propagation/danby.py
+++ b/src/poliastro/core/propagation/danby.py
@@ -83,26 +83,26 @@ def danby(k, r0, v0, tof, numiter=20, rtol=1e-8):
     ----------
     k : float
         Standard gravitational parameter of the attractor.
-    r0 : ~np.array
+    r0 : numpy.ndarray
         Position vector.
-    v0 : ~np.array
+    v0 : numpy.ndarray
         Velocity vector.
     tof : float
         Time of flight.
-    numiter: int, optional
+    numiter : int, optional
         Number of iterations, defaults to 20.
-    rtol: float, optional
+    rtol : float, optional
         Relative error for accuracy of the method, defaults to 1e-8.
 
     Returns
     -------
-    rr : ~np.array
+    rr : numpy.ndarray
         Final position vector.
-    vv : ~np.array
+    vv : numpy.ndarray
         Final velocity vector.
 
-    Note
-    ----
+    Notes
+    -----
     This algorithm was developed by Danby in his paper *The solution of Kepler
     Equation* with DOI: https://doi.org/10.1007/BF01686811
     """

--- a/src/poliastro/core/propagation/farnocchia.py
+++ b/src/poliastro/core/propagation/farnocchia.py
@@ -311,15 +311,15 @@ def farnocchia(k, r0, v0, tof):
     ----------
     k : float
         Standar Gravitational parameter
-    r0 : ~np.array
+    r0 : numpy.ndarray
         Initial position vector wrt attractor center.
-    v0 : ~np.array
+    v0 : numpy.ndarray
         Initial velocity vector.
     tof : float
         Time of flight (s).
 
-    Note
-    ----
+    Notes
+    -----
     This method takes initial :math:`\vec{r}, \vec{v}`, calculates classical orbit parameters,
     increases mean anomaly and performs inverse transformation to get final :math:`\vec{r}, \vec{v}`
     The logic is based on formulae (4), (6) and (7) from http://dx.doi.org/10.1007/s10569-013-9476-9

--- a/src/poliastro/core/propagation/farnocchia.py
+++ b/src/poliastro/core/propagation/farnocchia.py
@@ -99,6 +99,10 @@ def M_to_D_near_parabolic(M, ecc, tol=1.48e-08, maxiter=50):
         Mean anomaly in radians.
     ecc : float
         Eccentricity (~1).
+    tol : float, optional
+        Absolute tolerance for Newton convergence.
+    maxiter : int, optional
+        Maximum number of iterations for Newton convergence.
 
     Returns
     -------

--- a/src/poliastro/core/propagation/gooding.py
+++ b/src/poliastro/core/propagation/gooding.py
@@ -47,22 +47,22 @@ def gooding(k, r0, v0, tof, numiter=150, rtol=1e-8):
     ----------
     k : float
         Standard gravitational parameter of the attractor.
-    r0 : ~np.array
+    r0 : numpy.ndarray
         Position vector.
-    v0 : ~np.array
+    v0 : numpy.ndarray
         Velocity vector.
     tof : float
         Time of flight.
-    numiter: int, optional
+    numiter : int, optional
         Number of iterations, defaults to 150.
-    rtol: float, optional
+    rtol : float, optional
         Relative error for accuracy of the method, defaults to 1e-8.
 
     Returns
     -------
-    rr : ~np.array
+    rr : numpy.ndarray
         Final position vector.
-    vv : ~np.array
+    vv : numpy.ndarray
         Final velocity vector.
     Note
     ----

--- a/src/poliastro/core/propagation/markley.py
+++ b/src/poliastro/core/propagation/markley.py
@@ -69,22 +69,22 @@ def markley(k, r0, v0, tof):
     ----------
     k : float
         Standar Gravitational parameter.
-    r0 : ~np.array
+    r0 : numpy.ndarray
         Initial position vector wrt attractor center.
-    v0 : ~np.array
+    v0 : numpy.ndarray
         Initial velocity vector.
     tof : float
         Time of flight.
 
     Returns
     -------
-    rr: ~np.array
+    rr: numpy.ndarray
         Final position vector.
-    vv: ~np.array
+    vv: numpy.ndarray
         Final velocity vector.
 
-    Note
-    ----
+    Notes
+    -----
     The following algorithm was taken from http://dx.doi.org/10.1007/BF00691917.
 
     """

--- a/src/poliastro/core/propagation/mikkola.py
+++ b/src/poliastro/core/propagation/mikkola.py
@@ -103,9 +103,9 @@ def mikkola(k, r0, v0, tof, rtol=None):
     ----------
     k : float
         Standard gravitational parameter of the attractor.
-    r : numpy.ndarray
+    r0 : numpy.ndarray
         Position vector.
-    v : numpy.ndarray
+    v0 : numpy.ndarray
         Velocity vector.
     tof : float
         Time of flight.

--- a/src/poliastro/core/propagation/mikkola.py
+++ b/src/poliastro/core/propagation/mikkola.py
@@ -103,20 +103,20 @@ def mikkola(k, r0, v0, tof, rtol=None):
     ----------
     k : float
         Standard gravitational parameter of the attractor.
-    r : ~np.array
+    r : numpy.ndarray
         Position vector.
-    v : ~np.array
+    v : numpy.ndarray
         Velocity vector.
     tof : float
         Time of flight.
-    rtol: float
+    rtol : float
         This method does not require tolerance since it is non-iterative.
 
     Returns
     -------
-    rr : ~np.array
+    rr : numpy.ndarray
         Final velocity vector.
-    vv : ~np.array
+    vv : numpy.ndarray
         Final velocity vector.
     Note
     ----

--- a/src/poliastro/core/propagation/pimienta.py
+++ b/src/poliastro/core/propagation/pimienta.py
@@ -346,22 +346,22 @@ def pimienta(k, r0, v0, tof):
     ----------
     k : float
         Standar Gravitational parameter.
-    r0 : ~np.array
+    r0 : numpy.ndarray
         Initial position vector wrt attractor center.
-    v0 : ~np.array
+    v0 : numpy.ndarray
         Initial velocity vector.
     tof : float
         Time of flight.
 
     Returns
     -------
-    rr: ~np.array
+    rr: numpy.ndarray
         Final position vector.
-    vv: ~np.array
+    vv: numpy.ndarray
         Final velocity vector.
 
-    Note
-    ----
+    Notes
+    -----
     This algorithm was derived from the original paper:
     Pimienta-Peñalver, A. & Crassidis, John. (2013). Accurate Kepler equation
     solver without transcendental function evaluations. Advances in the Astronautical Sciences. 147. 233-247.

--- a/src/poliastro/core/propagation/vallado.py
+++ b/src/poliastro/core/propagation/vallado.py
@@ -42,16 +42,15 @@ def vallado(k, r0, v0, tof, numiter):
 
     Parameters
     ----------
-
-    k: float
+    k : float
         Standard gravitational parameter.
-    r0: ~np.array
+    r0 : numpy.ndarray
         Initial position vector.
-    v0: ~np.array
+    v0 : numpy.ndarray
         Initial velocity vector.
-    tof: float
+    tof : float
         Time of flight.
-    numiter: int
+    numiter : int
         Number of iterations.
 
     Returns
@@ -65,9 +64,8 @@ def vallado(k, r0, v0, tof, numiter):
     gdot: float
         Derivative of the second coefficient
 
-
-    Note
-    ----
+    Notes
+    -----
     The theoretical procedure is explained in section 3.7 of Curtis in really
     deep detail. For analytical example, check in the same book for example 3.6.
 

--- a/src/poliastro/core/sensors.py
+++ b/src/poliastro/core/sensors.py
@@ -8,13 +8,13 @@ def min_and_max_ground_range(h, η_fov, η_center, R):
 
     Parameters
     ----------
-    h: float
+    h : float
         Altitude over surface.
-    η_fov: float
+    η_fov : float
         Angle of the total area that a sensor can observe.
-    η_center: float
+    η_center : float
         Center boresight angle.
-    R: float
+    R : float
         Attractor equatorial radius.
 
     Returns
@@ -57,19 +57,19 @@ def ground_range_diff_at_azimuth(h, η_fov, η_center, β, φ_nadir, λ_nadir, R
 
     Parameters
     ----------
-    h: float
+    h : float
         Altitude over surface.
-    η_fov: float
+    η_fov : float
         Angle of the total area that a sensor can observe.
-    η_center: float
+    η_center : float
         Center boresight angle.
-    β: float
+    β : float
         Phase angle, used to specify where the sensor is looking.
-    φ_nadir: float
+    φ_nadir : float
         Latitude angle of nadir point.
-    λ_nadir: float
+    λ_nadir : float
         Longitude angle of nadir point.
-    R: float
+    R : float
         Earth equatorial radius.
 
     Returns

--- a/src/poliastro/core/spheroid_location.py
+++ b/src/poliastro/core/spheroid_location.py
@@ -129,8 +129,7 @@ def distance(cartesian_cords, px, py, pz):
 
 @jit
 def is_visible(cartesian_cords, px, py, pz, N):
-    """Determines whether an object located at a given point is visible from the given location.
-    Returns true if true, false otherwise.
+    """Determine whether an object located at a given point is visible from the given location.
 
     Parameters
     ----------
@@ -142,6 +141,8 @@ def is_visible(cartesian_cords, px, py, pz, N):
         y-coordinate of the point
     pz : float
         z-coordinate of the point
+    N : numpy.ndarray
+        Normal vector of the ellipsoid at the given location.
 
     """
     c = cartesian_cords

--- a/src/poliastro/core/spheroid_location.py
+++ b/src/poliastro/core/spheroid_location.py
@@ -10,15 +10,15 @@ def cartesian_cords(_a, _c, _lon, _lat, _h):
 
     Parameters
     ----------
-    _a: float
+    _a : float
         Semi-major axis
-    _c: float
+    _c : float
         Semi-minor axis
-    _lon: float
+    _lon : float
         Geodetic longitude
-    _lat: float
+    _lat : float
         Geodetic latitude
-    _h: float
+    _h : float
         Geodetic height
 
     """
@@ -37,9 +37,9 @@ def f(_a, _c):
 
     Parameters
     ----------
-    _a: float
+    _a : float
         Semi-major axis
-    _c: float
+    _c : float
         Semi-minor axis
 
     """
@@ -52,13 +52,13 @@ def N(a, b, c, cartesian_cords):
 
     Parameters
     ----------
-    a: float
+    a : float
         Semi-major axis
-    b: float
+    b : float
         Equatorial radius
-    c: float
+    c : float
         Semi-minor axis
-    cartesian_cords: ~np.array
+    cartesian_cords : numpy.ndarray
         Cartesian coordinates
 
     """
@@ -74,7 +74,7 @@ def tangential_vecs(N):
 
     Parameters
     ----------
-    N: ~np.array
+    N : numpy.ndarray
         Normal vector of the ellipsoid
 
     """
@@ -92,11 +92,11 @@ def radius_of_curvature(_a, _c, _lat):
 
     Parameters
     ----------
-    _a: float
+    _a : float
         Semi-major axis
-    _c: float
+    _c : float
         Semi-minor axis
-    _lat: float
+    _lat : float
         Geodetic latitude
 
     """
@@ -111,13 +111,13 @@ def distance(cartesian_cords, px, py, pz):
 
     Parameters
     ----------
-    cartesian_cords: ~np.array
+    cartesian_cords : numpy.ndarray
         Cartesian coordinates
-    px: float
+    px : float
         x-coordinate of the point
-    py: float
+    py : float
         y-coordinate of the point
-    pz: float
+    pz : float
         z-coordinate of the point
 
     """
@@ -134,13 +134,13 @@ def is_visible(cartesian_cords, px, py, pz, N):
 
     Parameters
     ----------
-    cartesian_cords: ~np.array
+    cartesian_cords : numpy.ndarray
         Cartesian coordinates
-    px: float
+    px : float
         x-coordinate of the point
-    py: float
+    py : float
         y-coordinate of the point
-    pz: float
+    pz : float
         z-coordinate of the point
 
     """
@@ -161,15 +161,15 @@ def cartesian_to_ellipsoidal(_a, _c, x, y, z):
 
     Parameters
     ----------
-    _a: float
+    _a : float
         Semi-major axis
-    _c: float
+    _c : float
         Semi-minor axis
-    x: float
+    x : float
         x coordinate
-    y: float
+    y : float
         y coordinate
-    z: float
+    z : float
         z coordinate
 
     """

--- a/src/poliastro/core/thrust/change_a_inc.py
+++ b/src/poliastro/core/thrust/change_a_inc.py
@@ -75,11 +75,8 @@ def change_a_inc(k, a_0, a_f, inc_0, inc_f, f):
     Returns
     -------
     a_d : function
-
     delta_V : numpy.array
-
     t_f : float
-
 
     Notes
     -----

--- a/src/poliastro/core/thrust/change_argp.py
+++ b/src/poliastro/core/thrust/change_argp.py
@@ -48,9 +48,7 @@ def change_argp(k, a, ecc, argp_0, argp_f, f):
     Returns
     -------
     a_d : function
-
     delta_V : numpy.array
-
     t_f : float
     """
 

--- a/src/poliastro/core/util.py
+++ b/src/poliastro/core/util.py
@@ -58,7 +58,6 @@ def spherical_to_cartesian(v):
 
     Returns
     -------
-
     v : np.array
         Cartesian coordinates (x,y,z)
 

--- a/src/poliastro/czml/extract_czml.py
+++ b/src/poliastro/czml/extract_czml.py
@@ -55,16 +55,16 @@ class CZMLExtractor:
 
         Parameters
         ----------
-        start_epoch: ~astropy.time.core.Time
+        start_epoch : ~astropy.time.core.Time
             Starting epoch
-        end_epoch: ~astropy.time.core.Time
+        end_epoch : ~astropy.time.core.Time
             Ending epoch
-        N: int
+        N : int
             Default number of sample points. Unless otherwise specified, the
             number of sampled data points will be N when calling add_orbit()
-        attractor: poliastro.Body
+        attractor : poliastro.Body
             Attractor of the orbits
-        scene3D: bool
+        scene3D : bool
             Determines the scene mode. If set to true, the scene is set to 3D
             mode, otherwise it's the orthographic projection.
 
@@ -107,13 +107,13 @@ class CZMLExtractor:
 
     def _init_orbit_packet_cords_(self, i, rtol):
         """
-
         Parameters
         ----------
-        i: int
+        i : int
             Index of referenced orbit
-        rtol: float
+        rtol : float
             Maximum relative error permitted
+
         Returns
         -------
         coordinate list
@@ -141,12 +141,11 @@ class CZMLExtractor:
 
     def _init_groundtrack_packet_cords_(self, i, rtol):
         """
-
         Parameters
         ----------
-        i: int
+        i : int
             Index of referenced orbit
-        rtol: float
+        rtol : float
             Maximum relative error permitted
 
         Returns
@@ -210,10 +209,10 @@ class CZMLExtractor:
 
         Parameters
         ----------
-        ellipsoid: list(int)
+        ellipsoid : list(int)
             Defines the attractor ellipsoid. The list must have three numbers
             representing the radii in the x, y and z axis
-        pr_map: str
+        pr_map : str
             A URL to the projection of the defined ellipsoid (UV map)
 
         """
@@ -250,20 +249,20 @@ class CZMLExtractor:
 
         Parameters
         ----------
-        pos: list [~astropy.units.Quantity]
+        pos : list[~astropy.units.Quantity]
             Coordinates of ground station,
             list of geodetic latitude and longitude [lon, lat] (0 elevation)
-        id_description: str
+        id_description : str
             Set ground station description
-        label_fill_color: list (int)
+        label_fill_color : list[int]
             Fill Color in rgba format
-        label_outline_color: list (int)
+        label_outline_color : list[int]
             Outline Color in rgba format
-        label_font: str
+        label_font : str
             Set label font style and size (CSS syntax)
-        label_text: str
+        label_text : str
             Set label text
-        label_show: bool
+        label_show : bool
             Indicates whether the label is visible
         """
         if (
@@ -338,42 +337,42 @@ class CZMLExtractor:
 
         Parameters
         ----------
-        orbit: poliastro.twobody.orbit.Orbit
+        orbit : poliastro.twobody.orbit.Orbit
             Orbit to be added
-        rtol: float
+        rtol : float
             Maximum relative error permitted
-        N: int
+        N : int
             Number of sample points
-        groundtrack_show: bool
+        groundtrack_show : bool
             If set to true, the groundtrack is
             displayed.
-        groundtrack_lead_time: float
+        groundtrack_lead_time : float
             The time the animation is ahead of the real-time groundtrack
-        groundtrack_trail_time: float
+        groundtrack_trail_time : float
             The time the animation is behind the real-time groundtrack
-        groundtrack_width: int
+        groundtrack_width : int
             Groundtrack width
-        groundtrack_color: list (int)
+        groundtrack_color : list[int]
             Rgba groundtrack color. By default, it is set to the path color
-        id_name: str
+        id_name : str
             Set orbit name
-        id_description: str
+        id_description : str
             Set orbit description
-        path_width: int
+        path_width : int
             Path width
-        path_show: bool
+        path_show : bool
             Indicates whether the path is visible
-        path_color: list (int)
+        path_color : list[int]
             Rgba path color
-        label_fill_color: list (int)
+        label_fill_color : list[int]
             Fill Color in rgba format
-        label_outline_color: list (int)
+        label_outline_color : list[int]
             Outline Color in rgba format
-        label_font: str
+        label_font : str
             Set label font style and size (CSS syntax)
-        label_text: str
+        label_text : str
             Set label text
-        label_show: bool
+        label_show : bool
             Indicates whether the label is visible
         """
 
@@ -502,40 +501,40 @@ class CZMLExtractor:
 
         Parameters
         ----------
-        positions: ~astropy.coordinates.CartesianRepresentation
+        positions : ~astropy.coordinates.CartesianRepresentation
             Trajectory to plot.
-        epochs: ~astropy.time.Time
+        epochs : ~astropy.time.Time
             Epochs for positions.
-        groundtrack_show: bool
+        groundtrack_show : bool
             If set to true, the groundtrack is
             displayed.
-        groundtrack_lead_time: float
+        groundtrack_lead_time : float
             The time the animation is ahead of the real-time groundtrack
-        groundtrack_trail_time: float
+        groundtrack_trail_time : float
             The time the animation is behind the real-time groundtrack
-        groundtrack_width: int
+        groundtrack_width : int
             Groundtrack width
-        groundtrack_color: list (int)
+        groundtrack_color : list[int]
             Rgba groundtrack color. By default, it is set to the path color
-        id_name: str
+        id_name : str
             Set orbit name
-        id_description: str
+        id_description : str
             Set orbit description
-        path_width: int
+        path_width : int
             Path width
-        path_show: bool
+        path_show : bool
             Indicates whether the path is visible
-        path_color: list (int)
+        path_color : list[int]
             Rgba path color
-        label_fill_color: list (int)
+        label_fill_color : list[int]
             Fill Color in rgba format
-        label_outline_color: list (int)
+        label_outline_color : list[int]
             Outline Color in rgba format
-        label_font: str
+        label_font : str
             Set label font style and size (CSS syntax)
-        label_text: str
+        label_text : str
             Set label text
-        label_show: bool
+        label_show : bool
             Indicates whether the label is visible
 
         """

--- a/src/poliastro/czml/extract_czml.py
+++ b/src/poliastro/czml/extract_czml.py
@@ -62,8 +62,10 @@ class CZMLExtractor:
         N : int
             Default number of sample points. Unless otherwise specified, the
             number of sampled data points will be N when calling add_orbit()
-        attractor : poliastro.Body
+        attractor : poliastro.bodies.Body
             Attractor of the orbits
+        pr_map : str
+            A URL to the projection of the defined ellipsoid (UV map).
         scene3D : bool
             Determines the scene mode. If set to true, the scene is set to 3D
             mode, otherwise it's the orthographic projection.
@@ -209,11 +211,14 @@ class CZMLExtractor:
 
         Parameters
         ----------
-        ellipsoid : list(int)
+        ellipsoid : list[int]
             Defines the attractor ellipsoid. The list must have three numbers
             representing the radii in the x, y and z axis
         pr_map : str
-            A URL to the projection of the defined ellipsoid (UV map)
+            A URL to the projection of the defined ellipsoid (UV map).
+        scene3D : bool
+            If set to true, the scene is set to 3D mode,
+            otherwise it's the orthographic projection.
 
         """
 

--- a/src/poliastro/earth/__init__.py
+++ b/src/poliastro/earth/__init__.py
@@ -29,7 +29,7 @@ class EarthSatellite:
         orbit : Orbit
             Position and velocity of a body with respect to an attractor
             at a given time (epoch).
-        spacecraft: Spacecraft
+        spacecraft : Spacecraft
 
         Raises
         ------
@@ -63,12 +63,11 @@ class EarthSatellite:
 
         Parameters
         ----------
-
         tof : ~astropy.units.Quantity, ~astropy.time.Time, ~astropy.time.TimeDelta
             Scalar time to propagate.
         atmosphere:
             a callable model from poliastro.earth.atmosphere
-        gravity: EarthGravity
+        gravity : EarthGravity
             There are two possible values, SPHERICAL and J2. Only J2 is implemented at the moment. Default value is None.
         *args:
             parameters used in perturbation models.

--- a/src/poliastro/earth/atmosphere/base.py
+++ b/src/poliastro/earth/atmosphere/base.py
@@ -16,7 +16,7 @@ class COESA:
 
         Parameters
         ----------
-        tables: *tables
+        *tables : *tables
             Different tables that define the atmosphere.
 
         """
@@ -52,11 +52,11 @@ class COESA:
 
         Parameters
         ----------
-        alt: ~astropy.units.Quantity
+        alt : ~astropy.units.Quantity
             Altitude to be checked.
-        r0: ~astropy.units.Quantity
+        r0 : ~astropy.units.Quantity
             Attractor radius.
-        geometric: bool
+        geometric : bool
             If `True`, assumes geometric altitude kind.
 
         Returns
@@ -86,9 +86,9 @@ class COESA:
 
         Parameters
         ----------
-        x: ~astropy.units.Quantity
+        x : ~astropy.units.Quantity
             Element to be searched.
-        x_levels: ~astropy.units.Quantity
+        x_levels : ~astropy.units.Quantity
             List for searching.
 
         Returns

--- a/src/poliastro/earth/atmosphere/coesa62.py
+++ b/src/poliastro/earth/atmosphere/coesa62.py
@@ -102,9 +102,9 @@ class COESA62(COESA):
 
         Parameters
         ----------
-        alt: ~astropy.units.Quantity
+        alt : ~astropy.units.Quantity
             Geometric/Geopotential altitude.
-        geometric: bool
+        geometric : bool
             If `True`, assumes geometric altitude kind.
 
         Returns
@@ -136,9 +136,9 @@ class COESA62(COESA):
 
         Parameters
         ----------
-        alt: ~astropy.units.Quantity
+        alt : ~astropy.units.Quantity
             Geometric/Geopotential altitude.
-        geometric: bool
+        geometric : bool
             If `True`, assumes geometric altitude.
 
         Returns
@@ -196,9 +196,9 @@ class COESA62(COESA):
 
         Parameters
         ----------
-        alt: ~astropy.units.Quantity
+        alt : ~astropy.units.Quantity
             Geometric/Geopotential altitude.
-        geometric: bool
+        geometric : bool
             If `True`, assumes geometric altitude.
 
         Returns
@@ -222,9 +222,9 @@ class COESA62(COESA):
 
         Parameters
         ----------
-        alt: ~astropy.units.Quantity
+        alt : ~astropy.units.Quantity
             Geometric/Geopotential height.
-        geometric: bool
+        geometric : bool
             If `True`, assumes that `alt` argument is geometric kind.
 
         Returns
@@ -247,9 +247,9 @@ class COESA62(COESA):
 
         Parameters
         ----------
-        alt: ~astropy.units.Quantity
+        alt : ~astropy.units.Quantity
             Geometric/Geopotential height.
-        geometric: bool
+        geometric : bool
             If `True`, assumes that `alt` argument is geometric kind.
 
         Returns
@@ -275,9 +275,9 @@ class COESA62(COESA):
 
         Parameters
         ----------
-        alt: ~astropy.units.Quantity
+        alt : ~astropy.units.Quantity
             Geometric/Geopotential height.
-        geometric: bool
+        geometric : bool
             If `True`, assumes that `alt` argument is geometric kind.
 
         Returns
@@ -303,9 +303,9 @@ class COESA62(COESA):
 
         Parameters
         ----------
-        alt: ~astropy.units.Quantity
+        alt : ~astropy.units.Quantity
             Geometric/Geopotential height.
-        geometric: bool
+        geometric : bool
             If `True`, assumes that `alt` argument is geometric kind.
 
         Returns

--- a/src/poliastro/earth/atmosphere/coesa76.py
+++ b/src/poliastro/earth/atmosphere/coesa76.py
@@ -112,9 +112,9 @@ class COESA76(COESA):
 
         Parameters
         ----------
-        z: ~astropy.units.Quantity
+        z : ~astropy.units.Quantity
             Geometric altitude
-        table_coeff: list
+        table_coeff : list
             List containing different coefficient lists.
 
         Returns
@@ -136,9 +136,9 @@ class COESA76(COESA):
 
         Parameters
         ----------
-        alt: ~astropy.units.Quantity
+        alt : ~astropy.units.Quantity
             Geometric/Geopotential altitude.
-        geometric: bool
+        geometric : bool
             If `True`, assumes geometric altitude kind.
 
         Returns
@@ -187,9 +187,9 @@ class COESA76(COESA):
 
         Parameters
         ----------
-        alt: ~astropy.units.Quantity
+        alt : ~astropy.units.Quantity
             Geometric/Geopotential altitude.
-        geometric: bool
+        geometric : bool
             If `True`, assumes geometric altitude kind.
 
         Returns
@@ -233,9 +233,9 @@ class COESA76(COESA):
 
         Parameters
         ----------
-        alt: ~astropy.units.Quantity
+        alt : ~astropy.units.Quantity
             Geometric/Geopotential height.
-        geometric: bool
+        geometric : bool
             If `True`, assumes that `alt` argument is geometric kind.
 
         Returns
@@ -273,9 +273,9 @@ class COESA76(COESA):
 
         Parameters
         ----------
-        alt: ~astropy.units.Quantity
+        alt : ~astropy.units.Quantity
             Geometric/Geopotential height.
-        geometric: bool
+        geometric : bool
             If `True`, assumes that `alt` argument is geometric kind.
 
         Returns
@@ -298,9 +298,9 @@ class COESA76(COESA):
 
         Parameters
         ----------
-        alt: ~astropy.units.Quantity
+        alt : ~astropy.units.Quantity
             Geometric/Geopotential height.
-        geometric: bool
+        geometric : bool
             If `True`, assumes that `alt` argument is geometric kind.
 
         Returns
@@ -326,9 +326,9 @@ class COESA76(COESA):
 
         Parameters
         ----------
-        alt: ~astropy.units.Quantity
+        alt : ~astropy.units.Quantity
             Geometric/Geopotential height.
-        geometric: bool
+        geometric : bool
             If `True`, assumes that `alt` argument is geometric kind.
 
         Returns
@@ -354,9 +354,9 @@ class COESA76(COESA):
 
         Parameters
         ----------
-        alt: ~astropy.units.Quantity
+        alt : ~astropy.units.Quantity
             Geometric/Geopotential height.
-        geometric: bool
+        geometric : bool
             If `True`, assumes that `alt` argument is geometric kind.
 
         Returns

--- a/src/poliastro/earth/atmosphere/jacchia.py
+++ b/src/poliastro/earth/atmosphere/jacchia.py
@@ -74,7 +74,7 @@ class Jacchia77:
 
         Parameters
         ----------
-        alt: ~astropy.units.Quantity
+        alt : ~astropy.units.Quantity
             Geometric/Geopotential altitude.
 
         Returns
@@ -96,7 +96,7 @@ class Jacchia77:
 
         Parameters
         ----------
-        alt: ~astropy.units.Quantity
+        alt : ~astropy.units.Quantity
             Geometric/Geopotential altitude.
 
         Returns
@@ -112,10 +112,8 @@ class Jacchia77:
 
         Parameters
         ----------
-        alt: ~astropy.units.Quantity
+        alt : ~astropy.units.Quantity
             Geometric/Geopotential altitude.
-        Texo: ~astropy.units.Quantity
-            Exospheric temperature
 
         Returns
         -------
@@ -134,7 +132,7 @@ class Jacchia77:
 
         Parameters
         ----------
-        alt: ~astropy.units.Quantity
+        alt : ~astropy.units.Quantity
             Geometric/Geopotential altitude.
 
         Returns

--- a/src/poliastro/earth/plotting/groundtrack.py
+++ b/src/poliastro/earth/plotting/groundtrack.py
@@ -22,9 +22,9 @@ class GroundtrackPlotter:
 
         Parameters
         ----------
-        fig: ~plotly.graph_objects.Figure
+        fig : ~plotly.graph_objects.Figure
             Figure instance for the canvas
-        color_palette: dict
+        color_palette : dict
             A color palette for background map
 
         """
@@ -54,7 +54,7 @@ class GroundtrackPlotter:
 
         Parameters
         ----------
-        config: dict
+        **config : dict
             A collection of custom values for geo figure
 
         """
@@ -66,7 +66,7 @@ class GroundtrackPlotter:
 
         Parameters
         ----------
-        config: dict
+        **config : dict
             A collection of custom values for figure layout
 
         """
@@ -83,16 +83,16 @@ class GroundtrackPlotter:
 
         Parameters
         ----------
-        ss: ~poliastro.twobody.orbit
+        ss : ~poliastro.twobody.orbit
             Orbit to be propagated
-        t_deltas: ~astropy.time.DeltaTime
+        t_deltas : ~astropy.time.DeltaTime
             Desired observation time
 
         Returns
         -------
-        raw_xyz: array
+        raw_xyz : numpy.ndarray
             A collection of raw cartessian position vectors
-        raw_epochs: array
+        raw_epochs : numpy.ndarray
             Associated epoch with previously raw coordinates
         """
 
@@ -107,9 +107,9 @@ class GroundtrackPlotter:
 
         Parameters
         ----------
-        raw_xyz: array
+        raw_xyz : numpy.ndarray
             A collection of rwa position coordinates
-        raw_obstime: array
+        raw_obstime : numpy.ndarray
             Associated observation time
 
         Returns
@@ -132,13 +132,13 @@ class GroundtrackPlotter:
 
         Parameters
         ----------
-        ss: ~poliastro.twobody.Orbit
+        ss : ~poliastro.twobody.Orbit
             EarthSatellite's associated Orbit
-        t_deltas: ~astropy.time.DeltaTime
+        t_deltas : ~astropy.time.DeltaTime
             Collection of epochs
-        label: string
+        label : string
             Name for the trace
-        line_style: dict
+        line_style : dict
             Dictionary for customizing groundtrack line trace
 
         Returns
@@ -169,11 +169,11 @@ class GroundtrackPlotter:
 
         Parameters
         ----------
-        ss: ~poliastro.twobody.Orbit
+        ss : ~poliastro.twobody.Orbit
             EarthSatellite's orbit
-        label: string
+        label : string
             Label for the orbit
-        marker: dict
+        marker : dict
             Dicitonary holding plotly marker configuration
 
         Returns
@@ -208,15 +208,15 @@ class GroundtrackPlotter:
 
         Parameters
         ----------
-        earth_ss: ~poliastro.earth.EarthSatellite
+        earth_ss : ~poliastro.earth.EarthSatellite
             Desired Earth's satellite to who's grountrack will be plotted
-        t_span: ~astropy.time.TimeDelta
+        t_span : ~astropy.time.TimeDelta
             A collection of epochs
-        color: string
+        color : string
             Desired lines and traces color
-        line_style: dict
+        line_style : dict
             Dictionary for customizing groundtrack line trace
-        marker: dict
+        marker : dict
             Dictionary for customizing groundtrack marker trace
 
         Returns

--- a/src/poliastro/earth/plotting/groundtrack.py
+++ b/src/poliastro/earth/plotting/groundtrack.py
@@ -204,7 +204,7 @@ class GroundtrackPlotter:
         return trace
 
     def plot(self, earth_ss, t_span, label, color, line_style={}, marker={}):
-        """Plots desired Earth satellite orbit for a given time span
+        """Plots desired Earth satellite orbit for a given time span.
 
         Parameters
         ----------
@@ -212,6 +212,8 @@ class GroundtrackPlotter:
             Desired Earth's satellite to who's grountrack will be plotted
         t_span : ~astropy.time.TimeDelta
             A collection of epochs
+        label : str
+            Label for the groundtrack.
         color : string
             Desired lines and traces color
         line_style : dict

--- a/src/poliastro/earth/util.py
+++ b/src/poliastro/earth/util.py
@@ -13,17 +13,17 @@ def raan_from_ltan(epoch, ltan=12.0):
     Parameters
     ----------
     epoch : ~astropy.time.Time
-         Value of time to calculate the RAAN for
-    ltan: ~astropy.units.Quantity
-         Decimal hour between 0 and 24
+        Value of time to calculate the RAAN for
+    ltan : ~astropy.units.Quantity
+        Decimal hour between 0 and 24
 
     Returns
     -------
     RAAN: ~astropy.units.Quantity
         Right ascension of the ascending node angle in GCRS
 
-    Note
-    ----
+    Notes
+    -----
     Calculations of the sun mean longitude and equation of time
     follow "Fundamentals of Astrodynamics and Applications"
     Fourth edition by Vallado, David A.

--- a/src/poliastro/ephem.py
+++ b/src/poliastro/ephem.py
@@ -47,6 +47,8 @@ def build_ephem_interpolant(body, period, t_span, rtol=1e-5):
     rtol : float, optional
         Relative tolerance. Controls the number of sampled data points,
         defaults to 1e-5.
+    attractor : ~poliastro.bodies.Body, optional
+        Attractor, default to Earth.
 
     Returns
     -------
@@ -333,6 +335,8 @@ class Ephem:
         method : ~poliastro.ephem.InterpolationMethods, optional
             Interpolation method to use for epochs outside of the original ones,
             default to splines.
+        **kwargs
+            Extra kwargs for interpolation method.
 
         Returns
         -------
@@ -357,6 +361,8 @@ class Ephem:
         ----------
         epochs : ~astropy.time.Time, optional
             Epochs to sample the ephemerides, default to now.
+        **kwargs
+            Extra kwargs for interpolation method.
 
         """
         coordinates = self.sample(epochs, **kwargs)

--- a/src/poliastro/ephem.py
+++ b/src/poliastro/ephem.py
@@ -189,9 +189,9 @@ class Ephem:
 
         Parameters
         ----------
-        body: ~poliastro.bodies.SolarSystemPlanet
+        body : ~poliastro.bodies.SolarSystemPlanet
             Body.
-        epochs: ~astropy.time.Time
+        epochs : ~astropy.time.Time
             Epochs to sample the body positions.
         attractor : ~poliastro.bodies.SolarSystemPlanet, optional
             Body to use as central location,
@@ -242,7 +242,7 @@ class Ephem:
         ----------
         name : str
             Name of the body to query for.
-        epochs: ~astropy.time.Time
+        epochs : ~astropy.time.Time
             Epochs to sample the body positions.
         attractor : ~poliastro.bodies.SolarSystemPlanet, optional
             Body to use as central location,
@@ -306,11 +306,11 @@ class Ephem:
 
         Parameters
         ----------
-        orbit: ~poliastro.twobody.orbit.Orbit
+        orbit : ~poliastro.twobody.orbit.Orbit
             Orbit.
-        epochs: ~astropy.time.Time
+        epochs : ~astropy.time.Time
             Epochs to sample the orbit positions.
-        plane: ~poliastro.frames.Planes, optional
+        plane : ~poliastro.frames.Planes, optional
             Fundamental plane of the frame, default to Earth Equator.
 
         """
@@ -327,7 +327,7 @@ class Ephem:
 
         Parameters
         ----------
-        epochs: ~astropy.time.Time, optional
+        epochs : ~astropy.time.Time, optional
             Epochs to sample the ephemerides,
             if not given the original one from the object will be used.
         method : ~poliastro.ephem.InterpolationMethods, optional

--- a/src/poliastro/iod/vallado.py
+++ b/src/poliastro/iod/vallado.py
@@ -35,8 +35,8 @@ def lambert(k, r0, r, tof, short=True, numiter=35, rtol=1e-8):
     RuntimeError
         If it was not possible to compute the orbit.
 
-    Note
-    ----
+    Notes
+    -----
     This uses the universal variable approach found in Battin, Mueller & White
     with the bisection iteration suggested by Vallado. Multiple revolutions
     not supported.

--- a/src/poliastro/maneuver.py
+++ b/src/poliastro/maneuver.py
@@ -68,7 +68,7 @@ class Maneuver:
 
         Parameters
         ----------
-        dv: np.array
+        dv : np.array
             Velocity components of the impulse.
 
         """
@@ -81,9 +81,9 @@ class Maneuver:
 
         Parameters
         ----------
-        orbit_i: poliastro.twobody.orbit.Orbit
+        orbit_i : poliastro.twobody.orbit.Orbit
             Initial orbit
-        r_f: astropy.unit.Quantity
+        r_f : astropy.unit.Quantity
             Final altitude of the orbit
 
         """
@@ -117,11 +117,11 @@ class Maneuver:
 
         Parameters
         ----------
-        orbit_i: poliastro.twobody.orbit.Orbit
+        orbit_i : poliastro.twobody.orbit.Orbit
             Initial orbit
-        r_b: astropy.unit.Quantity
+        r_b : astropy.unit.Quantity
             Altitude of the intermediate orbit
-        r_f: astropy.unit.Quantity
+        r_f : astropy.unit.Quantity
             Final altitude of the orbit
 
         """
@@ -168,13 +168,13 @@ class Maneuver:
 
         Parameters
         ----------
-        orbit_i: ~poliastro.twobody.Orbit
+        orbit_i : ~poliastro.twobody.Orbit
             Initial orbit
-        orbit_f: ~poliastro.twobody.Orbit
+        orbit_f : ~poliastro.twobody.Orbit
             Final orbit
-        method: function
+        method : function
             Method for solving Lambert's problem
-        short: keyword, boolean
+        short : bool
             Selects between short and long solution
 
         """
@@ -187,7 +187,8 @@ class Maneuver:
         tof = orbit_f.epoch - orbit_i.epoch
         if tof < 0:
             raise ValueError(
-                "Epoch of intial orbit Greater than Epoch of final orbit causing a Negative Time Of Flight"
+                "Epoch of initial orbit greater than epoch of final orbit, "
+                "causing a negative time of flight"
             )
 
         # Compute all possible solutions to the Lambert transfer
@@ -221,7 +222,7 @@ class Maneuver:
         orbit : Orbit
             Position and velocity of a body with respect to an attractor
             at a given time (epoch).
-        max_delta_r: ~astropy.units.Quantity
+        max_delta_r : ~astropy.units.Quantity
             Maximum satellite’s geocentric distance
 
         Returns

--- a/src/poliastro/maneuver.py
+++ b/src/poliastro/maneuver.py
@@ -33,7 +33,7 @@ class Maneuver:
 
         Parameters
         ----------
-        impulses : list
+        *args : list
             List of pairs (delta_time, delta_velocity)
 
         """
@@ -176,6 +176,8 @@ class Maneuver:
             Method for solving Lambert's problem
         short : bool
             Selects between short and long solution
+        **kwargs
+            Extra kwargs for Lambert method.
 
         """
         # Get initial algorithm conditions

--- a/src/poliastro/plotting/_base.py
+++ b/src/poliastro/plotting/_base.py
@@ -318,9 +318,9 @@ class BaseOrbitPlotter:
 
         Parameters
         ----------
-        initial_orbit: ~poliastro.twobody.orbit.Orbit
+        initial_orbit : ~poliastro.twobody.orbit.Orbit
             The base orbit for which the maneuver will be applied.
-        manuever: ~poliastro.maneuver.Maneuver
+        maneuver : ~poliastro.maneuver.Maneuver
             The maneuver to be plotted.
         label : str, optional
             Label of the trajectory.

--- a/src/poliastro/plotting/interactive.py
+++ b/src/poliastro/plotting/interactive.py
@@ -65,9 +65,9 @@ class _PlotlyOrbitPlotter(BaseOrbitPlotter):
 
         Parameters
         ----------
-        initial_orbit: ~poliastro.twobody.orbit.Orbit
+        initial_orbit : ~poliastro.twobody.orbit.Orbit
             The base orbit for which the maneuver will be applied.
-        manuever: ~poliastro.maneuver.Maneuver
+        maneuver : ~poliastro.maneuver.Maneuver
             The maneuver to be plotted.
         label : str, optional
             Label of the trajectory.

--- a/src/poliastro/plotting/misc.py
+++ b/src/poliastro/plotting/misc.py
@@ -58,7 +58,7 @@ def plot_solar_system(outer=True, epoch=None, use_3d=False, interactive=False):
     .. versionadded:: 0.9.0
 
     Parameters
-    ------------
+    ----------
     outer : bool, optional
         Whether to print the outer Solar System, default to True.
     epoch : ~astropy.time.Time, optional

--- a/src/poliastro/plotting/porkchop.py
+++ b/src/poliastro/plotting/porkchop.py
@@ -116,11 +116,11 @@ class PorkchopPlotter:
         Time span for launch
     arrival_span: astropy.time.Time
         Time span for arrival
-    ax: matplotlib.axes.Axes:
+    ax: matplotlib.axes.Axes
         For custom figures
-    tfl: boolean
+    tfl: bool
         For plotting time flight contour lines
-    vhp: boolean
+    vhp: bool
         For plotting arrival velocity contour lines
     max_c3: float
         Sets the maximum C3 value for porkchop
@@ -156,19 +156,19 @@ class PorkchopPlotter:
 
         Returns
         -------
-        dv_launch: np.ndarray
+        dv_launch: numpy.ndarray
             Launch delta v
-        dv_arrival: np.ndarray
+        dv_arrival: numpy.ndarray
             Arrival delta v
-        c3_launch: np.ndarray
+        c3_launch: numpy.ndarray
             Characteristic launch energy
-        c3_arrrival: np.ndarray
+        c3_arrrival: numpy.ndarray
             Characteristic arrival energy
-        tof: np.ndarray
+        tof: numpy.ndarray
             Time of flight for each transfer
 
-        Example
-        -------
+        Examples
+        --------
         >>> from poliastro.plotting.porkchop import PorkchopPlotter
         >>> from poliastro.bodies import Earth, Mars
         >>> from poliastro.util import time_range

--- a/src/poliastro/plotting/static.py
+++ b/src/poliastro/plotting/static.py
@@ -38,6 +38,8 @@ class StaticOrbitPlotter(BaseOrbitPlotter, Mixin2D):
             Number of points to use in plots, default to 150.
         dark : bool, optional
             If set as True, plots the orbit in Dark mode.
+        plane : ~poliastro.frames.Planes
+            Reference plane of the coordinates.
 
         """
         super().__init__(num_points=num_points, plane=plane)

--- a/src/poliastro/plotting/static.py
+++ b/src/poliastro/plotting/static.py
@@ -215,9 +215,9 @@ class StaticOrbitPlotter(BaseOrbitPlotter, Mixin2D):
 
         Parameters
         ----------
-        initial_orbit: ~poliastro.twobody.orbit.Orbit
+        initial_orbit : ~poliastro.twobody.orbit.Orbit
             The base orbit for which the maneuver will be applied.
-        manuever: ~poliastro.maneuver.Maneuver
+        maneuver : ~poliastro.maneuver.Maneuver
             The maneuver to be plotted.
         label : str, optional
             Label of the trajectory.

--- a/src/poliastro/plotting/tisserand.py
+++ b/src/poliastro/plotting/tisserand.py
@@ -26,9 +26,9 @@ class TisserandPlotter:
 
         Parameters
         ----------
-        kind: TisserandKind
+        kind : TisserandKind
             Nature for the Tisserand
-        axes: ~matplotlib.pyplot.axes
+        axes : ~matplotlib.pyplot.axes
             Axes for the figure
 
         """
@@ -54,17 +54,17 @@ class TisserandPlotter:
 
         Parameters
         ----------
-        body: ~poliastro.bodies.Body
+        body : ~poliastro.bodies.Body
             Body to be plotted Tisserand
-        vinf_array: ~astropy.units.Quantity
+        vinf_array : ~astropy.units.Quantity
             Desired Vinf for the flyby
-        num_contours: int
+        num_contours : int
             Number of contour lines for flyby speed
-        N: int
+        N : int
             Number of points for flyby angle
 
-        Note
-        ----
+        Notes
+        -----
         The algorithm for generating Tisserand plots is the one depicted in
         "Preliminary Trajectory Design of a Mission to Enceladus" by David
         Falcato Fialho Palma, section 3.6
@@ -101,7 +101,7 @@ class TisserandPlotter:
 
         Parameters
         ----------
-        data: list
+        data : list
             Array containing [RR_P, RR_A, EE, TT, color]
 
         Returns
@@ -130,13 +130,13 @@ class TisserandPlotter:
 
         Parameters
         ----------
-        body: ~poliastro.bodies.Body
+        body : ~poliastro.bodies.Body
             Body to be plotted Tisserand
-        vinf: ~astropy.units.Quantity
+        vinf : ~astropy.units.Quantity
             Vinf velocity line
-        alpha_lim: tuple
+        alpha_lim : tuple
             Minimum and maximum flyby angles
-        color: str
+        color : str
             String representing for the color lines
 
         Returns
@@ -168,13 +168,13 @@ class TisserandPlotter:
 
         Parameters
         ----------
-        body: ~poliastro.bodies.Body
+        body : ~poliastro.bodies.Body
             Body to be plotted Tisserand
-        vinf_span: tuple
+        vinf_span : tuple
             Minimum and maximum Vinf velocities
-        num_contours: int
+        num_contours : int
             Number of points to iterate over previously defined velocities
-        color: str
+        color : str
             String representing for the color lines
 
         Returns

--- a/src/poliastro/plotting/tisserand.py
+++ b/src/poliastro/plotting/tisserand.py
@@ -60,8 +60,10 @@ class TisserandPlotter:
             Desired Vinf for the flyby
         num_contours : int
             Number of contour lines for flyby speed
+        alpha_lim : tuple
+            Minimum and maximum flyby angles.
         N : int
-            Number of points for flyby angle
+            Number of points for flyby angle.
 
         Notes
         -----

--- a/src/poliastro/sensors.py
+++ b/src/poliastro/sensors.py
@@ -13,13 +13,13 @@ def min_and_max_ground_range(altitude, fov, boresight, R):
 
     Parameters
     ----------
-    altitude: ~astropy.units.Quantity
+    altitude : ~astropy.units.Quantity
         Altitude over surface.
-    fov: ~astropy.units.Quantity
+    fov : ~astropy.units.Quantity
         Angle of the total area that a sensor can observe.
-    boresight: ~astropy.units.Quantity
+    boresight : ~astropy.units.Quantity
         Center boresight angle.
-    R: ~astropy.units.Quantity
+    R : ~astropy.units.Quantity
         Attractor equatorial radius.
 
     Returns
@@ -61,19 +61,19 @@ def ground_range_diff_at_azimuth(
 
     Parameters
     ----------
-    altitude: ~astropy.units.Quantity
+    altitude : ~astropy.units.Quantity
         Altitude over surface.
-    fov: ~astropy.units.Quantity
+    fov : ~astropy.units.Quantity
         Angle of the total area that a sensor can observe.
-    boresight: ~astropy.units.Quantity
+    boresight : ~astropy.units.Quantity
         Center boresight angle.
-    azimuth: ~astropy.units.Quantity
+    azimuth : ~astropy.units.Quantity
         Azimuth angle, used to specify where the sensor is looking.
-    nadir_lat: ~astropy.units.Quantity
+    nadir_lat : ~astropy.units.Quantity
         Latitude angle of nadir point.
-    nadir_lon: ~astropy.units.Quantity
+    nadir_lon : ~astropy.units.Quantity
         Longitude angle of nadir point.
-    R: ~astropy.units.Quantity
+    R : ~astropy.units.Quantity
         Attractor equatorial radius.
 
     Returns

--- a/src/poliastro/spacecraft/__init__.py
+++ b/src/poliastro/spacecraft/__init__.py
@@ -13,13 +13,13 @@ class Spacecraft:
 
         Parameters
         ----------
-        A: ~astropy.units.Quantity
+        A : ~astropy.units.Quantity
             Area of the spacecraft (km^2)
-        C_D: ~astropy.units.Quantity
+        C_D : ~astropy.units.Quantity
             Dimensionless drag coefficient ()
-        m: ~astropy.units.Quantity
+        m : ~astropy.units.Quantity
             Mass of the Spacecraft (kg)
-        metadata: Dict[object, dict]
+        **metadata : Dict[object, dict]
             Optional keyword arguments to Spacecraft
 
         """

--- a/src/poliastro/spheroid_location.py
+++ b/src/poliastro/spheroid_location.py
@@ -18,16 +18,15 @@ class SpheroidLocation:
 
     def __init__(self, lon, lat, h, body):
         """
-
         Parameters
         ----------
-        lon: ~astropy.units.quantity.Quantity
+        lon : ~astropy.units.quantity.Quantity
             Geodetic longitude
-        lat: ~astropy.units.quantity.Quantity
+        lat : ~astropy.units.quantity.Quantity
             Geodetic latitude
-        h: ~astropy.units.quantity.Quantity
+        h : ~astropy.units.quantity.Quantity
             Geodetic height
-        body: ~poliastro.bodies.Body
+        body : ~poliastro.bodies.Body
             Planetary body the spheroid location lies on
 
         """
@@ -96,11 +95,11 @@ class SpheroidLocation:
 
         Parameters
         ----------
-        px: ~astropy.units.quantity.Quantity
+        px : ~astropy.units.quantity.Quantity
             x-coordinate of the point
-        py: ~astropy.units.quantity.Quantity
+        py : ~astropy.units.quantity.Quantity
             y-coordinate of the point
-        pz: ~astropy.units.quantity.Quantity
+        pz : ~astropy.units.quantity.Quantity
             z-coordinate of the point
 
         """
@@ -117,11 +116,11 @@ class SpheroidLocation:
 
         Parameters
         ----------
-        px: ~astropy.units.quantity.Quantity
+        px : ~astropy.units.quantity.Quantity
             x-coordinate of the point
-        py: ~astropy.units.quantity.Quantity
+        py : ~astropy.units.quantity.Quantity
             y-coordinate of the point
-        pz: ~astropy.units.quantity.Quantity
+        pz : ~astropy.units.quantity.Quantity
             z-coordinate of the point
 
         """
@@ -136,11 +135,11 @@ class SpheroidLocation:
 
         Parameters
         ----------
-        x: ~astropy.units.quantity.Quantity
+        x : ~astropy.units.quantity.Quantity
             x coordinate
-        y: ~astropy.units.quantity.Quantity
+        y : ~astropy.units.quantity.Quantity
             y coordinate
-        z: ~astropy.units.quantity.Quantity
+        z : ~astropy.units.quantity.Quantity
             z coordinate
 
         """

--- a/src/poliastro/threebody/restricted.py
+++ b/src/poliastro/threebody/restricted.py
@@ -89,6 +89,7 @@ def lagrange_points_vec(m1, r1, m2, r2, n):
         Position of the secondary body.
     n : ~astropy.units.Quantity
         Normal vector to the orbital plane.
+
     Returns
     -------
     list:

--- a/src/poliastro/twobody/angles.py
+++ b/src/poliastro/twobody/angles.py
@@ -104,7 +104,7 @@ def nu_to_F(nu, ecc):
     F : ~astropy.units.Quantity
         Hyperbolic eccentric anomaly.
 
-    Note
+    Notes
     -----
     Taken from Curtis, H. (2013). *Orbital mechanics for engineering students*. 167
 
@@ -287,7 +287,7 @@ def fp_angle(nu, ecc):
     ecc : ~astropy.units.Quantity
         Eccentricity.
 
-    Note
+    Notes
     -----
     Algorithm taken from Vallado 2007, pp. 113.
 

--- a/src/poliastro/twobody/elements.py
+++ b/src/poliastro/twobody/elements.py
@@ -137,7 +137,7 @@ def get_eccentricity_critical_argp(R, J2, J3, a, inc):
     a : ~astropy.units.Quantity
         Orbit's semimajor axis
     inc : ~astropy.units.Quantity
-         Inclination.
+        Inclination.
 
     """
     ecc = -J3 * R * np.sin(inc) / 2 / J2 / a
@@ -176,7 +176,7 @@ def get_eccentricity_critical_inc(ecc=None):
 
     Parameters
     ----------
-    ecc: ~astropy.units.Quantity, optional
+    ecc : ~astropy.units.Quantity, optional
         Eccentricity, default to None.
 
     """

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -508,6 +508,8 @@ class Orbit:
         ----------
         name : str
             Name of the body to make the request.
+        **kwargs
+            Extra kwargs for astroquery.
 
         Returns
         -------
@@ -716,6 +718,8 @@ class Orbit:
 
         Parameters
         ----------
+        attractor : ~poliastro.bodies.SolarSystemPlanet
+            Attractor.
         a : ~astropy.units.Quantity
             Semi-major axis.
         ecc : ~astropy.units.Quantity

--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -262,9 +262,9 @@ class Orbit:
 
         Parameters
         ----------
-        attractor: Body
+        attractor : Body
             Main attractor
-        coord: ~astropy.coordinates.SkyCoord or ~astropy.coordinates.BaseCoordinateFrame
+        coord : ~astropy.coordinates.SkyCoord or ~astropy.coordinates.BaseCoordinateFrame
             Position and velocity vectors in any reference frame. Note that coord must have
             a representation and its differential with respect to time.
         plane : ~poliastro.frames.Planes, optional
@@ -426,9 +426,9 @@ class Orbit:
 
         Parameters
         ----------
-        new_attractor: poliastro.bodies.Body
+        new_attractor : poliastro.bodies.Body
             Desired new attractor.
-        force: bool
+        force : bool
             If `True`, changes attractor even if physically has no-sense.
 
         Returns
@@ -506,7 +506,7 @@ class Orbit:
 
         Parameters
         ----------
-        name: str
+        name : str
             Name of the body to make the request.
 
         Returns
@@ -550,7 +550,7 @@ class Orbit:
             Right ascension of the ascending node, default to 0 deg.
         arglat : ~astropy.units.Quantity, optional
             Argument of latitude, default to 0 deg.
-        epoch: ~astropy.time.Time, optional
+        epoch : ~astropy.time.Time, optional
             Epoch, default to J2000.
         plane : ~poliastro.frames.Planes
             Fundamental plane of the frame.
@@ -655,7 +655,6 @@ class Orbit:
 
         Notes
         -----
-
         Thus:
 
         .. math::
@@ -717,13 +716,13 @@ class Orbit:
 
         Parameters
         ----------
-        a: ~astropy.units.Quantity
+        a : ~astropy.units.Quantity
             Semi-major axis.
-        ecc: ~astropy.units.Quantity
+        ecc : ~astropy.units.Quantity
             Eccentricity.
-        inc: ~astropy.units.Quantity
+        inc : ~astropy.units.Quantity
             Inclination.
-        raan: ~astropy.units.Quantity
+        raan : ~astropy.units.Quantity
             Right ascension of the ascending node.
         argp : ~astropy.units.Quantity
             Argument of the pericenter.
@@ -783,7 +782,7 @@ class Orbit:
             Argument of the pericenter.
         nu : ~astropy.units.Quantity
             True anomaly.
-        epoch: ~astropy.time.Time, optional
+        epoch : ~astropy.time.Time, optional
             Epoch, default to J2000.
         plane : ~poliastro.frames.Planes
             Fundamental plane of the frame.
@@ -867,7 +866,7 @@ class Orbit:
             Argument of latitude, default to 0 deg.
         ecc : ~astropy.units.Quantity
             Eccentricity, default to the eccentricity of the Moon's orbit around the Earth
-        epoch: ~astropy.time.Time, optional
+        epoch : ~astropy.time.Time, optional
             Epoch, default to J2000.
         plane : ~poliastro.frames.Planes
             Fundamental plane of the frame.

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -137,6 +137,8 @@ def farnocchia(k, r, v, tofs, **kwargs):
         Velocity vector.
     tofs : ~astropy.units.Quantity
         Array of times to propagate.
+    **kwargs
+        Unused.
 
     Returns
     -------
@@ -173,6 +175,8 @@ def vallado(k, r, v, tofs, numiter=350, **kwargs):
         Array of times to propagate.
     numiter : int, optional
         Maximum number of iterations, default to 35.
+    **kwargs
+        Unused.
 
     Returns
     -------
@@ -343,8 +347,10 @@ def pimienta(k, r, v, tofs, rtol=None):
 
 
 def gooding(k, r, v, tofs, numiter=150, rtol=1e-8):
-    """Solves the Elliptic Kepler Equation with a cubic convergence and
-    accuracy better than 10e-12 rad is normally achieved. It is not valid for
+    """Propagate the orbit using the Gooding method.
+
+    The Gooding method solves the Elliptic Kepler Equation with a cubic convergence,
+    and accuracy better than 10e-12 rad is normally achieved. It is not valid for
     eccentricities equal or greater than 1.0.
 
     Parameters
@@ -357,6 +363,8 @@ def gooding(k, r, v, tofs, numiter=150, rtol=1e-8):
         Velocity vector.
     tofs : ~astropy.units.Quantity
         Array of times to propagate.
+    numiter : int
+        Maximum number of iterations for convergence.
     rtol : float
         This method does not require of tolerance since it is non iterative.
 
@@ -438,6 +446,8 @@ def propagate(orbit, time_of_flight, *, method=farnocchia, rtol=1e-10, **kwargs)
         Propagation method, default to farnocchia.
     rtol : float, optional
         Relative tolerance, default to 1e-10.
+    **kwargs
+        Extra kwargs for propagation method.
 
     Returns
     -------

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -72,7 +72,7 @@ def cowell(k, r, v, tofs, rtol=1e-11, *, events=None, f=func_twobody):
     RuntimeError
         If the algorithm didn't converge.
 
-    Note
+    Notes
     -----
     This method uses the Dormand & Prince integration method of order 8(5,3) (DOP853).
     If multiple tofs are provided, the method propagates to the maximum value
@@ -186,7 +186,7 @@ def vallado(k, r, v, tofs, numiter=350, **kwargs):
     RuntimeError
         If the algorithm didn't converge.
 
-    Note
+    Notes
     -----
     This algorithm is based on Vallado implementation, and does basic Newton
     iteration on the Kepler equation written using universal variables. Battin
@@ -235,7 +235,7 @@ def mikkola(k, r, v, tofs, rtol=None):
         Velocity vector.
     tofs : ~astropy.units.Quantity
         Array of times to propagate.
-    rtol: float
+    rtol : float
         This method does not require of tolerance since it is non iterative.
 
     Returns
@@ -244,8 +244,8 @@ def mikkola(k, r, v, tofs, rtol=None):
         Propagated position vectors.
     vv : ~astropy.units.Quantity
 
-    Note
-    ----
+    Notes
+    -----
     This method was derived by Seppo Mikola in his paper *A Cubic Approximation
     For Kepler's Equation* with DOI: https://doi.org/10.1007/BF01235850
 
@@ -274,7 +274,7 @@ def markley(k, r, v, tofs, rtol=None):
         Velocity vector.
     tofs : ~astropy.units.Quantity
         Array of times to propagate.
-    rtol: float
+    rtol : float
         This method does not require of tolerance since it is non iterative.
 
     Returns
@@ -284,8 +284,8 @@ def markley(k, r, v, tofs, rtol=None):
     vv : ~astropy.units.Quantity
         Propagated velocity vectors.
 
-    Note
-    ----
+    Notes
+    -----
     This method was originally presented by Markley in his paper *Kepler Equation Solver*
     with DOI: https://doi.org/10.1007/BF00691917
 
@@ -315,7 +315,7 @@ def pimienta(k, r, v, tofs, rtol=None):
         Velocity vector.
     tofs : ~astropy.units.Quantity
         Array of times to propagate.
-    rtol: float
+    rtol : float
         This method does not require of tolerance since it is non iterative.
 
     Returns
@@ -325,8 +325,8 @@ def pimienta(k, r, v, tofs, rtol=None):
     vv : ~astropy.units.Quantity
         Propagated velocity vectors.
 
-    Note
-    ----
+    Notes
+    -----
     This algorithm was developed by Pimienta-Peñalver and John L. Crassidis in
     their paper *Accurate Kepler Equation solver without trascendental function
     evaluations*. Original paper is on Buffalo's UBIR repository: http://hdl.handle.net/10477/50522
@@ -357,7 +357,7 @@ def gooding(k, r, v, tofs, numiter=150, rtol=1e-8):
         Velocity vector.
     tofs : ~astropy.units.Quantity
         Array of times to propagate.
-    rtol: float
+    rtol : float
         This method does not require of tolerance since it is non iterative.
 
     Returns
@@ -366,8 +366,8 @@ def gooding(k, r, v, tofs, numiter=150, rtol=1e-8):
         Propagated position vectors.
     vv : ~astropy.units.Quantity
 
-    Note
-    ----
+    Notes
+    -----
     This method was developed by Gooding and Odell in their paper *The
     hyperbolic Kepler equation (and the elliptic equation revisited)* with
     DOI: https://doi.org/10.1007/BF01235540
@@ -399,7 +399,7 @@ def danby(k, r, v, tofs, rtol=1e-8):
         Velocity vector.
     tofs : ~astropy.units.Quantity
         Array of times to propagate.
-    rtol: float
+    rtol : float
         Relative error for accuracy of the method.
 
     Returns
@@ -409,8 +409,8 @@ def danby(k, r, v, tofs, rtol=1e-8):
     vv : ~astropy.units.Quantity
         Propagated velocity vectors.
 
-    Note
-    ----
+    Notes
+    -----
     This algorithm was developed by Danby in his paper *The solution of Kepler
     Equation* with DOI: https://doi.org/10.1007/BF01686811
 

--- a/src/poliastro/twobody/thrust/change_a_inc.py
+++ b/src/poliastro/twobody/thrust/change_a_inc.py
@@ -27,7 +27,6 @@ def change_a_inc(k, a_0, a_f, inc_0, inc_f, f):
     -------
     a_d, delta_V, t_f : tuple (function, ~astropy.units.quantity.Quantity, ~astropy.time.Time)
 
-
     Notes
     -----
     Edelbaum theory, reformulated by Kéchichian.

--- a/src/poliastro/twobody/thrust/change_ecc_inc.py
+++ b/src/poliastro/twobody/thrust/change_ecc_inc.py
@@ -9,11 +9,11 @@ def change_ecc_inc(ss_0, ecc_f, inc_f, f):
     Parameters
     ----------
     ss_0 : Orbit
-           Initial orbit, containing all the information.
+        Initial orbit, containing all the information.
     ecc_f : float
-            Final eccentricity.
+        Final eccentricity.
     inc_f : ~astropy.units.quantity.Quantity
-            Final inclination.
+        Final inclination.
     f : ~astropy.units.quantity.Quantity
         Magnitude of constant acceleration.
 

--- a/src/poliastro/util.py
+++ b/src/poliastro/util.py
@@ -29,6 +29,8 @@ def time_range(start, *, periods=50, spacing=None, end=None, format=None, scale=
 
     Parameters
     ----------
+    start : ~astropy.time.Time or ~astropy.units.Quantity
+        Start time.
     periods : int, optional
         Number of periods, default to 50.
     spacing : ~astropy.time.Time or ~astropy.units.Quantity, optional

--- a/tests/test_maneuver.py
+++ b/tests/test_maneuver.py
@@ -256,5 +256,5 @@ def test_lambert_tof_exception():
     assert excinfo.type == ValueError
     assert (
         str(excinfo.value)
-        == "Epoch of intial orbit Greater than Epoch of final orbit causing a Negative Time Of Flight"
+        == "Epoch of initial orbit greater than epoch of final orbit, causing a negative time of flight"
     )


### PR DESCRIPTION
I applied this beta tool https://github.com/Carreau/velin that reformats the docstrings automatically and detects mismatches (undocumented parameters, or documented parameters that don't exist). I also used the opportunity to make some minor corrections.

Most of the changes are whitespace ones.