### PR TITLE
Fixing radiation pressure formula

### DIFF
--- a/src/poliastro/constants/general.py
+++ b/src/poliastro/constants/general.py
@@ -649,8 +649,8 @@ rho0_earth = Constant(
 Wdivc_sun = Constant(
     "Wdivc_sun",
     "total radiation power of Sun divided by the speed of light",
-    1.0203759306204136e14,
-    "kg km / (s2)",
+    1.0203759306204136e20,
+    "W s / km",
     1,
     "Howard Curtis",
     system="si",

--- a/src/poliastro/core/perturbations.py
+++ b/src/poliastro/core/perturbations.py
@@ -236,7 +236,7 @@ def radiation_pressure(t0, state, k, R, C_R, A_over_m, Wdivc_s, star):
     """
     r_star = star(t0)
     r_sat = state[:3]
-    P_s = Wdivc_s / (norm(r_star) ** 2)
+    P_s = Wdivc_s / 1e6 / (norm(r_star) ** 2)
 
     nu = float(line_of_sight_fast(r_sat, r_star, R) > 0)
     return -nu * P_s * (C_R * A_over_m) * r_star / norm(r_star)


### PR DESCRIPTION
### Fixing radiation pressure implementation
The documentation for `radiation_pressure` states it taks the `Wdivc_s` (Total star emitted power divided by the speed of light) argument as **W * s / km**. All the calculations use **km** instead of **m**, so passing, for example, `Wdivc_sun.to_value(u.W*u.s/u.km)` is 1 million times stronger than it should be.

The error happens becaus **W = kg m²/s³ = 1e-6 kg km²/s³**

We either fix the entire documentation or just fix this function so it actually uses **W * s / km** as stated in the docs.

By the way, this error was noticed while I tried to reproduce example **5.5.4** from the book Space Flight Dynamics, Craig A. Kluever. The value for _p_srp_ found by the autor was **4.54e−6 N/m²**, which was precisely **1e6** greater than the value I printed doing `print(P_s)` inside the function `radiation_pressure`.

Here is a reproducible example of the problem stated above. The solar radiation pressure is crushing a satelite orbiting mere **100km** above earth surface:

```
import numpy as np
import matplotlib.pyplot as plt

from astropy.coordinates import solar_system_ephemeris
from astropy import units as u
from astropy.time import Time, TimeDelta

from poliastro.bodies import Earth, Sun
from poliastro.constants import Wdivc_sun
from poliastro.twobody import Orbit
from poliastro.core.propagation import func_twobody
from poliastro.twobody.propagation import propagate, cowell
from poliastro.core.perturbations import radiation_pressure
from poliastro.ephem import build_ephem_interpolant

total_time = 120 * u.min

solar_system_ephemeris.set("de432s")
epoch = Time(
    2454283.0, format="jd", scale="tdb"
)
sun_body_r = build_ephem_interpolant(
    Sun, 365*u.day, (epoch.value*u.day, epoch.value*u.day + total_time)
)


def f(t0, u_, k):
    # accel due to gravity
    du_two_body = func_twobody(t0, u_, k)

    # accel due to sun radiation pressure
    ax, ay, az = radiation_pressure(
        t0, u_, k, Earth.R.to_value(u.km),
        C_R=1.4,
        A_over_m=(0.01 * u.m**2 / u.kg).to_value(u.km**2 / u.kg),
        Wdivc_s=Wdivc_sun.to_value(u.W*u.s/u.km),
        star=sun_body_r
    )
    du_radiation = np.array([0, 0, 0, ax, ay, az])

    du_total = du_two_body + du_radiation
    return du_total


r_p = 100 * u.km + Earth.R
r_a = r_p
raan = 0 * u.deg
inc = 10 * u.deg
argp = 0 * u.deg
nu = 0 * u.deg
a = (r_p + r_a) / 2
ecc = (r_a - r_p) / (r_a + r_p)

initial_orbit = Orbit.from_classical(Earth, a, ecc, inc, raan, argp, nu, epoch=epoch)
tofs = TimeDelta(np.linspace(0*u.h, total_time, num=1000))
coords = propagate(initial_orbit, tofs, method=cowell, f=f)

rr = coords.xyz.T
altitude = [np.linalg.norm(r.to_value(u.km)) for r in rr] - Earth.R.to_value(u.km)
time = [t.to_value(u.min) for t in tofs]
plt.plot(time, altitude)
plt.xlabel('time (min)')
plt.ylabel('Altitude (km)')
plt.grid()
plt.show()
```
In less than 30 min the satelite goes below ground level (mind you I did not set any stop event).