### PR TITLE
fix pylint#2910 via workaround: ignore not an iterable warning on numba.prange

### DIFF
--- a/src/poliastro/core/elements.py
+++ b/src/poliastro/core/elements.py
@@ -189,12 +189,16 @@ def coe2rv(k, p, ecc, inc, raan, argp, nu):
 
 @jit(parallel=sys.maxsize > 2**31)
 def coe2rv_many(k, p, ecc, inc, raan, argp, nu):
+    """
+    Parallel version of coe2rv
+    """
 
     n = nu.shape[0]
     rr = np.zeros((n, 3))
     vv = np.zeros((n, 3))
 
-    for i in prange(n):
+    # Disabling pylint waring, see https://github.com/PyCQA/pylint/issues/2910
+    for i in prange(n):  # pylint: disable=not-an-iterable
         rr[i, :], vv[i, :] = coe2rv(
             k[i], p[i], ecc[i], inc[i], raan[i], argp[i], nu[i]
         )

--- a/src/poliastro/core/elements.py
+++ b/src/poliastro/core/elements.py
@@ -197,7 +197,7 @@ def coe2rv_many(k, p, ecc, inc, raan, argp, nu):
     rr = np.zeros((n, 3))
     vv = np.zeros((n, 3))
 
-    # Disabling pylint waring, see https://github.com/PyCQA/pylint/issues/2910
+    # Disabling pylint warning, see https://github.com/PyCQA/pylint/issues/2910
     for i in prange(n):  # pylint: disable=not-an-iterable
         rr[i, :], vv[i, :] = coe2rv(
             k[i], p[i], ecc[i], inc[i], raan[i], argp[i], nu[i]


### PR DESCRIPTION
Long standing annoyance, see [here](https://github.com/PyCQA/pylint/issues/2910). Simply globally disabling this warning is a rather bad idea, so it should go into the code.