### PR TITLE
Add `__reduce__` to `Body` class

### DIFF
--- a/src/poliastro/bodies.py
+++ b/src/poliastro/bodies.py
@@ -96,6 +96,9 @@ class Body(
     def __str__(self):
         return f"{self.name} ({self.symbol})"
 
+    def __reduce__(self):
+        return self.name
+
     def __repr__(self):
         return self.__str__()
 

--- a/tests/test_bodies.py
+++ b/tests/test_bodies.py
@@ -1,4 +1,5 @@
 import pickle
+
 import pytest
 from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose
@@ -77,6 +78,7 @@ def test_from_relative():
     )
     assert Earth.k == VALUECHECK.k
     assert Earth.R == VALUECHECK.R
+
 
 def test_attractor_identity_does_not_change_when_pickling(tmp_path):
     d = tmp_path / "tmp"

--- a/tests/test_bodies.py
+++ b/tests/test_bodies.py
@@ -1,8 +1,10 @@
+import pickle
 import pytest
 from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose
 
 from poliastro.bodies import Body, Earth, Jupiter, Sun
+from poliastro.examples import iss
 
 
 def test_body_has_k_given_in_constructor():
@@ -75,3 +77,16 @@ def test_from_relative():
     )
     assert Earth.k == VALUECHECK.k
     assert Earth.R == VALUECHECK.R
+
+def test_attractor_identity_does_not_change_when_pickling(tmp_path):
+    d = tmp_path / "tmp"
+    d.mkdir()
+    f = d / "orbit.pkl"
+
+    with open(f"{f}", "wb") as fh:
+        pickle.dump(iss, fh)
+
+    with open(f"{f}", "rb") as fh:
+        iss_pickle = pickle.load(fh)
+
+    assert id(iss.attractor) == id(iss_pickle.attractor)


### PR DESCRIPTION
This change does seem to solve the problem mentioned in #1395. `__reduce__` returns a string, which I think is commonly done for singleton classes. As a result, I was able to get the plot:
![fig](https://user-images.githubusercontent.com/68844397/149654749-bc2901d8-ddcf-41fa-bc2a-de3d62c6652c.png)

Just wondering if this is really a solution to the issue...
