### PR TITLE
Update change_ecc_inc.py to allow for incl. reduction

### DIFF
--- a/src/poliastro/core/thrust/change_ecc_inc.py
+++ b/src/poliastro/core/thrust/change_ecc_inc.py
@@ -85,7 +85,7 @@ def change_ecc_inc(k, a, ecc_0, ecc_f, inc_0, inc_f, argp, r, v, f):
             np.cos(nu)
         )  # The sign of ß reverses at minor axis crossings
 
-        w_ = cross(r_, v_) / norm(cross(r_, v_))
+        w_ = (cross(r_, v_) / norm(cross(r_, v_))) * np.sign(inc_f - inc_0)
         accel_v = f * (np.cos(beta_) * thrust_unit + np.sin(beta_) * w_)
         return accel_v
 


### PR DESCRIPTION
This change should allow for negative and positive inclination changes by letting the out-of-plane thrust direction toggle in the right direction.

<!-- readthedocs-preview poliastro start -->
----
:books: Documentation preview :books:: https://poliastro--1579.org.readthedocs.build/en/1579/

<!-- readthedocs-preview poliastro end -->