### PR TITLE
fix pylint invalid-all-object / E0604 in propagators

### DIFF
--- a/src/poliastro/twobody/propagation/__init__.py
+++ b/src/poliastro/twobody/propagation/__init__.py
@@ -65,6 +65,4 @@ HYPERBOLIC_PROPAGATORS = [
 ]
 
 
-__all__ = [
-    item.__name__ for item in ALL_PROPAGATORS
-] + ["propagate"]
+__all__ = [item.__name__ for item in ALL_PROPAGATORS] + ["propagate"]

--- a/src/poliastro/twobody/propagation/__init__.py
+++ b/src/poliastro/twobody/propagation/__init__.py
@@ -65,4 +65,6 @@ HYPERBOLIC_PROPAGATORS = [
 ]
 
 
-__all__ = ALL_PROPAGATORS + ["propagate"]
+__all__ = [
+    item.__name__ for item in ALL_PROPAGATORS
+] + ["propagate"]


### PR DESCRIPTION
Fixes [E0604](https://pylint.pycqa.org/en/latest/user_guide/messages/error/invalid-all-object.html). Edge case, but strictly speaking `__all__` is supposed to be a list/tuple of strings and some tools are rather unhappy if they're not.