### PR TITLE
Rename notebooks to `.myst.md`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -78,7 +78,11 @@ hoverxref_role_types = {
 # Other
 autodoc_member_order = "bysource"
 templates_path = ["_templates"]
-# source_suffix = ['.rst' , '.md']
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".myst.md": "jupyter_notebook",
+    ".md": "markdown",
+}
 
 project = "poliastro"
 copyright = "2013, Juan Luis Cano Rodríguez and the poliastro development team"
@@ -163,7 +167,7 @@ nbsphinx_thumbnails = {
 }
 
 nbsphinx_custom_formats = {
-    ".mystnb": ["jupytext.reads", {"fmt": "mystnb"}],
+    ".myst.md": ["jupytext.reads", {"fmt": "mystnb"}],
 }
 
 # sphinx-autoapi configuration

--- a/docs/source/examples/Analyzing NEOs.myst.md
+++ b/docs/source/examples/Analyzing NEOs.myst.md
@@ -2,7 +2,7 @@
 jupytext:
   encoding: '# -*- coding: utf-8 -*-'
   text_representation:
-    extension: .mystnb
+    extension: .md
     format_name: myst
     format_version: 0.13
     jupytext_version: 1.14.0

--- a/docs/source/examples/Analyzing the Parker Solar Probe flybys.myst.md
+++ b/docs/source/examples/Analyzing the Parker Solar Probe flybys.myst.md
@@ -1,7 +1,7 @@
 ---
 jupytext:
   text_representation:
-    extension: .mystnb
+    extension: .md
     format_name: myst
     format_version: 0.13
     jupytext_version: 1.14.0

--- a/docs/source/examples/Atmospheric models.myst.md
+++ b/docs/source/examples/Atmospheric models.myst.md
@@ -1,7 +1,7 @@
 ---
 jupytext:
   text_representation:
-    extension: .mystnb
+    extension: .md
     format_name: myst
     format_version: 0.13
     jupytext_version: 1.14.0

--- a/docs/source/examples/CZML Tutorial.myst.md
+++ b/docs/source/examples/CZML Tutorial.myst.md
@@ -1,7 +1,7 @@
 ---
 jupytext:
   text_representation:
-    extension: .mystnb
+    extension: .md
     format_name: myst
     format_version: 0.13
     jupytext_version: 1.14.0

--- a/docs/source/examples/Catch that asteroid!.myst.md
+++ b/docs/source/examples/Catch that asteroid!.myst.md
@@ -2,7 +2,7 @@
 jupytext:
   encoding: '# -*- coding: utf-8 -*-'
   text_representation:
-    extension: .mystnb
+    extension: .md
     format_name: myst
     format_version: 0.13
     jupytext_version: 1.14.0

--- a/docs/source/examples/Comparing Hohmann and bielliptic transfers.myst.md
+++ b/docs/source/examples/Comparing Hohmann and bielliptic transfers.myst.md
@@ -1,7 +1,7 @@
 ---
 jupytext:
   text_representation:
-    extension: .mystnb
+    extension: .md
     format_name: myst
     format_version: 0.13
     jupytext_version: 1.14.0

--- a/docs/source/examples/Customising static orbit plots.myst.md
+++ b/docs/source/examples/Customising static orbit plots.myst.md
@@ -1,7 +1,7 @@
 ---
 jupytext:
   text_representation:
-    extension: .mystnb
+    extension: .md
     format_name: myst
     format_version: 0.13
     jupytext_version: 1.14.0

--- a/docs/source/examples/Detecting Events.myst.md
+++ b/docs/source/examples/Detecting Events.myst.md
@@ -1,7 +1,7 @@
 ---
 jupytext:
   text_representation:
-    extension: .mystnb
+    extension: .md
     format_name: myst
     format_version: 0.13
     jupytext_version: 1.14.0

