### PR TITLE
adding libration point calculation using newton raphson method

### DIFF
--- a/src/poliastro/threebody/cr3bp_char_quant.py
+++ b/src/poliastro/threebody/cr3bp_char_quant.py
@@ -36,6 +36,9 @@ class SystemChars:
         self._mu = mu
         self._lstar = lstar
         self._tstar = tstar
+        # self._L_ND = u.def_unit("dist_nd", self.lstar)
+        # self._V_ND = u.def_unit("vel_nd", self.lstar/self.tstar)
+
 
     @classmethod
     def from_primaries(cls, p1, p2):
@@ -118,3 +121,13 @@ class SystemChars:
     def tstar(self):
         """Characterisitc time of P1-P2 system"""
         return self._tstar
+
+    # @property
+    # def L_ND(self):
+    #     """Non-dimensional length unit of P1-P2 system"""
+    #     return self._L_ND
+    
+    # @property
+    # def V_ND(self):
+    #     """Non-dimensional velocity unit of P1-P2 system"""
+    #     return self._V_ND

--- a/src/poliastro/threebody/cr3bp_lib_calc.py
+++ b/src/poliastro/threebody/cr3bp_lib_calc.py
@@ -1,0 +1,114 @@
+"""
+@author: Dhruv Jain, Multi-Body Dynaminitial_guesss Research Group, MSAAE Purdue University
+
+Objectve: Calculates the position [nd] of 5 libration points of a CR3BP system
+"""
+import numpy as np
+from astropy import units as u
+
+def lib_pt_loc(SysChars, conv_tol=1e-12):
+    """Computes libration points position [nd] for a CR3BP system
+    
+    Parameters
+    ----------
+    SysChars: object
+        Object of Class SystemChars
+    conv_tol: float
+        convergence tolerance for Newton-Raphson Method
+
+    Returns
+    -------
+    lib_loc: numpy ndarray (5x3)
+        5 Libration Points, [nd]
+    """
+    
+    mu = SysChars.mu
+
+    lib_loc = np.zeros((5, 3))
+    
+    # 5th degree polynomial of L1, L2 and L3
+    f_lib123_coeffs = np.array(
+        [
+            [1, mu - 3, 3 - 2 * mu, -mu, 2 * mu, -mu],
+            [1, 3 - mu, 3 - 2 * mu, -mu, -2 * mu, -mu],
+            [1, 2 + mu, 1 + 2 * mu, mu - 1, 2 * mu - 2, -1 + mu],
+        ]
+    )
+
+    # First-order derivative of the polyomial defined in f_lib123 with respect to 'Li,x'; e.g. L1,x ; L2,x ; L3,x
+    df_lib123_coeffs = np.array(
+        [
+            [0, 5, 4 * (mu - 3), 3 * (3 - 2 * mu), 2 * -mu, 2 * mu],
+            [0, 5, 4 * (3 - mu), 3 * (3 - 2 * mu), 2 * -mu, -2 * mu],
+            [0, 5, 4 * (2 + mu), 3 * (1 + 2 * mu), 2 * (mu - 1), 2 * mu - 2],
+        ]
+    )
+    
+    initial_guess123 = np.array([0.9, 1.1, -1]) # Initial guess for L1, L2, L3
+    
+    # computes L1    
+    lib_loc[0,0] = 1 - mu - newton_raphson_lib_calc(initial_guess123[0], f_lib123_coeffs[0,:], df_lib123_coeffs[0,:], conv_tol)   
+
+    # computes L2
+    lib_loc[1,0] = 1 - mu + newton_raphson_lib_calc(initial_guess123[1], f_lib123_coeffs[1,:], df_lib123_coeffs[1,:], conv_tol)
+    
+    # computes L3
+    lib_loc[2,0] = - mu - newton_raphson_lib_calc(initial_guess123[2], f_lib123_coeffs[2,:], df_lib123_coeffs[2,:], conv_tol)
+    
+    # L4, analytical solution 
+    lib_loc[3, :] = [
+            0.5 - mu,
+            3**0.5 / 2,
+            0,
+        ]  
+    
+    # L5, analytical solution
+    lib_loc[4, :] = [
+            0.5 - mu,
+            -(3**0.5) / 2,
+            0,
+        ]  
+
+    # # Define custome units, [nd]: non-dimensional unit for distance
+    L_ND = u.def_unit("dist_nd", SysChars.lstar)
+    # # u.add_enabled_units(L_ND)
+
+    return lib_loc*L_ND
+ 
+def newton_raphson_lib_calc(initial_guess, func_coeffs, dfunc_coeffs, conv_tol):
+    """Uses Newton-Raphson Method to compute a zero of a function
+    
+    Parameters
+    ----------
+    initial_guess: float
+        Approximate value of a zero of the function 'func'
+    func_coeffs: numpy ndarray (6x1)
+        Coeffecients of a polynomial function whose zero is to be computed
+        [C_n, C_n-1, C_n-2, ...., C_0]
+        Setup: C_n * x^n + C_n-1 * x^(n-1) ..... C0 * x^0 
+    dfunc_coeffs: numpy ndarray (6x1)
+        Coeffecients of the derivative of function 'func' w.r.t 'x' whose zero is to be computed
+        [C_n, C_n-1, C_n-2, ...., C_0]
+        Setup: C_n * x^(n-1) + C_n-1 * x^(n-2) ..... C0 * x^0 
+    conv_tol: float
+        convergence tolerance for Newton-Raphson Method
+        
+    Returns
+    -------
+    initial_guess: float
+        zero of function 'func_coeffs' within conv_tol 
+    """
+    
+    initial_guess = np.array([initial_guess]) # To increase dimension to 1, which is the minimum required dimension for np.vander input
+    
+    val = np.vander(initial_guess, N=6)
+    h = np.dot(val, func_coeffs) / np.dot(val, dfunc_coeffs)
+     
+    # Using Newton-Raphson Method
+    while abs(h) >= conv_tol:
+     	 
+        val = np.vander(initial_guess, N=6)
+        h = np.dot(val, func_coeffs) / np.dot(val, dfunc_coeffs)
+        initial_guess = initial_guess - h
+
+    return initial_guess

