### PR TITLE
Starting to get rid of {eval-rst} blocks on documentation files

### DIFF
--- a/docs/source/api.md
+++ b/docs/source/api.md
@@ -18,20 +18,28 @@ The most important high level objects and methods are
 {py:class}`poliastro.maneuver.Maneuver`.
 Here is a summarized reference of commonly used methods:
 
-```{eval-rst}
-.. autoapiclass:: poliastro.twobody.Orbit
-   :members: from_classical, from_vectors, from_sbdb, propagate, to_ephem
-   :noindex:
+#### `poliastro.twobody.Orbit`
 
-.. autoapiclass:: poliastro.ephem.Ephem
-   :members: from_body, from_orbit, from_horizons, sample, rv
-   :noindex:
+- `from_classical`
+- `from_vectors`
+- `from_sbdb`
+- `propagate`
+- `to_ephem`
 
-.. autoapiclass:: poliastro.maneuver.Maneuver
-   :members: impulse, hohmann, bielliptic, lambert
-   :noindex:
+#### `poliastro.ephem.Ephem`
 
-```
+- `from_body`
+- `from_orbit`
+- `from_horizons`
+- `sample`
+- `rv`
+
+#### `poliastro.maneuver.Maneuver`
+
+- `impulse`
+- `hohmann`
+- `bielliptic`
+- `lambert`
 
 You can read the complete reference of the high level API here:
 

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -417,9 +417,8 @@ Plot of a Hohmann transfer.
 
 ### Where are the planets? Computing celestial ephemerides
 
-```{eval-rst}
-.. versionadded:: 0.14.0
-```
+**Version Added:** 0.14.0
+
 
 Thanks to Astropy and jplephem, poliastro can read Satellite Planet Kernel (SPK) files,
 part of NASA's SPICE toolkit. This means that you can query the position and velocity


### PR DESCRIPTION
### Small fix on #1197 

I have detected the presence of {eval-rst} blocks in the following files.

- [x] `api.md`
- [ ] `background.md`
- [ ] `changelog.md`
- [ ] `gallery.md`
- [ ] `index.md`
- [x] `quickstart.md`
 
I started making fixes in some of these files.
Your feedback on this PR would be greatly appreciated

