### PR TITLE
Add offline-friendly formats to Read the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,10 @@ build:
   tools:
     python: "3.9"
 
+formats:
+  - epub
+  - htmlzip
+
 python:
   install:
     - method: pip


### PR DESCRIPTION
Hopefully closes gh-1242.

Having PDF docs with current Sphinx + Read the Docs is a pain, LaTeX is very flaky, unfortunately. So let's see if we're luckier with HTMLZIP and EPUB formats.