--- a/tests/tests_threebody/test_cr3bp_lib_calc.py
+++ b/tests/tests_threebody/test_cr3bp_lib_calc.py
@@ -1,0 +1,32 @@
+import pytest
+import numpy as np
+# from astropy import units as u
+# from astropy.units import L_ND
+from astropy.tests.helper import assert_quantity_allclose
+
+from poliastro.threebody.cr3bp_char_quant import SystemChars
+from poliastro.threebody.cr3bp_lib_calc import lib_pt_loc
+
+@pytest.mark.parametrize(
+    "SysChars, conv_tol, expected_lib_pt_loc",
+    [
+        (SystemChars('EarthMoon', 1.215058560962404e-02, 389703.2648292776, 382981.2891290545), 1e-12, 
+        np.array([
+        [0.8369151257723572, 0.0, 0.0],
+        [1.155682165444884, 0.0, 0.0], 
+        [-1.005062645810278, 0.0, 0.0],
+        [0.4878494143903759, 0.8660254037844386, 0.0],
+        [0.4878494143903759, -0.8660254037844386, 0.0]])),
+        # Earth-Moon mu, l*, t*, libration ponints: https://ssd-api.jpl.nasa.gov/periodic_orbits.api?sys=earth-moon&family=halo&libr=1&branch=S
+    ],
+)
+
+def test_lib_pt_loc(SysChars, conv_tol, expected_lib_pt_loc):
+ 
+    lib_pt = lib_pt_loc(SysChars, conv_tol)
+    
+    # L_ND = u.def_unit("dist_nd", SysChars.lstar)
+    
+    lib_pt = lib_pt.value
+    
+    assert_quantity_allclose(lib_pt, expected_lib_pt_loc, 1e-6)


### PR DESCRIPTION
I like my method of libration point calculation compared to the one in restricted.py that uses brentq:
1. Compatible with cr3bp_char_quant
2. Uses non-dim units, which will be helpful later for cr3bp propagation
3. Uses Newton Raphson instead of brentq as I am not sure if the limit intervals set for brentq can encapsulate all systems, while Newton Raphson is more robust
4. Uses regularized form of the CR3BP EOMs to define a function, whose zeros are the liberation points -> less susceptible numerical errors

a. The function and its test work if I compare their values but L_ND is throwing an error that I am having difficulty getting around. I have tried to use 'u_enabled_units' but that has not resolved the problem. 
b. I would like to add the L_ND and V_ND (added as comments in SystemChars) so that we can use SystemChars' object and not have to define the units in multiple functions.