### PR TITLE
Updated Version Pins to backport Python 3.10 support to 0.16.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Astronomy",
 ]
 dependencies = [
-    "astropy >=3.2,<5",
+    "astropy >=5.0,<6",
     "astroquery >=0.3.9",
     "cached_property ; python_version<'3.8'",
     "jplephem",
@@ -67,7 +67,7 @@ Funding = "https://opencollective.com/poliastro"
 jupyter = ["notebook", "ipywidgets>=7.6"]
 cesium = ["czml3 ~=0.5.3"]
 dev = [
-    "black==21.12b0",
+    "black==22.3.0",
     "coverage",
     "hypothesis",
     "import-linter",

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ commands =
 [testenv:check]
 description = this environments checks for flake8, black, isort and poliastro code style
 deps =
-    black==21.12b0
+    black==22.3.0
     docutils
     isort
     flake8
@@ -65,7 +65,7 @@ commands =
 [testenv:reformat]
 description = reformats the code using black and isort
 deps =
-    black==21.12b0
+    black==22.3.0
     isort
 skip_install = true
 commands =


### PR DESCRIPTION
Updated tox.ini and pyproject.toml to pin black at 22.3.0 and astropy at >=5.0<6 to address issue 1496
https://github.com/poliastro/poliastro/issues/1496