### PR TITLE
MAINT: rename 'py' environments in tox to 'tests'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 jobs:
   quality: &test-template
+    description: Code style
     docker:
       - image: python:3.8
     environment:
@@ -13,28 +14,33 @@ jobs:
       - run: python -m pip install tox
       - run: tox
 
-  py38-fast:
+  tests38-fast:
     <<: *test-template
+    description: Tests fast - Python 3.8
     environment:
       TOXENV: tests38-fast
 
-  py38-online:
+  tests38-online:
     <<: *test-template
+    description: Tests online - Python 3.8
     environment:
       TOXENV: tests38-online
 
-  py38-slow:
+  tests38-slow:
     <<: *test-template
+    description: Tests slow - Python 3.8
     environment:
       TOXENV: tests38-slow
 
-  py38-images:
+  tests38-images:
     <<: *test-template
+    description: Tests images - Python 3.8
     environment:
       TOXENV: tests38-images
 
-  py38-coverage:
+  tests38-coverage:
     <<: *test-template
+    description: Tests coverage - Python 3.8
     environment:
       TOXENV: tests38-coverage
     steps:
@@ -43,22 +49,25 @@ jobs:
       - run: tox
       - run: python -m pip install codecov && codecov
 
-  py39:
+  tests39:
     <<: *test-template
+    description: Tests - Python 3.9
     docker:
       - image: python:3.9
     environment:
       TOXENV: tests39
 
-  py310:
+  tests310:
     <<: *test-template
+    description: Tests - Python 3.10
     docker:
       - image: python:3.10
     environment:
       TOXENV: tests310
 
-  py311:
+  tests311:
     <<: *test-template
+    description: Tests - Python 3.11
     docker:
       - image: python:3.11
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,27 +16,27 @@ jobs:
   py38-fast:
     <<: *test-template
     environment:
-      TOXENV: py38-fast
+      TOXENV: tests38-fast
 
   py38-online:
     <<: *test-template
     environment:
-      TOXENV: py38-online
+      TOXENV: tests38-online
 
   py38-slow:
     <<: *test-template
     environment:
-      TOXENV: py38-slow
+      TOXENV: tests38-slow
 
   py38-images:
     <<: *test-template
     environment:
-      TOXENV: py38-images
+      TOXENV: tests38-images
 
   py38-coverage:
     <<: *test-template
     environment:
-      TOXENV: py38-coverage
+      TOXENV: tests38-coverage
     steps:
       - checkout
       - run: python -m pip install tox
@@ -48,48 +48,48 @@ jobs:
     docker:
       - image: python:3.9
     environment:
-      TOXENV: py39
+      TOXENV: tests39
 
   py310:
     <<: *test-template
     docker:
       - image: python:3.10
     environment:
-      TOXENV: py310
+      TOXENV: tests310
 
   py311:
     <<: *test-template
     docker:
       - image: python:3.11
     environment:
-      TOXENV: py311
+      TOXENV: tests311
 
 workflows:
   version: 2
   build_and_test:
     jobs:
       - quality
-      - py38-fast:
+      - tests38-fast:
           requires:
             - quality
-      - py38-online:
+      - tests38-online:
           requires:
             - quality
-      - py38-slow:
+      - tests38-slow:
           requires:
             - quality
-      - py38-images:
+      - tests38-images:
           requires:
             - quality
-      - py38-coverage:
+      - tests38-coverage:
           requires:
             - quality
-      - py39:
+      - tests39:
           requires:
             - quality
-      - py310:
+      - tests310:
           requires:
             - quality
-      - py311:
+      - tests311:
           requires:
             - quality

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,11 +190,11 @@ Apart from all the steps described above, you need to have these extra things in
 1. Add tests to your code. You have lots of examples in the `tests/` directory
    to get inspiration from. All new features and fixes should be tested,
    and in the ideal case the coverage rate should increase or stay the same.
-2. To check if your code is correct, run `tox -e reformat,check,py39-fast`
-   (`py39` stands for Python 3.9, you can replace it by `py38`).
+2. To check if your code is correct, run `tox`. This command runs the code
+   style, the tests and build the documentation of the project.
 3. Notice that you can run a subset of the tests by
    passing extra arguments to pytest, for example running
-   `tox -e py39-fast -- -k "anomaly"`
+   `tox -e tests-fast -- -k "anomaly"`
 
 Automatic services will ensure your code works
 on all the supported operating systems and Python versions.

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 description = list of environments againts tox runs the tests
 envlist =
     style
-    py3-fast
+    tests-fast
+    docs
 # See https://tox.readthedocs.io/en/latest/example/package.html#flit
 isolated_build = True
 isolated_build_env = build
@@ -14,11 +15,11 @@ whitelist_externals=
     /usr/bin/bash
 basepython =
     pypy3: pypy3
-    py38: python3.8
-    py39: python3.9
-    py310: python3.10
-    py311: python3.11
-    {style,docs,reformat,build}: python3
+    tests38: python3.8
+    tests39: python3.9
+    tests310: python3.10
+    tests311: python3.11
+    {style,tests,docs,build}: python3
 setenv =
     PYTHONUNBUFFERED = yes
     PIP_PREFER_BINARY = 1


### PR DESCRIPTION
I decided to open this pull-request to rename the 'py*' environments to 'tests' in our `tox.ini` file. The reason is that this naming leads to a lower confusion and a better syntax:

```diff
tox -e py310-fast-cov
tox -e tests-fast-cov
```

Also, the default environments are now `style, tests, docs`, which will executed no matter the Python environment installed in the machine, as long as it is a version supported by poliastro.

<!-- readthedocs-preview poliastro start -->
----
:books: Documentation preview :books:: https://poliastro--1626.org.readthedocs.build/en/1626/

<!-- readthedocs-preview poliastro end -->