### PR TITLE
Refactor build ephem interpolant

### DIFF
--- a/docs/source/examples/Generating orbit groundtracks.myst.md
+++ b/docs/source/examples/Generating orbit groundtracks.myst.md
@@ -58,7 +58,7 @@ the time vector and thus, the amount of values:
 # Build spacecraft instance
 iss_spacecraft = EarthSatellite(iss, None)
 t_span = time_range(
-    iss.epoch - 1.5 * u.h, periods=150, end=iss.epoch + 1.5 * u.h
+    iss.epoch - 1.5 * u.h, num_values=150, end=iss.epoch + 1.5 * u.h
 )
 ```
 

--- a/docs/source/examples/Going to Jupiter with Python using Jupyter and poliastro.myst.md
+++ b/docs/source/examples/Going to Jupiter with Python using Jupyter and poliastro.myst.md
@@ -66,7 +66,7 @@ Since both Earth states have been obtained (initial and flyby) we can now solve 
 
 ```{code-cell}
 earth = Ephem.from_body(
-    Earth, time_range(date_launch, end=date_arrival, periods=500)
+    Earth, time_range(date_launch, end=date_arrival, num_values=500)
 )
 
 r_e0, v_e0 = earth.rv(date_launch)

--- a/docs/source/examples/Loading OMM and TLE satellite data.myst.md
+++ b/docs/source/examples/Loading OMM and TLE satellite data.myst.md
@@ -207,7 +207,7 @@ from poliastro.util import time_range
 ```
 
 ```{code-cell}
-times = time_range(now, end=now + (1 << u.h), periods=3)
+times = time_range(now, end=now + (1 << u.h), num_values=3)
 ```
 
 ```{code-cell}

--- a/docs/source/examples/Natural and artificial perturbations.myst.md
+++ b/docs/source/examples/Natural and artificial perturbations.myst.md
@@ -193,11 +193,10 @@ epoch = Time(
 )  # setting the exact event date is important
 
 # create interpolant of 3rd body coordinates (calling in on every iteration will be just too slow)
