### PR TITLE
add missing test dependency: tox

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ test = [
     "pytest-mpl",
     "pytest-mypy",
     "pytest-remotedata",
+    "tox",
 ]
 
 [tool.flit.sdist]


### PR DESCRIPTION
If this is intentional, please ignore.