### PR TITLE
Release notes for 0.16.2

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -29,14 +29,14 @@ and restructures the API documentation to make it more useful.
 This is the complete list of the people that contributed to this
 release, with a + sign indicating first contribution.
 
-- Abhishek K. M.
-- Carlosbogo
+- Abhishek K. M.+
+- Carlosbogo+
 - Juan Luis Cano Rodríguez
-- Luis Grau
+- Luis Grau+
 - Ole Streicher
 - Sebastian M. Ernst
-- TreshUp
-- Varenyam Bhardwaj
+- TreshUp+
+- Varenyam Bhardwaj+
 - Yash Gondhalekar
 
 ## poliastro 0.16.0 - 2021-12-08

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,5 +1,9 @@
 # What's new
 
+## poliastro 0.16.2 - 2022-02-10
+
+Same as 0.16.1, but fixes the documentation building process.
+
 ## poliastro 0.16.1 - 2022-02-10
 
 This release adds support for Python 3.10,


### PR DESCRIPTION
Backporting to `main` from `0.16.x`.