+epochs_moon = time_range(epoch,num_values=60,end=epoch + 60*u.day)
 body_r = build_ephem_interpolant(
     Moon,
-    28 * u.day,
-    (epoch.value * u.day, epoch.value * u.day + 60 * u.day),
-    rtol=1e-2,
+    epochs_moon
 )
 
 initial = Orbit.from_classical(

--- a/docs/source/examples/Natural and artificial perturbations.myst.md
+++ b/docs/source/examples/Natural and artificial perturbations.myst.md
@@ -36,7 +36,7 @@ from poliastro.plotting import OrbitPlotter3D
 from poliastro.twobody import Orbit
 from poliastro.twobody.propagation import CowellPropagator
 from poliastro.twobody.sampling import EpochsArray
-from poliastro.util import norm
+from poliastro.util import norm, time_range
 ```
 
 ```{code-cell}

--- a/docs/source/examples/Natural and artificial perturbations.myst.md
+++ b/docs/source/examples/Natural and artificial perturbations.myst.md
@@ -193,7 +193,7 @@ epoch = Time(
 )  # setting the exact event date is important
 
 # create interpolant of 3rd body coordinates (calling in on every iteration will be just too slow)
-epochs_moon = time_range(epoch,num_values=60,end=epoch + 60*u.day)
+epochs_moon = time_range(epoch,num_values=214,end=epoch + 60*u.day)
 body_r = build_ephem_interpolant(
     Moon,
     epochs_moon

--- a/docs/source/examples/Plotting in 3D.myst.md
+++ b/docs/source/examples/Plotting in 3D.myst.md
@@ -68,7 +68,7 @@ date_launch = Time("2011-11-26 15:02", scale="utc").tdb
 date_arrival = Time("2012-08-06 05:17", scale="utc").tdb
 
 earth = Ephem.from_body(
-    Earth, time_range(date_launch, end=date_arrival, periods=50)
+    Earth, time_range(date_launch, end=date_arrival, num_values=50)
 )
 ```
 

--- a/src/poliastro/ephem.py
+++ b/src/poliastro/ephem.py
@@ -8,7 +8,6 @@ from astropy.coordinates import (
     CartesianRepresentation,
     get_body_barycentric_posvel,
 )
-from astropy.time import Time
 from astroquery.jplhorizons import Horizons
 
 from poliastro._math.interpolate import interp1d, sinc_interp, spline_interp
@@ -16,26 +15,20 @@ from poliastro.bodies import Earth
 from poliastro.frames import Planes
 from poliastro.frames.util import get_frame
 from poliastro.twobody.sampling import EpochsArray
-from poliastro.util import time_range
 from poliastro.warnings import TimeScaleWarning
 
 EPHEM_FORMAT = "Ephemerides at {num} epochs from {start} ({start_scale}) to {end} ({end_scale})"
 
 
-def build_ephem_interpolant(body, period, t_span, rtol=1e-5, attractor=Earth):
+def build_ephem_interpolant(body, epochs, attractor=Earth):
     """Interpolates ephemerides data
 
     Parameters
     ----------
     body : Body
         Source body.
-    period : ~astropy.units.Quantity
-        Orbital period.
-    t_span : list(~astropy.units.Quantity)
-        Initial and final epochs.
-    rtol : float, optional
-        Relative tolerance. Controls the number of sampled data points,
-        defaults to 1e-5.
+    epochs : ~astropy.time.Time
+        Array of time values, can be generated with poliastro.util.time_range.
     attractor : ~poliastro.bodies.Body, optional
         Attractor, default to Earth.
 
@@ -46,13 +39,6 @@ def build_ephem_interpolant(body, period, t_span, rtol=1e-5, attractor=Earth):
         since the initial epoch.
 
     """
-    epochs = time_range(
-        Time(t_span[0], format="jd", scale="tdb"),
-        end=Time(t_span[1], format="jd", scale="tdb"),
-        periods=int(
-            ((t_span[1] - t_span[0]) / (period * rtol)).to_value(u.one)
-        ),
-    )
     ephem = Ephem.from_body(body, epochs, attractor=attractor)
 
     interpolant = interp1d(

--- a/src/poliastro/plotting/_base.py
+++ b/src/poliastro/plotting/_base.py
@@ -267,7 +267,7 @@ class BaseOrbitPlotter:
 
         label = generate_label(epoch, label or str(body))
         epochs = time_range(
-            epoch, periods=self._num_points, end=epoch + period, scale="tdb"
+            epoch, num_values=self._num_points, end=epoch + period, scale="tdb"
         )
         ephem = Ephem.from_body(
             body, epochs, attractor=body.parent, plane=self.plane

--- a/src/poliastro/util.py
+++ b/src/poliastro/util.py
@@ -34,7 +34,7 @@ def norm(vec, axis=None):
 
 
 def time_range(
-    start, *, periods=50, spacing=None, end=None, format=None, scale=None
+    start, *, num_values=50, spacing=None, end=None, format=None, scale=None
 ):
     """Generates range of astronomical times.
 
@@ -44,8 +44,8 @@ def time_range(
     ----------
     start : ~astropy.time.Time or ~astropy.units.Quantity
         Start time.
-    periods : int, optional
-        Number of periods, default to 50.
+    num_values : int, optional
+        Number of equal spaced time values to be generated, default to 50.
     spacing : ~astropy.time.Time or ~astropy.units.Quantity, optional
         Spacing between periods, optional.
     end : ~astropy.time.Time or equivalent, optional
@@ -60,11 +60,11 @@ def time_range(
     start = Time(start, format=format, scale=scale)
 
     if spacing is not None and end is None:
-        result = start + spacing * np.arange(0, periods)
+        result = start + spacing * np.arange(0, num_values)
 
     elif end is not None and spacing is None:
         end = Time(end, format=format, scale=scale)
-        result = start + (end - start) * np.linspace(0, 1, periods)
+        result = start + (end - start) * np.linspace(0, 1, num_values)
 
     else:
         raise ValueError("Either 'end' or 'spacing' must be specified")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -6,22 +6,22 @@ from astropy.time import Time
 from poliastro.util import time_range
 
 
-def test_time_range_spacing_periods():
+def test_time_range_spacing_num_values():
     start_time = "2017-10-12 00:00:00"
     end_time = "2017-10-12 00:04:00"
     spacing = 1 * u.minute
-    periods = 5
+    num_values = 5
 
     expected_scale = "utc"
     expected_duration = 4 * u.min
 
-    result_1 = time_range(start_time, spacing=spacing, periods=periods)
-    result_2 = time_range(start_time, end=end_time, periods=periods)
+    result_1 = time_range(start_time, spacing=spacing, num_values=num_values)
+    result_2 = time_range(start_time, end=end_time, num_values=num_values)
     result_3 = time_range(
-        Time(start_time), end=Time(end_time), periods=periods
+        Time(start_time), end=Time(end_time), num_values=num_values
     )
 
-    assert len(result_1) == len(result_2) == len(result_3) == periods
+    assert len(result_1) == len(result_2) == len(result_3) == num_values
     assert result_1.scale == result_2.scale == result_3.scale == expected_scale
 
     assert_quantity_allclose(
@@ -53,7 +53,7 @@ def test_time_range_raises_error_wrong_arguments():
         time_range("2017-10-12 00:00")
 
     with pytest.raises(ValueError) as excinfo_2:
-        time_range("2017-10-12 00:00", spacing=0, end=0, periods=0)
+        time_range("2017-10-12 00:00", spacing=0, end=0, num_values=0)
 
     assert exception_message in excinfo_1.exconly()
     assert exception_message in excinfo_2.exconly()

--- a/tests/tests_twobody/test_perturbations.py
+++ b/tests/tests_twobody/test_perturbations.py
@@ -616,7 +616,7 @@ def test_3rd_body_Curtis(test_params):
 def sun_r():
     j_date = 2_438_400.5 * u.day
     tof = 600 * u.day
-    ephem_epochs = time_range(j_date, num_values=165, end=j_date + tof)
+    ephem_epochs = time_range(j_date, num_values=164, end=j_date + tof)
     return build_ephem_interpolant(Sun, ephem_epochs)
 
 

--- a/tests/tests_twobody/test_perturbations.py
+++ b/tests/tests_twobody/test_perturbations.py
@@ -562,7 +562,7 @@ def test_3rd_body_Curtis(test_params):
 
     epoch = Time(j_date, format="jd", scale="tdb")
     initial = Orbit.from_classical(Earth, *test_params["orbit"], epoch=epoch)
-    
+
     body_epochs = time_range(
         epoch,
         num_values=test_params["ephem_values"],

--- a/tests/tests_twobody/test_perturbations.py
+++ b/tests/tests_twobody/test_perturbations.py
@@ -559,9 +559,13 @@ def test_3rd_body_Curtis(test_params):
     body = test_params["body"]
     j_date = 2454283.0 * u.day
     tof = (test_params["tof"]).to_value(u.s)
-    
-    body_epochs = time_range(j_date, num_values=test_params["ephem_values"],end=j_date + test_params["tof"])
-    body_r = build_ephem_interpolant(body,body_epochs)
+
+    body_epochs = time_range(
+        j_date,
+        num_values=test_params["ephem_values"],
+        end=j_date + test_params["tof"],
+    )
+    body_r = build_ephem_interpolant(body, body_epochs)
 
     epoch = Time(j_date, format="jd", scale="tdb")
     initial = Orbit.from_classical(Earth, *test_params["orbit"], epoch=epoch)

--- a/tests/tests_twobody/test_perturbations.py
+++ b/tests/tests_twobody/test_perturbations.py
@@ -560,15 +560,15 @@ def test_3rd_body_Curtis(test_params):
     j_date = 2454283.0 * u.day
     tof = (test_params["tof"]).to_value(u.s)
 
-    body_epochs = time_range(
-        j_date,
-        num_values=test_params["ephem_values"],
-        end=j_date + test_params["tof"],
-    )
-    body_r = build_ephem_interpolant(body, body_epochs)
-
     epoch = Time(j_date, format="jd", scale="tdb")
     initial = Orbit.from_classical(Earth, *test_params["orbit"], epoch=epoch)
+    
+    body_epochs = time_range(
+        epoch,
+        num_values=test_params["ephem_values"],
+        end=epoch + test_params["tof"],
+    )
+    body_r = build_ephem_interpolant(body, body_epochs)
 
     def f(t0, u_, k):
         du_kep = func_twobody(t0, u_, k)
@@ -620,7 +620,8 @@ def test_3rd_body_Curtis(test_params):
 def sun_r():
     j_date = 2_438_400.5 * u.day
     tof = 600 * u.day
-    ephem_epochs = time_range(j_date, num_values=164, end=j_date + tof)
+    epoch = Time(j_date, format="jd", scale="tdb")
+    ephem_epochs = time_range(epoch, num_values=164, end=epoch + tof)
     return build_ephem_interpolant(Sun, ephem_epochs)
 
 

--- a/tests/tests_twobody/test_perturbations.py
+++ b/tests/tests_twobody/test_perturbations.py
@@ -25,6 +25,7 @@ from poliastro.ephem import build_ephem_interpolant
 from poliastro.twobody import Orbit
 from poliastro.twobody.events import LithobrakeEvent
 from poliastro.twobody.propagation import CowellPropagator
+from poliastro.util import time_range
 
 
 @pytest.mark.slow
@@ -447,7 +448,7 @@ moon_heo = {
         -10.12921 * u.deg,
         0.0 * u.rad,
     ],
-    "period": 28 * u.day,
+    "ephem_values": 214,
 }
 
 moon_leo = {
@@ -464,7 +465,7 @@ moon_leo = {
         0.0 * u.deg,
         0.0 * u.rad,
     ],
-    "period": 28 * u.day,
+    "ephem_values": 214,
 }
 
 moon_geo = {
@@ -481,7 +482,7 @@ moon_geo = {
         0.0 * u.deg,
         0.0 * u.rad,
     ],
-    "period": 28 * u.day,
+    "ephem_values": 214,
 }
 
 sun_heo = {
@@ -498,7 +499,7 @@ sun_heo = {
         -10.12921 * u.deg,
         0.0 * u.rad,
     ],
-    "period": 365 * u.day,
+    "ephem_values": 54,
 }
 
 sun_leo = {
@@ -515,7 +516,7 @@ sun_leo = {
         0.0 * u.deg,
         0.0 * u.rad,
     ],
-    "period": 365 * u.day,
+    "ephem_values": 54,
 }
 
 sun_geo = {
@@ -532,7 +533,7 @@ sun_geo = {
         0.0 * u.deg,
         0.0 * u.rad,
     ],
-    "period": 365 * u.day,
+    "ephem_values": 54,
 }
 
 
@@ -558,12 +559,9 @@ def test_3rd_body_Curtis(test_params):
     body = test_params["body"]
     j_date = 2454283.0 * u.day
     tof = (test_params["tof"]).to_value(u.s)
-    body_r = build_ephem_interpolant(
-        body,
-        test_params["period"],
-        (j_date, j_date + test_params["tof"]),
-        rtol=1e-2,
-    )
+    
+    body_epochs = time_range(j_date, num_values=test_params["ephem_values"],end=j_date + test_params["tof"])
+    body_r = build_ephem_interpolant(body,body_epochs)
 
     epoch = Time(j_date, format="jd", scale="tdb")
     initial = Orbit.from_classical(Earth, *test_params["orbit"], epoch=epoch)
@@ -618,9 +616,8 @@ def test_3rd_body_Curtis(test_params):
 def sun_r():
     j_date = 2_438_400.5 * u.day
     tof = 600 * u.day
-    return build_ephem_interpolant(
-        Sun, 365 * u.day, (j_date, j_date + tof), rtol=1e-2
-    )
+    ephem_epochs = time_range(j_date, num_values=165, end=j_date + tof)
+    return build_ephem_interpolant(Sun, ephem_epochs)
 
 
 def normalize_to_Curtis(t0, sun_r):


### PR DESCRIPTION
This is a refactoring done to avoid issues such as #1506 and #1494.
```
def build_ephem_interpolant(body, period, t_span, rtol=1e-5, attractor=Earth)
```
Becomes
```
def build_ephem_interpolant(body, epochs, attractor=Earth)
```
This was done because a too small `t_span` in combination with a too big `rtol` could lead to zero or one epoch point(s), meaning no interpolant could be made, causing errors. This somewhat unclear behaviour is now solved by only giving a `poliastro.util.time_range` generated array of time values directly, together with the `body`. For the user it should be more clear that they input an array of times through which an interpolant will be made.

Furthermore the `poliastro.util.time_range` function had its `periods` argument renamed to `num_values` to reflect the purpose of this value a bit more clear.