### PR TITLE
Install latest `sphinx-hoverxref` dependency for docs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ doc = [
     "sphinx-autoapi",
     "sphinx-gallery<=0.7.0",  # Just to avoid the jupytext warning
     "sphinx_rtd_theme~=1.0.0",
-    "sphinx-hoverxref==0.7b1",
+    "sphinx-hoverxref",
     "sphinx-notfound-page",
     "sphinx-copybutton>0.2.9",
     "sphinx-github-role~=0.1.0",


### PR DESCRIPTION
I'm not sure why an older version of this Sphinx extension is used here and there is no comment about it, so I'm upgrading it to see if it works successfully on the PR preview.

<!-- readthedocs-preview poliastro start -->
----
:books: Documentation preview :books:: https://poliastro--1641.org.readthedocs.build/en/1641/

<!-- readthedocs-preview poliastro end -->