### PR TITLE
Added recursive series Kepler solver for elliptical orbits

### DIFF
--- a/src/poliastro/core/propagation/__init__.py
+++ b/src/poliastro/core/propagation/__init__.py
@@ -10,6 +10,7 @@ from poliastro.core.propagation.markley import markley, markley_coe
 from poliastro.core.propagation.mikkola import mikkola, mikkola_coe
 from poliastro.core.propagation.pimienta import pimienta, pimienta_coe
 from poliastro.core.propagation.vallado import vallado
+from poliastro.core.propagation.recSeries import recSeries, recSeries_coe
 
 __all__ = [
     "func_twobody",
@@ -26,6 +27,8 @@ __all__ = [
     "gooding",
     "danby_coe",
     "danby",
+    "recSeries_coe",
+    "recSeries",
 ]
 
 

--- a/src/poliastro/core/propagation/__init__.py
+++ b/src/poliastro/core/propagation/__init__.py
@@ -9,8 +9,8 @@ from poliastro.core.propagation.gooding import gooding, gooding_coe
 from poliastro.core.propagation.markley import markley, markley_coe
 from poliastro.core.propagation.mikkola import mikkola, mikkola_coe
 from poliastro.core.propagation.pimienta import pimienta, pimienta_coe
-from poliastro.core.propagation.vallado import vallado
 from poliastro.core.propagation.recSeries import recSeries, recSeries_coe
+from poliastro.core.propagation.vallado import vallado
 
 __all__ = [
     "func_twobody",

--- a/src/poliastro/core/propagation/__init__.py
+++ b/src/poliastro/core/propagation/__init__.py
@@ -9,7 +9,7 @@ from poliastro.core.propagation.gooding import gooding, gooding_coe
 from poliastro.core.propagation.markley import markley, markley_coe
 from poliastro.core.propagation.mikkola import mikkola, mikkola_coe
 from poliastro.core.propagation.pimienta import pimienta, pimienta_coe
-from poliastro.core.propagation.recSeries import recseries, recseries_coe
+from poliastro.core.propagation.recseries import recseries, recseries_coe
 from poliastro.core.propagation.vallado import vallado
 
 __all__ = [

--- a/src/poliastro/core/propagation/__init__.py
+++ b/src/poliastro/core/propagation/__init__.py
@@ -9,7 +9,7 @@ from poliastro.core.propagation.gooding import gooding, gooding_coe
 from poliastro.core.propagation.markley import markley, markley_coe
 from poliastro.core.propagation.mikkola import mikkola, mikkola_coe
 from poliastro.core.propagation.pimienta import pimienta, pimienta_coe
-from poliastro.core.propagation.recSeries import recSeries, recSeries_coe
+from poliastro.core.propagation.recSeries import recseries, recseries_coe
 from poliastro.core.propagation.vallado import vallado
 
 __all__ = [
@@ -27,8 +27,8 @@ __all__ = [
     "gooding",
     "danby_coe",
     "danby",
-    "recSeries_coe",
-    "recSeries",
+    "recseries_coe",
+    "recseries",
 ]
 
 

--- a/src/poliastro/core/propagation/danby.py
+++ b/src/poliastro/core/propagation/danby.py
@@ -13,7 +13,7 @@ def danby_coe(k, p, ecc, inc, raan, argp, nu, tof, numiter=20, rtol=1e-8):
 
     if ecc == 0:
         # Solving for circular orbit
-        M0 = E_to_M(nu_to_E(nu, ecc), ecc)
+        M0 = nu # for circular orbit M = E = nu
         M = M0 + n * tof
         nu = M - 2 * np.pi * np.floor(M / 2 / np.pi)
         return nu

--- a/src/poliastro/core/propagation/danby.py
+++ b/src/poliastro/core/propagation/danby.py
@@ -13,7 +13,7 @@ def danby_coe(k, p, ecc, inc, raan, argp, nu, tof, numiter=20, rtol=1e-8):
 
     if ecc == 0:
         # Solving for circular orbit
-        M0 = nu # for circular orbit M = E = nu
+        M0 = nu  # for circular orbit M = E = nu
         M = M0 + n * tof
         nu = M - 2 * np.pi * np.floor(M / 2 / np.pi)
         return nu

--- a/src/poliastro/core/propagation/recSeries.py
+++ b/src/poliastro/core/propagation/recSeries.py
@@ -1,0 +1,82 @@
+import numpy as np
+from numba import njit as jit
+
+from poliastro.core.angles import E_to_M, nu_to_E, E_to_nu
+from poliastro.core.elements import coe2rv, rv2coe
+
+
+@jit
+def recSeries_coe(k, p, ecc, inc, raan, argp, nu, tof, numiter=20, order=8):
+
+    semi_axis_a = p / (1 - ecc ** 2)
+    n = np.sqrt(k / np.abs(semi_axis_a) ** 3)
+
+    
+    if ecc == 0:
+        # Solving for circular orbit
+        
+        M0 = nu
+        M = M0 + n * tof
+        nu = M - 2 * np.pi * np.floor(M / 2 / np.pi)
+        return nu
+
+    elif ecc < 1.0:
+        # Solving for elliptical orbit
+        
+        M0 = E_to_M(nu_to_E(nu, ecc), ecc)
+        M = M0 + n * tof
+        M = M - 2 * np.pi * np.floor(M / 2 / np.pi)
+        
+        E = M
+        for i in range(0,order):
+            E = M + ecc*np.sin(E)
+        
+        return E_to_nu(E,ecc)
+        
+        
+    else:
+        raise ValueError("Parabolic/Hyperbolic orbits not supported.")
+
+    return nu
+
+
+@jit
+def recSeries(k, r0, v0, tof, numiter=20, order=8):
+    """Kepler solver for elliptical orbits with recursive series approximation
+    method. The order of the series is a user defined parameter.
+
+    Parameters
+    ----------
+    k : float
+        Standard gravitational parameter of the attractor.
+    r0 : numpy.ndarray
+        Position vector.
+    v0 : numpy.ndarray
+        Velocity vector.
+    tof : float
+        Time of flight.
+    numiter : int, optional
+        Number of iterations, defaults to 20.
+    order : int, optional
+        Order of recursion, defaults to 8.
+
+    Returns
+    -------
+    rr : numpy.ndarray
+        Final position vector.
+    vv : numpy.ndarray
+        Final velocity vector.
+
+    Notes
+    -----
+    This algorithm uses series developed in the paper *Recursive solution to
+    Kepler’s problem for elliptical orbits - application in robust 
+    Newton-Raphson and co-planar closest approach estimation* 
+    with DOI: http://dx.doi.org/10.13140/RG.2.2.18578.58563/1
+    """
+
+    # Solve first for eccentricity and mean anomaly
+    p, ecc, inc, raan, argp, nu = rv2coe(k, r0, v0)
+    nu = recSeries_coe(k, p, ecc, inc, raan, argp, nu, tof, numiter, order)
+
+    return coe2rv(k, p, ecc, inc, raan, argp, nu)

--- a/src/poliastro/core/propagation/recSeries.py
+++ b/src/poliastro/core/propagation/recSeries.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numba import njit as jit
 
-from poliastro.core.angles import E_to_M, nu_to_E, E_to_nu
+from poliastro.core.angles import E_to_M, E_to_nu, nu_to_E
 from poliastro.core.elements import coe2rv, rv2coe
 
 
@@ -12,35 +12,35 @@ def recSeries_coe(k, p, ecc, inc, raan, argp, nu, tof, order=8):
     semi_axis_a = p / (1 - ecc ** 2)
     # mean angular motion
     n = np.sqrt(k / np.abs(semi_axis_a) ** 3)
-    
+
     if ecc == 0:
         # Solving for circular orbit
-        
+
         # compute initial mean anoamly
-        M0 = nu # For circular orbit (M = E = nu)
+        M0 = nu  # For circular orbit (M = E = nu)
         # final mean anaomaly
         M = M0 + n * tof
         # snapping anomaly to [0,pi] range
         nu = M - 2 * np.pi * np.floor(M / 2 / np.pi)
-        
+
         return nu
 
     elif ecc < 1.0:
         # Solving for elliptical orbit
-        
+
         # compute initial mean anoamly
         M0 = E_to_M(nu_to_E(nu, ecc), ecc)
         # final mean anaomaly
         M = M0 + n * tof
         # snapping anomaly to [0,pi] range
         M = M - 2 * np.pi * np.floor(M / 2 / np.pi)
-        
+
         # compute eccentric anomaly through recursive series
         E = M
-        for i in range(0,order):
-            E = M + ecc*np.sin(E)
-        
-        return E_to_nu(E,ecc)
+        for i in range(0, order):
+            E = M + ecc * np.sin(E)
+
+        return E_to_nu(E, ecc)
 
     else:
         # Parabolic/Hyperbolic orbits are not supported
@@ -77,8 +77,8 @@ def recSeries(k, r0, v0, tof, order=8):
     Notes
     -----
     This algorithm uses series discussed in the paper *Recursive solution to
-    Kepler’s problem for elliptical orbits - application in robust 
-    Newton-Raphson and co-planar closest approach estimation* 
+    Kepler’s problem for elliptical orbits - application in robust
+    Newton-Raphson and co-planar closest approach estimation*
     with DOI: http://dx.doi.org/10.13140/RG.2.2.18578.58563/1
     """
 

--- a/src/poliastro/core/propagation/recseries.py
+++ b/src/poliastro/core/propagation/recseries.py
@@ -36,7 +36,7 @@ def recseries_coe(k, p, ecc, inc, raan, argp, nu, tof, order=8):
         M = M - 2 * np.pi * np.floor(M / 2 / np.pi)
 
         # compute eccentric anomaly through recursive series
-        E = M + e  # Using initial guess from vallado to improve convergence
+        E = M + ecc  # Using initial guess from vallado to improve convergence
         for i in range(0, order):
             E = M + ecc * np.sin(E)
 
@@ -84,6 +84,6 @@ def recseries(k, r0, v0, tof, order=8):
 
     # Solve first for eccentricity and mean anomaly
     p, ecc, inc, raan, argp, nu = rv2coe(k, r0, v0)
-    nu = recSeries_coe(k, p, ecc, inc, raan, argp, nu, tof, order)
+    nu = recseries_coe(k, p, ecc, inc, raan, argp, nu, tof, order)
 
     return coe2rv(k, p, ecc, inc, raan, argp, nu)

--- a/src/poliastro/core/propagation/recseries.py
+++ b/src/poliastro/core/propagation/recseries.py
@@ -36,7 +36,7 @@ def recseries_coe(k, p, ecc, inc, raan, argp, nu, tof, order=8):
         M = M - 2 * np.pi * np.floor(M / 2 / np.pi)
 
         # compute eccentric anomaly through recursive series
-        E = M + e # Using initial guess from vallado to improve convergence
+        E = M + e  # Using initial guess from vallado to improve convergence
         for i in range(0, order):
             E = M + ecc * np.sin(E)
 

--- a/src/poliastro/core/propagation/recseries.py
+++ b/src/poliastro/core/propagation/recseries.py
@@ -6,7 +6,7 @@ from poliastro.core.elements import coe2rv, rv2coe
 
 
 @jit
-def recSeries_coe(k, p, ecc, inc, raan, argp, nu, tof, order=8):
+def recseries_coe(k, p, ecc, inc, raan, argp, nu, tof, order=8):
 
     # semi-major axis
     semi_axis_a = p / (1 - ecc ** 2)
@@ -36,7 +36,7 @@ def recSeries_coe(k, p, ecc, inc, raan, argp, nu, tof, order=8):
         M = M - 2 * np.pi * np.floor(M / 2 / np.pi)
 
         # compute eccentric anomaly through recursive series
-        E = M
+        E = M + e # Using initial guess from vallado to improve convergence
         for i in range(0, order):
             E = M + ecc * np.sin(E)
 
@@ -50,7 +50,7 @@ def recSeries_coe(k, p, ecc, inc, raan, argp, nu, tof, order=8):
 
 
 @jit
-def recSeries(k, r0, v0, tof, order=8):
+def recseries(k, r0, v0, tof, order=8):
     """Kepler solver for elliptical orbits with recursive series approximation
     method. The order of the series is a user defined parameter.
 

--- a/src/poliastro/core/propagation/recseries.py
+++ b/src/poliastro/core/propagation/recseries.py
@@ -6,7 +6,9 @@ from poliastro.core.elements import coe2rv, rv2coe
 
 
 @jit
-def recseries_coe(k, p, ecc, inc, raan, argp, nu, tof, method='rtol', order=8, numiter=100, rtol=1e-8):
+def recseries_coe(
+    k, p, ecc, inc, raan, argp, nu, tof, method="rtol", order=8, numiter=100, rtol=1e-8
+):
 
     # semi-major axis
     semi_axis_a = p / (1 - ecc ** 2)
@@ -34,21 +36,21 @@ def recseries_coe(k, p, ecc, inc, raan, argp, nu, tof, method='rtol', order=8, n
         M = M0 + n * tof
         # snapping anomaly to [0,pi] range
         M = M - 2 * np.pi * np.floor(M / 2 / np.pi)
-        
-        # set recursion iteration 
-        if method == 'rtol':
+
+        # set recursion iteration
+        if method == "rtol":
             Niter = numiter
-        elif method == 'order':
+        elif method == "order":
             Niter = order
         else:
             raise ValueError("Unknown recursion termination method ('rtol','order').")
-        
+
         # compute eccentric anomaly through recursive series
         E = M + ecc  # Using initial guess from vallado to improve convergence
         for i in range(0, Niter):
             En = M + ecc * np.sin(E)
             # check for break condition
-            if method=='rtol' and (abs(En-E)/abs(E))<rtol:
+            if method == "rtol" and (abs(En - E) / abs(E)) < rtol:
                 break
             E = En
 
@@ -62,7 +64,7 @@ def recseries_coe(k, p, ecc, inc, raan, argp, nu, tof, method='rtol', order=8, n
 
 
 @jit
-def recseries(k, r0, v0, tof, method='rtol', order=8, numiter=100, rtol=1e-8):
+def recseries(k, r0, v0, tof, method="rtol", order=8, numiter=100, rtol=1e-8):
     """Kepler solver for elliptical orbits with recursive series approximation
     method. The order of the series is a user defined parameter.
 
@@ -102,6 +104,8 @@ def recseries(k, r0, v0, tof, method='rtol', order=8, numiter=100, rtol=1e-8):
 
     # Solve first for eccentricity and mean anomaly
     p, ecc, inc, raan, argp, nu = rv2coe(k, r0, v0)
-    nu = recseries_coe(k, p, ecc, inc, raan, argp, nu, tof, method, order, numiter, rtol)
+    nu = recseries_coe(
+        k, p, ecc, inc, raan, argp, nu, tof, method, order, numiter, rtol
+    )
 
     return coe2rv(k, p, ecc, inc, raan, argp, nu)

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -472,7 +472,7 @@ def recseries(k, r, v, tofs, rtol=1e-8):
     tofs = tofs.to_value(u.s)
 
     results = np.array(
-        [recseries_fast(k, r0, v0, tof, method="rtol", rtol=rtol) for tof in tofs]
+        [recseries_fast(k, r0, v0, tof, method='rtol', order=8, numiter=100, rtol) for tof in tofs]
     )
     return results[:, 0] << u.m, results[:, 1] << u.m / u.s
 

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -472,7 +472,7 @@ def recseries(k, r, v, tofs, rtol=1e-8):
     tofs = tofs.to_value(u.s)
 
     results = np.array(
-        [recseries_fast(k, r0, v0, tof, method='rtol', rtol=rtol) for tof in tofs]
+        [recseries_fast(k, r0, v0, tof, method="rtol", rtol=rtol) for tof in tofs]
     )
     return results[:, 0] << u.m, results[:, 1] << u.m / u.s
 

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -472,7 +472,7 @@ def recseries(k, r, v, tofs, rtol=1e-8):
     tofs = tofs.to_value(u.s)
 
     results = np.array(
-        [recseries_fast(k, r0, v0, tof, method='rtol', order=8, numiter=100, rtol) for tof in tofs]
+        [recseries_fast(k, r0, v0, tof, method='rtol', rtol=rtol) for tof in tofs]
     )
     return results[:, 0] << u.m, results[:, 1] << u.m / u.s
 

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -470,8 +470,11 @@ def recseries(k, r, v, tofs, rtol=1e-6):
     r0 = r.to_value(u.m)
     v0 = v.to_value(u.m / u.s)
     tofs = tofs.to_value(u.s)
+    
+    # rough estiamte of order from tolerance
+    order = 2*int( -np.log10(rtol) )
 
-    results = np.array([recseries_fast(k, r0, v0, tof, order=4) for tof in tofs])
+    results = np.array([recseries_fast(k, r0, v0, tof, order) for tof in tofs])
     return results[:, 0] << u.m, results[:, 1] << u.m / u.s
 
 

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -436,7 +436,7 @@ def danby(k, r, v, tofs, rtol=1e-8):
     return results[:, 0] << u.m, results[:, 1] << u.m / u.s
 
 
-def recseries(k, r, v, tofs, rtol=1e-6):
+def recseries(k, r, v, tofs, rtol=1e-8):
     """Kepler solver for elliptical orbits with recursive series approximation
     method. The order of the series is a user defined parameter.
     Parameters
@@ -471,17 +471,7 @@ def recseries(k, r, v, tofs, rtol=1e-6):
     v0 = v.to_value(u.m / u.s)
     tofs = tofs.to_value(u.s)
 
-    # angular momentum vector
-    h = np.cross(r0, v0)
-    # eccentricity vector
-    e = np.cross(v0, h) / k - r0 / np.linalg.norm(r0)
-    # eccentricity magnitude
-    ecc = np.linalg.norm(e)
-
-    # rough estiamte of order from tolerance
-    order = int(-2 * np.log10(rtol) + 10 * np.tanh(ecc))
-
-    results = np.array([recseries_fast(k, r0, v0, tof, order) for tof in tofs])
+    results = np.array([recseries_fast(k, r0, v0, tof, method='rtol',rtol=rtol) for tof in tofs])
     return results[:, 0] << u.m, results[:, 1] << u.m / u.s
 
 

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -470,9 +470,16 @@ def recseries(k, r, v, tofs, rtol=1e-6):
     r0 = r.to_value(u.m)
     v0 = v.to_value(u.m / u.s)
     tofs = tofs.to_value(u.s)
+    
+    # angular momentum vector
+    h = np.cross(r0,v0)
+    # eccentricity vector
+    e = np.cross(v0,h)/k - r0/np.linalg.norm(r0)
+    # eccentricity magnitude
+    ecc = np.linalg.norm(e)
 
     # rough estiamte of order from tolerance
-    order = 2 * int(-np.log10(rtol))
+    order = order = int( -2*np.log10(rtol) + 10*np.tanh(ecc) )
 
     results = np.array([recseries_fast(k, r0, v0, tof, order) for tof in tofs])
     return results[:, 0] << u.m, results[:, 1] << u.m / u.s

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -471,7 +471,9 @@ def recseries(k, r, v, tofs, rtol=1e-8):
     v0 = v.to_value(u.m / u.s)
     tofs = tofs.to_value(u.s)
 
-    results = np.array([recseries_fast(k, r0, v0, tof, method='rtol',rtol=rtol) for tof in tofs])
+    results = np.array(
+        [recseries_fast(k, r0, v0, tof, method="rtol", rtol=rtol) for tof in tofs]
+    )
     return results[:, 0] << u.m, results[:, 1] << u.m / u.s
 
 

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -470,9 +470,9 @@ def recseries(k, r, v, tofs, rtol=1e-6):
     r0 = r.to_value(u.m)
     v0 = v.to_value(u.m / u.s)
     tofs = tofs.to_value(u.s)
-    
+
     # rough estiamte of order from tolerance
-    order = 2*int( -np.log10(rtol) )
+    order = 2 * int(-np.log10(rtol))
 
     results = np.array([recseries_fast(k, r0, v0, tof, order) for tof in tofs])
     return results[:, 0] << u.m, results[:, 1] << u.m / u.s

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -470,16 +470,16 @@ def recseries(k, r, v, tofs, rtol=1e-6):
     r0 = r.to_value(u.m)
     v0 = v.to_value(u.m / u.s)
     tofs = tofs.to_value(u.s)
-    
+
     # angular momentum vector
-    h = np.cross(r0,v0)
+    h = np.cross(r0, v0)
     # eccentricity vector
-    e = np.cross(v0,h)/k - r0/np.linalg.norm(r0)
+    e = np.cross(v0, h) / k - r0 / np.linalg.norm(r0)
     # eccentricity magnitude
     ecc = np.linalg.norm(e)
 
     # rough estiamte of order from tolerance
-    order = order = int( -2*np.log10(rtol) + 10*np.tanh(ecc) )
+    order = order = int(-2 * np.log10(rtol) + 10 * np.tanh(ecc))
 
     results = np.array([recseries_fast(k, r0, v0, tof, order) for tof in tofs])
     return results[:, 0] << u.m, results[:, 1] << u.m / u.s

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -471,13 +471,7 @@ def recseries(k, r, v, tofs, rtol=1e-6):
     v0 = v.to_value(u.m / u.s)
     tofs = tofs.to_value(u.s)
 
-    # rough approximation orders for requried tolerance
-    if rtol > 1e-6:
-        order = 8
-    else:
-        order = 16
-
-    results = np.array([recseries_fast(k, r0, v0, tof, order) for tof in tofs])
+    results = np.array([recseries_fast(k, r0, v0, tof, order=4) for tof in tofs])
     return results[:, 0] << u.m, results[:, 1] << u.m / u.s
 
 

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -435,6 +435,7 @@ def danby(k, r, v, tofs, rtol=1e-8):
     results = np.array([danby_fast(k, r0, v0, tof) for tof in tofs])
     return results[:, 0] << u.m, results[:, 1] << u.m / u.s
 
+
 def recseries(k, r, v, tofs, rtol=1e-6):
     """Kepler solver for elliptical orbits with recursive series approximation
     method. The order of the series is a user defined parameter.
@@ -462,22 +463,23 @@ def recseries(k, r, v, tofs, rtol=1e-6):
     Kepler’s problem for elliptical orbits - application in robust
     Newton-Raphson and co-planar closest approach estimation*
     with DOI: http://dx.doi.org/10.13140/RG.2.2.18578.58563/1
-    
+
     """
 
     k = k.to_value(u.m ** 3 / u.s ** 2)
     r0 = r.to_value(u.m)
     v0 = v.to_value(u.m / u.s)
     tofs = tofs.to_value(u.s)
-    
+
     # rough approximation orders for requried tolerance
-    if rtol>1e-6:
-        order=8
+    if rtol > 1e-6:
+        order = 8
     else:
-        order=16
+        order = 16
 
     results = np.array([recseries_fast(k, r0, v0, tof, order) for tof in tofs])
     return results[:, 0] << u.m, results[:, 1] << u.m / u.s
+
 
 def propagate(orbit, time_of_flight, *, method=farnocchia, rtol=1e-10, **kwargs):
     """Propagate an orbit some time and return the result.

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -473,7 +473,7 @@ def recseries(k, r, v, tofs, rtol=1e-6):
     # rough approximation orders for requried tolerance
     if rtol>1e-6:
         order=8
-    esle:
+    else:
         order=16
 
     results = np.array([recseries_fast(k, r0, v0, tof, order) for tof in tofs])

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -37,8 +37,8 @@ from poliastro.core.propagation import (
     markley as markley_fast,
     mikkola as mikkola_fast,
     pimienta as pimienta_fast,
-    vallado as vallado_fast,
     recseries as recseries_fast,
+    vallado as vallado_fast,
 )
 
 

--- a/src/poliastro/twobody/propagation.py
+++ b/src/poliastro/twobody/propagation.py
@@ -479,7 +479,7 @@ def recseries(k, r, v, tofs, rtol=1e-6):
     ecc = np.linalg.norm(e)
 
     # rough estiamte of order from tolerance
-    order = order = int(-2 * np.log10(rtol) + 10 * np.tanh(ecc))
+    order = int(-2 * np.log10(rtol) + 10 * np.tanh(ecc))
 
     results = np.array([recseries_fast(k, r0, v0, tof, order) for tof in tofs])
     return results[:, 0] << u.m, results[:, 1] << u.m / u.s


### PR DESCRIPTION
- Added the series solution approximation for elliptical orbits. <img src="https://render.githubusercontent.com/render/math?math=(E\approx M + e \sin( M + \cdots + e \sin(M)) \cdots )"> 
- Small correction to Danby code. Corrected nu to M for circular orbits as M = nu @ e=0

Currently, I only included the manual series solution, where the user provides the order of recursion (instead of tolerance).

Later, I can implement a hybrid variant that uses a lookup table to select appropriate order for a mean anomaly and eccentricity and then uses the initial guess for a Newton-Raphson. Here, the user will be able to specify a tolerance, and hopefully, the table provides an order of recursion that overall reduce the cost of computing the solution. I am currently having trouble with fast lookup.

Hope I didn't mess anything up with the pull request. I have never worked with Github.

Cheers