### PR TITLE
Fix rho unit for atmospheric_drag

### DIFF
--- a/src/poliastro/core/perturbations.py
+++ b/src/poliastro/core/perturbations.py
@@ -151,7 +151,7 @@ def atmospheric_drag(t0, state, k, C_D, A_over_m, rho):
     A_over_m : float
         Frontal area/mass of the spacecraft (km^2/kg)
     rho : float
-        Air density at corresponding state (kg/m^3)
+        Air density at corresponding state (kg/km^3)
 
     Notes
     -----


### PR DESCRIPTION
Changed documentation unit for $\rho$ from `kg/m3` to `kg/km3` to match other units, as suggested in #1513.