### PR TITLE
CI: Add Python 3.11 to testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,13 @@ jobs:
     environment:
       TOXENV: py310
 
+  py311:
+    <<: *test-template
+    docker:
+      - image: python:3.11
+    environment:
+      TOXENV: py311
+
 workflows:
   version: 2
   build_and_test:
@@ -81,5 +88,8 @@ workflows:
           requires:
             - quality
       - py310:
+          requires:
+            - quality
+      - py311:
           requires:
             - quality

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Physics",

--- a/tests/test_maneuver.py
+++ b/tests/test_maneuver.py
@@ -27,12 +27,23 @@ def test_maneuver_constructor_raises_error_if_invalid_delta_v():
 
 
 def test_maneuver_raises_error_if_units_are_wrong():
-    wrong_dt = 1.0
+    wrong_dt = 1.0 * u.km
     _v = np.zeros(3) * u.km / u.s  # Unused velocity
     with pytest.raises(u.UnitsError) as excinfo:
         Maneuver([wrong_dt, _v])
     assert (
-        "Argument 'dts' to function '_initialize' must be in units convertible to 's'."
+        "Argument 'dts' to function 'impulse_has_valid_units' must be in units convertible to 's'."
+        in excinfo.exconly()
+    )
+
+
+def test_maneuver_raises_error_if_units_are_missing():
+    wrong_dt = 1.0
+    _v = np.zeros(3) * u.km / u.s  # Unused velocity
+    with pytest.raises(TypeError) as excinfo:
+        Maneuver([wrong_dt, _v])
+    assert (
+        "Argument 'dts' to function 'impulse_has_valid_units' has no 'unit' attribute. You should pass in an astropy Quantity instead."
         in excinfo.exconly()
     )
 

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ basepython =
     py38: python3.8
     py39: python3.9
     py310: python3.10
+    py311: python3.11
     {style,docs,reformat,build}: python3
 setenv =
     PYTHONUNBUFFERED = yes


### PR DESCRIPTION
* Add Python 3.11 to testing in CI.
* Update PyPI metadata to reflect Python 3.11 support.

<!-- readthedocs-preview poliastro start -->
----
:books: Documentation preview :books:: https://poliastro--1590.org.readthedocs.build/en/1590/

<!-- readthedocs-preview poliastro end -->