### PR TITLE
Bugfix issue #1460

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,4 @@
+name: python 3.10
+dependencies:
+- python=3.10
+- jupytext>=1.13.3

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,4 +1,0 @@
-# For application deployments, like Binder
-git+https://github.com/poliastro/poliastro.git#egg=poliastro
-
-jupytext>=1.13.3  # https://github.com/mwouts/jupytext/issues/271


### PR DESCRIPTION
The configuration file `environment.txt` has been replaced by a very similar file, including all necessary dependencies, `environment.yml`.

Note that other resolution path was intended, including another configuration file called `runtime.txt` but it did not work as expected, giving place to the issue [253 of binder's repo](https://github.com/jupyterhub/binder/issues/253).

The information to solve this bug has been obtained from [binder's doc](https://mybinder.readthedocs.io/en/latest/howto/languages.html#specifying-a-version-of-python), and thanks to the help of @astrojuanlu.