--- a/docs/source/examples/Exploring the New Horizons launch.myst.md
+++ b/docs/source/examples/Exploring the New Horizons launch.myst.md
@@ -1,7 +1,7 @@
 ---
 jupytext:
   text_representation:
-    extension: .mystnb
+    extension: .md
     format_name: myst
     format_version: 0.13
     jupytext_version: 1.14.0

--- a/docs/source/examples/Generating orbit groundtracks.myst.md
+++ b/docs/source/examples/Generating orbit groundtracks.myst.md
@@ -1,7 +1,7 @@
 ---
 jupytext:
   text_representation:
-    extension: .mystnb
+    extension: .md
     format_name: myst
     format_version: 0.13
     jupytext_version: 1.14.0

--- a/docs/source/examples/Going to Jupiter with Python using Jupyter and poliastro.myst.md
+++ b/docs/source/examples/Going to Jupiter with Python using Jupyter and poliastro.myst.md
@@ -1,7 +1,7 @@
 ---
 jupytext:
   text_representation:
-    extension: .mystnb
+    extension: .md
     format_name: myst
     format_version: 0.13
     jupytext_version: 1.14.0

--- a/docs/source/examples/Going to Mars with Python using poliastro.myst.md
+++ b/docs/source/examples/Going to Mars with Python using poliastro.myst.md
@@ -1,7 +1,7 @@
 ---
 jupytext:
   text_representation:
-    extension: .mystnb
+    extension: .md
     format_name: myst
     format_version: 0.13
     jupytext_version: 1.14.0

--- a/docs/source/examples/Loading OMM and TLE satellite data.myst.md
+++ b/docs/source/examples/Loading OMM and TLE satellite data.myst.md
@@ -1,7 +1,7 @@
 ---
 jupytext:
   text_representation:
-    extension: .mystnb
+    extension: .md
     format_name: myst
     format_version: 0.13
     jupytext_version: 1.14.0

--- a/docs/source/examples/Multirevolutions solution in Lamberts problem.myst.md
+++ b/docs/source/examples/Multirevolutions solution in Lamberts problem.myst.md
@@ -1,7 +1,7 @@
 ---
 jupytext:
   text_representation:
-    extension: .mystnb
+    extension: .md
     format_name: myst
     format_version: 0.13
     jupytext_version: 1.14.0

--- a/docs/source/examples/Natural and artificial perturbations.myst.md
+++ b/docs/source/examples/Natural and artificial perturbations.myst.md
@@ -1,7 +1,7 @@
 ---
 jupytext:
   text_representation:
-    extension: .mystnb
+    extension: .md
     format_name: myst
     format_version: 0.13
     jupytext_version: 1.14.0

--- a/docs/source/examples/Plotting in 3D.myst.md
+++ b/docs/source/examples/Plotting in 3D.myst.md
@@ -1,7 +1,7 @@
 ---
 jupytext:
   text_representation:
-    extension: .mystnb
+    extension: .md
     format_name: myst
     format_version: 0.13
     jupytext_version: 1.14.0

--- a/docs/source/examples/Porkchops with poliastro.myst.md
+++ b/docs/source/examples/Porkchops with poliastro.myst.md
@@ -1,7 +1,7 @@
 ---
 jupytext:
   text_representation:
-    extension: .mystnb
+    extension: .md
     format_name: myst
     format_version: 0.13
     jupytext_version: 1.14.0

--- a/docs/source/examples/Propagation using Cowells formulation.myst.md
+++ b/docs/source/examples/Propagation using Cowells formulation.myst.md
@@ -1,7 +1,7 @@
 ---
 jupytext:
   text_representation:
-    extension: .mystnb
+    extension: .md
     format_name: myst
     format_version: 0.13
     jupytext_version: 1.14.0

--- a/docs/source/examples/Revisiting Lamberts problem in Python.myst.md
+++ b/docs/source/examples/Revisiting Lamberts problem in Python.myst.md
@@ -1,7 +1,7 @@
 ---
 jupytext:
   text_representation:
