### PR TITLE
test: Use numpy.testing.assert_allclose with small relative tolerance

### DIFF
--- a/tests/test_stumpff.py
+++ b/tests/test_stumpff.py
@@ -1,5 +1,5 @@
 from numpy import cos, cosh, sin, sinh
-from numpy.testing import assert_allclose, assert_equal
+from numpy.testing import assert_allclose
 
 from poliastro._math.special import stumpff_c2 as c2, stumpff_c3 as c3
 
@@ -18,8 +18,8 @@ def test_stumpff_functions_above_zero():
     expected_c2 = (1 - cos(psi**0.5)) / psi
     expected_c3 = (psi**0.5 - sin(psi**0.5)) / psi**1.5
 
-    assert_equal(c2(psi), expected_c2)
-    assert_equal(c3(psi), expected_c3)
+    assert_allclose(c2(psi), expected_c2, rtol=1e-10)
+    assert_allclose(c3(psi), expected_c3, rtol=1e-10)
 
 
 def test_stumpff_functions_under_zero():
@@ -27,5 +27,5 @@ def test_stumpff_functions_under_zero():
     expected_c2 = (cosh((-psi) ** 0.5) - 1) / (-psi)
     expected_c3 = (sinh((-psi) ** 0.5) - (-psi) ** 0.5) / (-psi) ** 1.5
 
-    assert_equal(c2(psi), expected_c2)
-    assert_equal(c3(psi), expected_c3)
+    assert_allclose(c2(psi), expected_c2, rtol=1e-10)
+    assert_allclose(c3(psi), expected_c3, rtol=1e-10)


### PR DESCRIPTION
To avoid having `numpy.testing.assert_equal` fail in some cases at the level of machine precision, use `numpy.testing.assert_allclose` instead with a relative tolerance set small, `1e-10`, to still be restrictive in the level of equality accepted.

Example: Running the test suite locally with Python 3.10.6 on Ubuntu 22.04 can result in assertion errors like

```pytb
====================================================================================== FAILURES =======================================================================================
__________________________________________________________________________ test_stumpff_functions_under_zero __________________________________________________________________________

    def test_stumpff_functions_under_zero():
        psi = -3.0
        expected_c2 = (cosh((-psi) ** 0.5) - 1) / (-psi)
        expected_c3 = (sinh((-psi) ** 0.5) - (-psi) ** 0.5) / (-psi) ** 1.5

>       assert_equal(c2(psi), expected_c2)
E       AssertionError:
E       Items are not equal:
E        ACTUAL: 0.6381924800586426
E        DESIRED: 0.6381924800586427

tests/test_stumpff.py:31: AssertionError
```

with this fix applied

```
$ pytest tests/test_stumpff.py 
================================================================================= test session starts =================================================================================
platform linux -- Python 3.10.6, pytest-7.1.3, pluggy-1.0.0
rootdir: /home/feickert/Code/GitHub/forks/poliastro, configfile: pyproject.toml
plugins: hypothesis-6.56.2
collected 3 items                                                                                                                                                                     

tests/test_stumpff.py ...
```

<!-- readthedocs-preview poliastro start -->
----
:books: Documentation preview :books:: https://poliastro--1587.org.readthedocs.build/en/1587/

<!-- readthedocs-preview poliastro end -->