### PR TITLE
Documentation typo in Hohmann (Maneuver) functions (altitude/orbital radius) #1454

### DIFF
--- a/src/poliastro/core/maneuver.py
+++ b/src/poliastro/core/maneuver.py
@@ -37,7 +37,7 @@ def hohmann(k, rv, r_f):
     rv : numpy.ndarray, numpy.ndarray
         Position and velocity vectors
     r_f : float
-        Final altitude of the orbit
+        Final orbital radius
 
     """
     _, ecc, inc, raan, argp, nu = rv2coe(k, *rv)
@@ -105,7 +105,7 @@ def bielliptic(k, r_b, r_f, rv):
     r_b : float
         Altitude of the intermediate orbit
     r_f : float
-        Final altitude of the orbit
+        Final orbital radius
     rv : numpy.ndarray, numpy.ndarray
         Position and velocity vectors
 

--- a/src/poliastro/maneuver.py
+++ b/src/poliastro/maneuver.py
@@ -84,7 +84,7 @@ class Maneuver:
         orbit_i : poliastro.twobody.orbit.Orbit
             Initial orbit
         r_f : astropy.unit.Quantity
-            Final altitude of the orbit
+            Final orbital radius
 
         """
 
@@ -122,7 +122,7 @@ class Maneuver:
         r_b : astropy.unit.Quantity
             Altitude of the intermediate orbit
         r_f : astropy.unit.Quantity
-            Final altitude of the orbit
+            Final orbital radius
 
         """
 


### PR DESCRIPTION
Fixed as per #1454 
I've nothing more to add