-    extension: .mystnb
+    extension: .md
     format_name: myst
     format_version: 0.13
     jupytext_version: 1.14.0

--- a/docs/source/examples/Studying Hohmann transfers.myst.md
+++ b/docs/source/examples/Studying Hohmann transfers.myst.md
@@ -1,7 +1,7 @@
 ---
 jupytext:
   text_representation:
-    extension: .mystnb
+    extension: .md
     format_name: myst
     format_version: 0.13
     jupytext_version: 1.14.0

--- a/docs/source/examples/Tisserand.myst.md
+++ b/docs/source/examples/Tisserand.myst.md
@@ -1,7 +1,7 @@
 ---
 jupytext:
   text_representation:
-    extension: .mystnb
+    extension: .md
     format_name: myst
     format_version: 0.13
     jupytext_version: 1.14.0

--- a/docs/source/examples/Visualizing the SpaceX Tesla Roadster trip to Mars.myst.md
+++ b/docs/source/examples/Visualizing the SpaceX Tesla Roadster trip to Mars.myst.md
@@ -1,7 +1,7 @@
 ---
 jupytext:
   text_representation:
-    extension: .mystnb
+    extension: .md
     format_name: myst
     format_version: 0.13
     jupytext_version: 1.14.0

--- a/docs/source/gallery.md
+++ b/docs/source/gallery.md
@@ -8,22 +8,22 @@ the plotting utilities, insight on the {ref}`API <api-reference>` capabilities a
 ```{eval-rst}
 .. nbgallery::
 
-   /examples/Analyzing the Parker Solar Probe flybys.mystnb
-   /examples/Atmospheric models.mystnb
-   /examples/Catch that asteroid!.mystnb
-   /examples/Customising static orbit plots.mystnb
-   /examples/CZML Tutorial.mystnb
-   /examples/Exploring the New Horizons launch.mystnb
-   /examples/Going to Mars with Python using poliastro.mystnb
-   /examples/Going to Jupiter with Python using Jupyter and poliastro.mystnb
-   /examples/Generating orbit groundtracks.mystnb
-   /examples/Plotting in 3D.mystnb
-   /examples/Analyzing NEOs.mystnb
-   /examples/Visualizing the SpaceX Tesla Roadster trip to Mars.mystnb
-   /examples/Natural and artificial perturbations.mystnb
-   /examples/Porkchops with poliastro.mystnb
-   /examples/Tisserand.mystnb
-   /examples/Detecting Events.mystnb
-   /examples/Loading OMM and TLE satellite data.mystnb
+   /examples/Analyzing the Parker Solar Probe flybys.myst.md
+   /examples/Atmospheric models.myst.md
+   /examples/Catch that asteroid!.myst.md
+   /examples/Customising static orbit plots.myst.md
+   /examples/CZML Tutorial.myst.md
+   /examples/Exploring the New Horizons launch.myst.md
+   /examples/Going to Mars with Python using poliastro.myst.md
+   /examples/Going to Jupiter with Python using Jupyter and poliastro.myst.md
+   /examples/Generating orbit groundtracks.myst.md
+   /examples/Plotting in 3D.myst.md
+   /examples/Analyzing NEOs.myst.md
+   /examples/Visualizing the SpaceX Tesla Roadster trip to Mars.myst.md
+   /examples/Natural and artificial perturbations.myst.md
+   /examples/Porkchops with poliastro.myst.md
+   /examples/Tisserand.myst.md
+   /examples/Detecting Events.myst.md
+   /examples/Loading OMM and TLE satellite data.myst.md
    
 ```


### PR DESCRIPTION
I was really annoyed that we had to use a custom extension for our notebooks, because they were not being rendered in any Markdown editor. Thanks to a little help from @chrisjsewell I managed to configure Sphinx so that (1) nbsphinx handles `.myst.md` and (2) myst-parser handles the remaining `.md` files 🎉 