### PR TITLE
build: Remove upper bound on requires-python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "flit_core.buildapi"
 [project]
 name = "poliastro"
 readme = "README.md"
-requires-python = ">=3.8,<3.11"
+requires-python = ">=3.8"
 license = {file = "COPYING"}
 authors = [
     {name = "Juan Luis Cano Rodríguez", email = "hello@juanlu.space"}


### PR DESCRIPTION
Remove upper bound on `requires-python` as advocated for in Henry Schreiner's blog post "Should You Use Upper Bound Version Constraints?".
   - c.f. https://iscinumpy.dev/post/bound-version-constraints/#pinning-the-python-version-is-special

<!-- readthedocs-preview poliastro start -->
----
:books: Documentation preview :books:: https://poliastro--1588.org.readthedocs.build/en/1588/

<!-- readthedocs-preview poliastro end -->