### PR TITLE
Fix unit of h_vec in cross product calculation

### DIFF
--- a/src/poliastro/twobody/orbit/scalar.py
+++ b/src/poliastro/twobody/orbit/scalar.py
@@ -173,7 +173,7 @@ class Orbit(OrbitCreationMixin):
     def h_vec(self):
         """Specific angular momentum vector."""
         h_vec = (
-            np.cross(self.r.to_value(u.km), self.v.to(u.km / u.s))
+            np.cross(self.r.to_value(u.km), self.v.to_value(u.km / u.s))
             * u.km**2
             / u.s
         )


### PR DESCRIPTION
Calculating h_vec using `self.v.to(u.km / u.s)` in `np.cross(r, v)` retains $km/s$ as its unit.

Therefore, multiplying `np.cross(r, v)` with `u.km ** 2 / u.s` sets the unit of h_vec to $km^3/s^2$.

Instead, `self.v.to_value(u.km / u.s)` should be used to keep `np.cross(r, v)` unitless.

Fixes: #1575 

<!-- readthedocs-preview poliastro start -->
----
:books: Documentation preview :books:: https://poliastro--1576.org.readthedocs.build/en/1576/

<!-- readthedocs-preview poliastro end -->